### PR TITLE
feat: Add /setwarp alias and coordinate support for /addwarp

### DIFF
--- a/AddonExeBP/scripts/modules/commands/warp.js
+++ b/AddonExeBP/scripts/modules/commands/warp.js
@@ -77,14 +77,34 @@ commandManager.register({
 
 commandManager.register({
     name: 'addwarp',
-    description: 'Creates a new warp at your current location.',
+    description: 'Creates a new warp at your current location or at specified coordinates.',
+    aliases: ['setwarp'],
     category: 'Administration',
     permissionLevel: 1, // Admin
     parameters: [
-        { name: 'warpName', type: 'string', description: 'The name for the new warp.' }
+        { name: 'warpName', type: 'string', description: 'The name for the new warp.' },
+        { name: 'x', type: 'number', description: 'The x-coordinate for the warp.', optional: true },
+        { name: 'y', type: 'number', description: 'The y-coordinate for the warp.', optional: true },
+        { name: 'z', type: 'number', description: 'The z-coordinate for the warp.', optional: true }
     ],
     execute: (player, args) => {
-        const result = warpsManager.setWarp(args.warpName, player.location, player.dimension.id);
+        const { warpName, x, y, z } = args;
+        const hasX = x !== undefined && x !== null;
+        const hasY = y !== undefined && y !== null;
+        const hasZ = z !== undefined && z !== null;
+
+        let location;
+
+        if (hasX && hasY && hasZ) {
+            location = { x, y, z };
+        } else if (!hasX && !hasY && !hasZ) {
+            location = player.location;
+        } else {
+            player.sendMessage('§cYou must provide all three coordinates (x, y, z) or none to use your current location.');
+            return;
+        }
+
+        const result = warpsManager.setWarp(warpName, location, player.dimension.id);
         player.sendMessage(result.success ? `§a${result.message}` : `§c${result.message}`);
     }
 });


### PR DESCRIPTION
This commit introduces two main enhancements to the warp functionality:

1.  Adds `/setwarp` as an alias for the `/addwarp` command, providing more intuitive command access for users.
2.  Extends the `/addwarp` command to optionally accept `x`, `y`, and `z` coordinates. This allows administrators to create warps at precise locations without needing to be physically present at the spot.

The command now supports both setting a warp at the player's current location and setting it at specified coordinates, with appropriate error handling for partial coordinate input.

---
name: Pull Request
about: Propose changes to the AddonExe
title: "Brief description of changes (e.g., Fix: Resolve fly detection false positive)"
labels: ''
assignees: ''

---

**Description of Changes:**
<!--
Provide a detailed description of the changes introduced by this PR.
What problem does it solve? How does it solve it?
What are the key modifications?
Link to any related issues here, e.g., "Fixes #123".
-->

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

**Checklist:**
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] My code follows the project's coding style and guidelines.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code where necessary.
- [ ] I have made corresponding changes to the documentation if needed.
- [ ] My changes do not generate new ESLint warnings or errors.
- [ ] I have tested my changes thoroughly.

---

By submitting this pull request, you agree to license your contribution under the project's [MIT License](https://github.com/SjnExe/AddonExe/blob/main/LICENSE).
