### PR TITLE
Fix: Correctly import config.js module

### DIFF
--- a/Anti Cheats BP/scripts/index.js
+++ b/Anti Cheats BP/scripts/index.js
@@ -2,7 +2,7 @@ import { world, system } from '@minecraft/server'; // Ensure system and world ar
 import * as Minecraft from '@minecraft/server'; // For types like Player, GameMode, etc.
 
 // Local Script Imports
-import * as config from "./config.js"; // Assuming this is still CONFIG.default structure
+import CONFIG from "./config.js"; // Assuming this is still CONFIG.default structure
 import { i18n } from './assets/i18n.js';
 import "./command/importer.js"; // Still needed for command registration?
 import "./slash_commands.js"; // Still needed for slash command registration?
@@ -78,8 +78,8 @@ system.run(() => { // Final initialization run
 system.run(async () => {
     try {
         const currentVersion = world.getDynamicProperty("ac:version");
-        if (currentVersion !== config.version) { // Assuming config is now CONFIG.default -> CONFIG
-            world.setDynamicProperty("ac:version", config.version);
+        if (currentVersion !== CONFIG.version) { // Assuming config is now CONFIG.default -> CONFIG
+            world.setDynamicProperty("ac:version", CONFIG.version);
             // Potentially send a message to admins about the update if it's a significant version change
             // This could also be part of Initialize() or a dedicated update/migration script.
         }


### PR DESCRIPTION
The script `Anti Cheats BP/scripts/index.js` was attempting to import the default export from `Anti Cheats BP/scripts/config.js` using `import * as config from "./config.js"`, and then accessing properties like `config.version`.

However, `config.js` uses `export default { ... }`. When using `import * as config`, the actual configuration object becomes `config.default`.

This commit changes the import to `import CONFIG from "./config.js";` and updates all usages accordingly (e.g., `CONFIG.version`). This resolves the "SyntaxError: Could not find export 'CONFIG' in module 'config.js'" error, which was misleading, as the root cause was the incorrect import alias and usage.