### PR TITLE
Remove crafting table requirement for panel and stick recipes

### DIFF
--- a/AddonExeBP/recipes/panel.json
+++ b/AddonExeBP/recipes/panel.json
@@ -4,9 +4,6 @@
         "description": {
             "identifier": "exe:panel_recipe"
         },
-        "tags": [
-            "crafting_table"
-        ],
         "unlock": [
             {
                 "item": "minecraft:stick"

--- a/AddonExeBP/recipes/stick_from_panel.json
+++ b/AddonExeBP/recipes/stick_from_panel.json
@@ -4,9 +4,6 @@
         "description": {
             "identifier": "exe:stick_from_panel_recipe"
         },
-        "tags": [
-            "crafting_table"
-        ],
         "unlock": [
             {
                 "item": "exe:panel"


### PR DESCRIPTION
This change removes the "crafting_table" tag from the panel and stick_from_panel recipes, allowing them to be crafted in the player's inventory crafting grid.

---
name: Pull Request
about: Propose changes to the AddonExe
title: "Brief description of changes (e.g., Fix: Resolve fly detection false positive)"
labels: ''
assignees: ''

---

**Description of Changes:**
<!--
Provide a detailed description of the changes introduced by this PR.
What problem does it solve? How does it solve it?
What are the key modifications?
Link to any related issues here, e.g., "Fixes #123".
-->

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

**Checklist:**
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] My code follows the project's coding style and guidelines.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code where necessary.
- [ ] I have made corresponding changes to the documentation if needed.
- [ ] My changes do not generate new ESLint warnings or errors.
- [ ] I have tested my changes thoroughly.

---

By submitting this pull request, you agree to license your contribution under the project's [MIT License](https://github.com/SjnExe/AddonExe/blob/main/LICENSE).
