### PR TITLE
feat: Add new command aliases

### DIFF
--- a/AddonExeBP/scripts/modules/commands/ban.js
+++ b/AddonExeBP/scripts/modules/commands/ban.js
@@ -83,6 +83,7 @@ commandManager.register({
 
 commandManager.register({
     name: 'unban',
+    aliases: ['pardon'],
     description: 'Unbans a player.',
     category: 'Moderation',
     permissionLevel: 1, // Admins only

--- a/AddonExeBP/scripts/modules/commands/pay.js
+++ b/AddonExeBP/scripts/modules/commands/pay.js
@@ -6,6 +6,7 @@ import { getPlayer } from '../../core/playerDataManager.js';
 
 commandManager.register({
     name: 'pay',
+    aliases: ['givemoney', 'sendmoney'],
     description: 'Pays another player from your balance.',
     category: 'Economy',
     permissionLevel: 1024,

--- a/AddonExeBP/scripts/modules/commands/setspawn.js
+++ b/AddonExeBP/scripts/modules/commands/setspawn.js
@@ -4,6 +4,7 @@ import { playSound } from '../../core/utils.js';
 
 commandManager.register({
     name: 'setspawn',
+    aliases: ['setworldspawn'],
     description: 'Sets the server\'s spawn location to your current position.',
     category: 'Administration',
     permissionLevel: 1, // Admins only

--- a/AddonExeBP/scripts/modules/commands/tp.js
+++ b/AddonExeBP/scripts/modules/commands/tp.js
@@ -3,6 +3,7 @@ import { findPlayerByName } from '../utils/playerUtils.js';
 
 commandManager.register({
     name: 'tp',
+    aliases: ['teleport'],
     description: 'Teleports a player to another player or to coordinates.',
     category: 'General',
     permissionLevel: 1, // Admins only

--- a/AddonExeBP/scripts/modules/commands/tpahere.js
+++ b/AddonExeBP/scripts/modules/commands/tpahere.js
@@ -6,7 +6,7 @@ import { findPlayerByName } from '../utils/playerUtils.js';
 commandManager.register({
     name: 'tpahere',
     description: 'Requests another player to teleport to you.',
-    aliases: ['tphere'],
+    aliases: ['tphere', 'tprequesthere'],
     category: 'TPA System',
     permissionLevel: 1024, // Everyone
     execute: (player, args) => {


### PR DESCRIPTION
Adds several new aliases for existing commands to improve user experience and provide more intuitive command access.

The following aliases have been added:
- `unban`: `pardon`
- `pay`: `givemoney`, `sendmoney`
- `setspawn`: `setworldspawn`
- `tp`: `teleport`
- `tpahere`: `tprequesthere`

Other aliases that were requested were found to already exist in the codebase.

---
name: Pull Request
about: Propose changes to the AddonExe
title: "Brief description of changes (e.g., Fix: Resolve fly detection false positive)"
labels: ''
assignees: ''

---

**Description of Changes:**
<!--
Provide a detailed description of the changes introduced by this PR.
What problem does it solve? How does it solve it?
What are the key modifications?
Link to any related issues here, e.g., "Fixes #123".
-->

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

**Checklist:**
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] My code follows the project's coding style and guidelines.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code where necessary.
- [ ] I have made corresponding changes to the documentation if needed.
- [ ] My changes do not generate new ESLint warnings or errors.
- [ ] I have tested my changes thoroughly.

---

By submitting this pull request, you agree to license your contribution under the project's [MIT License](https://github.com/SjnExe/AddonExe/blob/main/LICENSE).
