### PR TITLE
Fix: Add missing icons to rule edit page buttons

### DIFF
--- a/AddonExeBP/scripts/core/uiManager.js
+++ b/AddonExeBP/scripts/core/uiManager.js
@@ -266,9 +266,9 @@ async function buildPanelForm(player, panelId, context) {
         const form = new ActionFormData()
             .title(panelDef.title)
             .body(`Selected Rule: ${ruleText}`)
-            .button('Edit Text', 'textures/ui/icon_edit')
-            .button('Move Up', 'textures/ui/arrow_up')
-            .button('Move Down', 'textures/ui/arrow_down')
+            .button('Edit Text', 'textures/ui/editIcon')
+            .button('Move Up', 'textures/gui/controls/up')
+            .button('Move Down', 'textures/gui/controls/down')
             .button('§cDelete Rule', 'textures/ui/trash')
             .button('§l§8< Back', 'textures/gui/controls/left.png');
         return form;


### PR DESCRIPTION
This commit fixes an issue where the "Edit Text", "Move Up", and "Move Down" buttons on the rule edit page were missing icons.

The icon paths in `AddonExeBP/scripts/core/uiManager.js` have been updated to use the correct vanilla Minecraft Bedrock Edition textures, as specified by the user.

- The "Edit Text" button now uses the `textures/ui/editIcon` icon.
- The "Move Up" button now uses the `textures/gui/controls/up` icon.
- The "Move Down" button now uses the `textures/gui/controls/down` icon.

---
name: Pull Request
about: Propose changes to the AddonExe
title: "Brief description of changes (e.g., Fix: Resolve fly detection false positive)"
labels: ''
assignees: ''

---

**Description of Changes:**
<!--
Provide a detailed description of the changes introduced by this PR.
What problem does it solve? How does it solve it?
What are the key modifications?
Link to any related issues here, e.g., "Fixes #123".
-->

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

**Checklist:**
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] My code follows the project's coding style and guidelines.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code where necessary.
- [ ] I have made corresponding changes to the documentation if needed.
- [ ] My changes do not generate new ESLint warnings or errors.
- [ ] I have tested my changes thoroughly.

---

By submitting this pull request, you agree to license your contribution under the project's [MIT License](https://github.com/SjnExe/AddonExe/blob/main/LICENSE).
