### PR TITLE
fix(docs): Correct console command usage

### DIFF
--- a/Docs/Commands.md
+++ b/Docs/Commands.md
@@ -2,6 +2,13 @@
 
 Commands in AddonExe are primarily run using native slash commands, which support autocomplete in-game.
 
+> [!IMPORTANT]
+> **Using Commands from the Server Console**
+> All slash commands can also be executed directly from the server console (e.g., in Bedrock Dedicated Server).
+> - **Commands are run with a `/` prefix,** just like in-game (e.g., `/xhelp`).
+> - **Specify the target player:** For commands that normally affect the person running them (like `/home` or `/clear`), you must specify the target player's name. For example: `/home "Steve" "my-base"` or `/clear "Steve"`.
+> - The chat-based `!` prefix is not supported in the console.
+
 > [!NOTE]
 > - To use slash commands, you must **enable cheats** in your world settings.
 > - Some commands have an `x` prefix (e.g., `/xhelp`) to avoid conflicts with built-in Minecraft commands.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Designed to be robust, highly configurable, and packed with features to ensure f
 
 - **Scripting Power:** Built entirely with the Minecraft Scripting API, offering flexibility and complex detection logic not always possible with traditional methods.
 - **Comprehensive Detection (Coming Soon):** While currently a powerful moderation tool, a full suite of cheat detections is in active development.
-- **User-Friendly Tools:** Manage your server with ease using an intuitive in-game UI (`/panel`) and extensive slash commands. Most commands also have a chat-based fallback (e.g. `!panel`).
+- **User-Friendly Tools:** Manage your server with ease using an intuitive in-game UI (`/panel`) and extensive slash commands, which can be used in-game, from the server console, or via a chat-based fallback (e.g. `!panel`).
 - **Highly Customizable:** Fine-tune almost every aspect, from feature toggles to command permissions, to perfectly suit your server's needs.
 - **Active Development:** Continuously updated with new features, improvements, and compatibility for the latest Minecraft versions.
 - **Open & Documented:** With clear documentation and an open codebase, understand how it works and even contribute!
@@ -95,7 +95,8 @@ We recommend the following manual installation method, as it makes future config
     - In your world settings, go to the "Game" section and enable **"Activate Cheats"**. This is required for slash commands to work.
     - Next, go to the "Experiments" section and **enable the "Beta APIs" toggle.** This addon relies on beta Minecraft Scripting API features and will not function without this setting enabled.
     > **For Bedrock Dedicated Server (BDS) users:**
-    > You must also edit your `server.properties` file and set `allow-cheats=true`.
+    > - You must also edit your `server.properties` file and set `allow-cheats=true`.
+    > - Commands can be run directly from the server console using the leading slash (e.g., `/xreload`). See the [Commands List](Docs/Commands.md) for more details.
 5.  **Prioritize:** Ensure `AddonExeBP` is at the **TOP** of your behavior pack list in the world settings. This is crucial for AddonExe to function correctly.
 6.  **👑 Set Owner(s) (CRUCIAL!):**
     - Now that you've installed the folders, navigate to `behavior_packs/AddonExeBP/scripts/` and open `config.js` in a text editor.


### PR DESCRIPTION
Corrects the documentation for using slash commands from the server console. Based on user feedback, commands require a leading `/` and this was not correctly documented.

- Updates `Docs/Commands.md` to state that a leading `/` is required.
- Updates `README.md` to state that a leading `/` is required.

---
name: Pull Request
about: Propose changes to the AddonExe
title: "Brief description of changes (e.g., Fix: Resolve fly detection false positive)"
labels: ''
assignees: ''

---

**Description of Changes:**
<!--
Provide a detailed description of the changes introduced by this PR.
What problem does it solve? How does it solve it?
What are the key modifications?
Link to any related issues here, e.g., "Fixes #123".
-->

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

**Checklist:**
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] My code follows the project's coding style and guidelines.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code where necessary.
- [ ] I have made corresponding changes to the documentation if needed.
- [ ] My changes do not generate new ESLint warnings or errors.
- [ ] I have tested my changes thoroughly.

---

By submitting this pull request, you agree to license your contribution under the project's [MIT License](https://github.com/SjnExe/AddonExe/blob/main/LICENSE).
