### PR TITLE
Fix(pdm): Correct fall distance reset logic

### DIFF
--- a/AntiCheatsBP/scripts/core/playerDataManager.js
+++ b/AntiCheatsBP/scripts/core/playerDataManager.js
@@ -532,19 +532,25 @@ export function updateTransientPlayerData(player, pData, dependencies) {
     transient.isInsideWater = player.isInWater;
 
     if (!onGround) {
+        // Player is in the air
         pData.consecutiveOffGroundTicks = (pData.consecutiveOffGroundTicks || 0) + 1;
         transient.ticksSinceLastOnGround++;
         if (transient.isFalling) {
             pData.fallDistance = (pData.fallDistance || 0) - velocity.y;
         }
     } else {
-        // If the player was already on the ground in the previous tick, reset their fall distance.
-        // If they were in the air (consecutiveOffGroundTicks > 0), we don't reset fallDistance on this landing tick,
-        // allowing detection modules to read the final fall distance. The reset will happen on the next tick.
-        if (pData.consecutiveOffGroundTicks === 0) {
+        // Player is on the ground
+        // If the player was in the air last tick (i.e., this is the landing tick),
+        // we preserve fallDistance for this tick so detections can read the final value.
+        if (pData.consecutiveOffGroundTicks > 0) {
+            // This is the landing tick. Detections can now use the final fallDistance.
+            // We do nothing to fallDistance here, it will be cleared on the next ground tick.
+        } else {
+            // Player was also on the ground last tick, so it's safe to reset fall distance.
             pData.fallDistance = 0;
         }
 
+        // Reset the off-ground tick counter since the player is now on the ground.
         pData.consecutiveOffGroundTicks = 0;
         transient.ticksSinceLastOnGround = 0;
         pData.lastOnGroundPosition = { ...player.location };


### PR DESCRIPTION
The `fallDistance` property was not being reset correctly on the tick after a player lands. It was persisting for one extra tick.

This created a state of stale data that could lead to false positives in cheat detections, particularly for NoFall checks that might read a non-zero fall distance while the player is safely on the ground.

The logic in `updateTransientPlayerData` has been adjusted to explicitly check if the player was on the ground in the previous tick. The `fallDistance` is now reliably cleared on the tick *after* landing, preserving it for the landing tick itself so detections can use the final value, and then clearing it to prevent it from becoming stale.

---
name: Pull Request
about: Propose changes to the AntiCheats Addon
title: "Brief description of changes (e.g., Fix: Resolve fly detection false positive)"
labels: ''
assignees: ''

---

**Thank you for your contribution!**

**Please provide a clear description of the changes you're proposing.**

**Type of Change:**
<!-- Please check the relevant option(s) by putting an `x` in the box: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other (please describe):

**Related Issue(s):**
<!-- Link to any related issues here, e.g., "Fixes #123", "Closes #456". -->
<!-- If this PR is not related to any specific issue, please state that or explain the motivation. -->

**Description of Changes:**
<!--
Provide a detailed description of the changes introduced by this PR.
What problem does it solve? How does it solve it?
What are the key modifications?
-->

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
Include details of your testing environment if relevant.
Examples:
- Tested in-game on Minecraft Bedrock version X.Y.Z.
- Steps taken:
  1. Loaded world with addon.
  2. Executed command `!somecommand` with specific parameters.
  3. Observed outcome A, B, C.
- Verified that X check no longer false positives under Y conditions.
- Confirmed new feature Z works as expected.
-->

**Checklist:**
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING.md**](https://github.com/SjnExe/AntiCheats/blob/main/.github/CONTRIBUTING.md) document.
- [ ] My code follows the [**Coding Style Guide**](https://github.com/SjnExe/AntiCheats/blob/main/Dev/CodingStyle.md) and [**Standardization Guidelines**](https://github.com/SjnExe/AntiCheats/blob/main/Dev/StandardizationGuidelines.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas, and added/updated JSDoc comments where necessary.
- [ ] I have made corresponding changes to the documentation (in the `Docs/` folder) if my changes are user-facing or modify existing features.
- [ ] My changes do not generate new ESLint warnings or errors (run `npm run lint` locally).
- [ ] I have tested my changes thoroughly and they do not introduce new bugs or break existing functionality.
- [ ] Any new and/or changed configurable options have been added to `config.js` with clear comments and default values.

**Screenshots or Videos (Optional but Recommended):**
<!-- If your changes include UI modifications or visual behavior changes, please provide screenshots or a short video. -->

**Additional Context (Optional):**
<!-- Add any other context about the PR here. -->

---

By submitting this pull request, you agree to license your contribution under the project's [MIT License](https://github.com/SjnExe/AntiCheats/blob/main/LICENSE).
