### PR TITLE
refactor(style): Correct naming convention in startupLogger.js

### DIFF
--- a/AntiCheatsBP/scripts/core/startupLogger.js
+++ b/AntiCheatsBP/scripts/core/startupLogger.js
@@ -5,14 +5,14 @@
  *              without relying on the main dependency container, which may not be initialized yet.
  */
 
-const LOG_PREFIX = '[AntiCheats:Startup]';
+const logPrefix = '[AntiCheats:Startup]';
 
 /**
  * Logs a standard message to the console.
  * @param {string} message The message to log.
  */
 export function log(message) {
-    console.log(`${LOG_PREFIX} ${message}`);
+    console.log(`${logPrefix} ${message}`);
 }
 
 /**
@@ -21,7 +21,7 @@ export function log(message) {
  * @param {Error} [errorObject] Optional error object to include its stack trace.
  */
 export function logError(message, errorObject) {
-    console.error(`${LOG_PREFIX} [ERROR] ${message}`);
+    console.error(`${logPrefix} [ERROR] ${message}`);
     if (errorObject && errorObject.stack) {
         console.error(errorObject.stack);
     }


### PR DESCRIPTION
The constant `LOG_PREFIX` was renamed to `logPrefix` to adhere to the project's coding standards, which disallow the use of `UPPER_SNAKE_CASE` for identifiers as specified in `agents.md`.

---
name: Pull Request
about: Propose changes to the AntiCheats Addon
title: "Brief description of changes (e.g., Fix: Resolve fly detection false positive)"
labels: ''
assignees: ''

---

**Description of Changes:**
<!--
Provide a detailed description of the changes introduced by this PR.
What problem does it solve? How does it solve it?
What are the key modifications?
Link to any related issues here, e.g., "Fixes #123".
-->

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

**Checklist:**
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] My code follows the project's coding style and guidelines.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code where necessary.
- [ ] I have made corresponding changes to the documentation if needed.
- [ ] My changes do not generate new ESLint warnings or errors.
- [ ] I have tested my changes thoroughly.

---

By submitting this pull request, you agree to license your contribution under the project's [MIT License](https://github.com/SjnExe/AntiCheats/blob/main/LICENSE).
