### PR TITLE
Feat(spawn): Add 'spawnset' as an alias for 'setspawn'

### DIFF
--- a/AddonExeBP/scripts/config.js
+++ b/AddonExeBP/scripts/config.js
@@ -57,28 +57,6 @@ export const config = {
     reports: {
         resolvedReportLifetimeDays: 7
     },
-    spawn: {
-        cooldownSeconds: 60,
-        teleportWarmupSeconds: 10,
-        // Default spawn location. Can be set manually here (e.g., { x: 0, y: 100, z: 0, dimensionId: 'minecraft:overworld' }) or with the in-game /setspawn command.
-        spawnLocation: null
-    },
-    spawnProtection: {
-        enabled: true,
-        protectionRadius: 32,
-        allowAdminBypass: true,
-        preventPvP: true,
-        preventPvE: true,
-        preventMobSpawning: true,
-        preventBlockBreaking: true,
-        preventBlockPlacing: true,
-        preventExplosions: true,
-        preventBlockInteraction: true,
-        preventFire: true,
-        preventHungerLoss: true,
-        preventItemDropping: false,
-        preventItemPickup: false
-    },
     chat: {
         logToConsole: true
     },

--- a/AddonExeBP/scripts/core/configManagerFactory.js
+++ b/AddonExeBP/scripts/core/configManagerFactory.js
@@ -90,7 +90,14 @@ function createConfigManager(key, configPath, name, configKey, wrapperKey = null
             if (isMigration) {
                 // Scenario 2: Addon Update (Migration)
                 errorLog(`[${name}ConfigManager] Version mismatch detected. Migrating config.`);
-                currentConfig = deepMerge(newDefaultConfig, userSavedConfig);
+                // For most configs, we want the new default to take precedence for new/changed properties.
+                // However, for the spawn config, the user's saved location is more important than the default.
+                if (name === 'Spawn') {
+                    // By putting the user's config first, we ensure its values are preserved.
+                    currentConfig = deepMerge(userSavedConfig, newDefaultConfig);
+                } else {
+                    currentConfig = deepMerge(newDefaultConfig, userSavedConfig);
+                }
                 lastLoadedConfig = newDefaultConfig;
                 saveLastLoadedConfig();
             } else {

--- a/AddonExeBP/scripts/core/configPanelSchema.js
+++ b/AddonExeBP/scripts/core/configPanelSchema.js
@@ -125,6 +125,7 @@ export const configPanelSchema = [
         id: 'spawn',
         title: '§l§eSpawn System§r',
         icon: 'textures/blocks/beacon',
+        configSource: 'spawn',
         settings: [
             {
                 key: 'spawn.cooldownSeconds',

--- a/AddonExeBP/scripts/core/configurations.js
+++ b/AddonExeBP/scripts/core/configurations.js
@@ -2,6 +2,7 @@ import createConfigManager from './configManagerFactory.js';
 
 const kitsConfigManager = createConfigManager('exe:kitsConfig:current', './kitsConfig.js', 'Kits', 'kitsConfig');
 const shopConfigManager = createConfigManager('exe:shopConfig:current', './shopConfig.js', 'Shop', 'shopConfig');
+const spawnConfigManager = createConfigManager('exe:spawnConfig:current', '../spawnConfig.js', 'Spawn', 'spawnConfig');
 // The last parameter 'rankDefinitions' is the wrapperKey. It ensures the imported array
 // is wrapped in an object like { rankDefinitions: [...] }, which the addon expects.
 const ranksConfigManager = createConfigManager('exe:ranksConfig', './ranksConfig.js', 'Ranks', 'rankDefinitions', 'rankDefinitions');
@@ -16,6 +17,11 @@ export const getShopConfig = shopConfigManager.get;
 export const saveShopConfig = shopConfigManager.save;
 export const resetShopConfig = shopConfigManager.reset;
 
+export const loadSpawnConfig = spawnConfigManager.load;
+export const getSpawnConfig = spawnConfigManager.get;
+export const saveSpawnConfig = spawnConfigManager.save;
+export const resetSpawnConfig = spawnConfigManager.reset;
+
 export const loadRanksConfig = ranksConfigManager.load;
 export const getRanksConfig = ranksConfigManager.get;
 export const saveRanksConfig = ranksConfigManager.save;
@@ -29,6 +35,10 @@ export const configResetRegistry = {
     'shop': {
         reset: resetShopConfig,
         message: 'The \'shop\' configuration section has been reset to default.'
+    },
+    'spawn': {
+        reset: resetSpawnConfig,
+        message: 'The \'spawn\' configuration section has been reset to default.'
     },
     'ranks': {
         reset: resetRanksConfig,

--- a/AddonExeBP/scripts/core/main.js
+++ b/AddonExeBP/scripts/core/main.js
@@ -1,6 +1,6 @@
 import { world, system } from '@minecraft/server';
 import { loadConfig, getConfig, updateConfig } from './configManager.js';
-import { loadShopConfig, loadKitsConfig, loadRanksConfig } from './configurations.js';
+import { getSpawnConfig, loadKitsConfig, loadRanksConfig, loadShopConfig, loadSpawnConfig } from './configurations.js';
 import * as dataManager from './dataManager.js';
 import * as rankManager from './rankManager.js';
 import * as playerDataManager from './playerDataManager.js';
@@ -77,14 +77,15 @@ function initializeManagers() {
  */
 function checkConfiguration() {
     const config = getConfig();
+    const spawnConfig = getSpawnConfig();
     // Add a guard in case config hasn't loaded yet, though the init flow should prevent this.
-    if (!config || !config.ownerPlayerNames || config.ownerPlayerNames.length === 0 || config.ownerPlayerNames[0] === 'Your•Name•Here') {
+    if (!config || !config.ownerPlayerNames || !config.ownerPlayerNames.length || config.ownerPlayerNames[0] === 'Your•Name•Here') {
         const warningMessage = '§l§c[AddonExe] WARNING: No owner is configured. Please set `ownerPlayerNames` in `scripts/config.js` to gain access to admin commands.';
         system.runTimeout(() => world.sendMessage(warningMessage), 20);
         errorLog('[AddonExe] No owner configured.');
     }
 
-    if (!config.spawn || !config.spawn.spawnLocation) {
+    if (!spawnConfig.spawn || !spawnConfig.spawn.spawnLocation) {
         const spawnWarning = '§l§e[AddonExe] NOTICE: The server spawn has not been set. Spawn protection and the /spawn command will not function until an admin runs /setspawn.';
         system.runTimeout(() => world.sendMessage(spawnWarning), 40);
         errorLog('[AddonExe] Server spawn not set.');
@@ -119,7 +120,8 @@ async function initializeAddon() {
         loadConfig(isMigration),
         loadKitsConfig(isMigration),
         loadShopConfig(isMigration),
-        loadRanksConfig(isMigration)
+        loadRanksConfig(isMigration),
+        loadSpawnConfig(isMigration)
     ];
     await Promise.all(loadPromises);
 

--- a/AddonExeBP/scripts/core/uiManager.js
+++ b/AddonExeBP/scripts/core/uiManager.js
@@ -10,7 +10,7 @@ import * as rankManager from './rankManager.js';
 import * as rankDb from './rankDb.js';
 import * as playerCache from './playerCache.js';
 import * as utils from './utils.js';
-import { getValueFromPath } from './objectUtils.js';
+import { getValueFromPath, setValueByPath } from './objectUtils.js';
 import * as reportManager from './reportManager.js';
 import * as bountyManager from './bountyManager.js';
 import * as economyManager from './economyManager.js';
@@ -21,7 +21,7 @@ import { banPlayer, offlineBanPlayer, unbanPlayer } from '../modules/commands/ba
 import { freezePlayer, unfreezePlayer } from '../modules/commands/freeze.js';
 import * as rulesManager from './rulesManager.js';
 import * as shopManager from './shopManager.js';
-import { getKitsConfig, saveKitsConfig, getShopConfig, saveShopConfig } from './configurations.js';
+import { getKitsConfig, saveKitsConfig, getShopConfig, saveShopConfig, getSpawnConfig, saveSpawnConfig } from './configurations.js';
 import { items as allItems } from './itemsConfig.js';
 import { createKit, deleteKit, getAllKits, updateKitSettings, renameKit } from './kitAdminManager.js';
 import { addItemToKit, updateItemInKit } from './kitItemsManager.js';
@@ -29,6 +29,17 @@ import * as shopAdminManager from './shopAdminManager.js';
 
 
 const itemsPerPage = 8; // Number of items to show per page in the shop
+
+const configHandlers = {
+    'main': {
+        get: getConfig,
+        save: (updates) => updateMultipleConfig(updates)
+    },
+    'spawn': {
+        get: getSpawnConfig,
+        save: (config) => saveSpawnConfig(config)
+    }
+};
 
 export const uiActionFunctions = {};
 
@@ -68,7 +79,15 @@ async function buildPanelForm(player, panelId, context) {
         }
         debugLog(`[UIManager] Building config settings form for category: ${categoryId}`);
         const form = new ModalFormData().title(category.title);
-        const config = getConfig();
+
+        const configSource = category.configSource || 'main';
+        const handler = configHandlers[configSource];
+        if (!handler) {
+            errorLog(`[UIManager] No config handler found for source: ${configSource}`);
+            return null;
+        }
+        const config = handler.get();
+
 
         for (const setting of category.settings) {
             const currentValue = getValueFromPath(config, setting.key);
@@ -1510,30 +1529,60 @@ async function handleFormResponse(player, panelId, response, context) {
     if (panelId.startsWith('config_')) {
         const categoryId = panelId.replace('config_', '');
         const category = configPanelSchema.find(c => c.id === categoryId);
-        if (!category) {return;}
+        if (!category) { return; }
+
+        const configSource = category.configSource || 'main';
+        const handler = configHandlers[configSource];
+        if (!handler) {
+            errorLog(`[UIManager] No config handler found for source: ${configSource}`);
+            return;
+        }
+
         const newValues = formValues;
-        const updates = {};
         let validationFailed = false;
-        category.settings.forEach((setting, index) => {
-            if (validationFailed) {return;}
-            let newValue = newValues[index];
+
+        const processAndValidate = (setting, value) => {
             if (setting.type === 'toggle') {
-                newValue = !!newValue;
-            } else if (setting.type === 'dropdown') {
-                newValue = setting.options[newValue];
-            } else if (setting.type === 'textField' && (setting.key.includes('Seconds') || setting.key.includes('Balance') || setting.key.includes('maxHomes') || setting.key.includes('Interval') || setting.key.includes('Radius'))) {
-                const numValue = Number(newValue);
+                return !!value;
+            }
+            if (setting.type === 'dropdown') {
+                return setting.options[value];
+            }
+            if (setting.type === 'textField' && (setting.key.includes('Seconds') || setting.key.includes('Balance') || setting.key.includes('maxHomes') || setting.key.includes('Interval') || setting.key.includes('Radius'))) {
+                const numValue = Number(value);
                 if (isNaN(numValue)) {
                     player.sendMessage(`§cInvalid number provided for ${setting.label}. Changes not saved.`);
                     validationFailed = true;
-                    return;
                 }
-                newValue = numValue;
+                return numValue;
             }
-            updates[setting.key] = newValue;
-        });
-        if (validationFailed) {return showPanel(player, panelId);}
-        updateMultipleConfig(updates);
+            return value;
+        };
+
+        if (configSource === 'main') {
+            const updates = {};
+            category.settings.forEach((setting, index) => {
+                if (validationFailed) { return; }
+                const newValue = processAndValidate(setting, newValues[index]);
+                if (!validationFailed) {
+                    updates[setting.key] = newValue;
+                }
+            });
+            if (validationFailed) { return showPanel(player, panelId); }
+            handler.save(updates);
+        } else {
+            const configToSave = handler.get();
+            category.settings.forEach((setting, index) => {
+                if (validationFailed) { return; }
+                const newValue = processAndValidate(setting, newValues[index]);
+                if (!validationFailed) {
+                    setValueByPath(configToSave, setting.key, newValue);
+                }
+            });
+            if (validationFailed) { return showPanel(player, panelId); }
+            handler.save(configToSave);
+        }
+
         player.sendMessage(`§2Successfully saved settings for ${category.title}§2.`);
         return showPanel(player, 'configCategoryPanel');
     }

--- a/AddonExeBP/scripts/modules/commands/spawn.js
+++ b/AddonExeBP/scripts/modules/commands/spawn.js
@@ -1,6 +1,7 @@
 import { world } from '@minecraft/server';
 import { commandManager } from './commandManager.js';
-import { getConfig, updateMultipleConfig } from '../../core/configManager.js';
+import { getConfig } from '../../core/configManager.js';
+import { getSpawnConfig, saveSpawnConfig } from '../../core/configurations.js';
 import { playSound, startTeleportWarmup } from '../../core/utils.js';
 import { errorLog } from '../../core/errorLogger.js';
 import { setCooldown } from '../../core/cooldownManager.js';
@@ -16,7 +17,8 @@ commandManager.register({
     hasCooldown: true,
     execute: (player, args) => {
         const config = getConfig();
-        const spawnLocation = config.spawn.spawnLocation;
+        const spawnConfig = getSpawnConfig();
+        const spawnLocation = spawnConfig.spawn.spawnLocation;
 
         if (!spawnLocation || typeof spawnLocation.x !== 'number') {
             player.sendMessage('§cThe server spawn point has not been set.');
@@ -28,7 +30,7 @@ commandManager.register({
             return;
         }
 
-        const warmupSeconds = config.spawn.teleportWarmupSeconds;
+        const warmupSeconds = spawnConfig.spawn.teleportWarmupSeconds;
 
         const teleportLogic = () => {
             try {
@@ -50,7 +52,7 @@ commandManager.register({
 
 commandManager.register({
     name: 'setspawn',
-    aliases: ['setworldspawn'],
+    aliases: ['setworldspawn', 'spawnset'],
     disabledSlashAliases: ['setworldspawn'],
     description: 'Sets the server\'s spawn location to your current position or specified coordinates.',
     category: 'Administration',
@@ -89,7 +91,9 @@ commandManager.register({
 
         try {
             // Update the addon's config first
-            updateMultipleConfig({ 'spawn.spawnLocation': location });
+            const spawnConfig = getSpawnConfig();
+            spawnConfig.spawn.spawnLocation = location;
+            saveSpawnConfig(spawnConfig);
             const locationString = `X: ${Math.floor(location.x)}, Y: ${Math.floor(location.y)}, Z: ${Math.floor(location.z)} in ${location.dimensionId.replace('minecraft:', '')}`;
             player.sendMessage(`§aAddon spawn point set to: ${locationString}`);
 

--- a/AddonExeBP/scripts/modules/detections/spawnProtection.js
+++ b/AddonExeBP/scripts/modules/detections/spawnProtection.js
@@ -1,27 +1,23 @@
-import { world, system, Player } from '@minecraft/server';
+import { world, system, Player, EntityDamageCause } from '@minecraft/server';
+import { getSpawnConfig } from '../../core/configurations.js';
 import { getConfig } from '../../core/configManager.js';
 import { getPlayerRank } from '../../core/rankManager.js';
+import { errorLog } from '../../core/errorLogger.js';
 
 /**
  * Checks if a location is within the protected spawn area.
- * @param {import('@minecraft/server').Vector3} location The location to check.
- * @param {string} dimensionId The dimension of the location.
- * @returns {boolean} True if the location is within the protected area, false otherwise.
+ * @param {import('@minecraft/server').Vector3 | undefined} location The location to check.
+ * @param {string | undefined} dimensionId The dimension of the location.
+ * @returns {boolean} True if the location is within the protected area.
  */
 function isWithinSpawnProtection(location, dimensionId) {
-    const config = getConfig();
-    const spawnProtectionConfig = config.spawnProtection;
-    const spawnLocation = config.spawn ? config.spawn.spawnLocation : null;
+    if (!location || !dimensionId) return false;
 
-    // Highly defensive check to prevent crashes
-    if (
-        !spawnProtectionConfig ||
-        !spawnProtectionConfig.enabled ||
-        !spawnLocation ||
-        typeof spawnLocation.x !== 'number' ||
-        typeof spawnLocation.z !== 'number' ||
-        typeof spawnLocation.dimensionId !== 'string'
-    ) {
+    const spawnConfig = getSpawnConfig();
+    const spawnProtectionConfig = spawnConfig?.spawnProtection;
+    const spawnLocation = spawnConfig?.spawn?.spawnLocation;
+
+    if (!spawnProtectionConfig?.enabled || !spawnLocation?.dimensionId) {
         return false;
     }
 
@@ -32,149 +28,181 @@ function isWithinSpawnProtection(location, dimensionId) {
     const dx = location.x - spawnLocation.x;
     const dz = location.z - spawnLocation.z;
     const distanceSquared = dx * dx + dz * dz;
+    const radiusSquared = spawnProtectionConfig.protectionRadius * spawnProtectionConfig.protectionRadius;
 
-    return distanceSquared <= spawnProtectionConfig.protectionRadius * spawnProtectionConfig.protectionRadius;
+    return distanceSquared <= radiusSquared;
 }
 
 /**
  * Checks if a player can bypass spawn protection.
- * @param {Player} player The player to check.
- * @returns {boolean} True if the player can bypass protection, false otherwise.
+ * @param {Player | undefined} player The player to check.
+ * @returns {boolean} True if the player can bypass protection.
  */
 function canBypass(player) {
-    const config = getConfig();
-    const spawnProtectionConfig = config.spawnProtection;
+    if (!(player instanceof Player)) return false;
 
-    if (!spawnProtectionConfig || !spawnProtectionConfig.allowAdminBypass) {
+    const spawnConfig = getSpawnConfig();
+    const mainConfig = getConfig();
+    const spawnProtectionConfig = spawnConfig?.spawnProtection;
+
+    if (!spawnProtectionConfig?.allowAdminBypass) {
         return false;
     }
-    const playerRank = getPlayerRank(player, config);
-    // Permission level 1 or lower is considered admin/owner
-    return playerRank.permissionLevel <= 1;
+    const playerRank = getPlayerRank(player, mainConfig);
+    return playerRank.permissionLevel <= 1; // Admin or Owner
 }
 
+/**
+ * Registers all spawn protection event listeners based on the current config.
+ */
 function initialize() {
-    const config = getConfig();
-    const spawnProtectionConfig = config.spawnProtection;
-
-    // Add a robust check to ensure the config section is a valid object before proceeding
-    if (!spawnProtectionConfig || typeof spawnProtectionConfig !== 'object' || !spawnProtectionConfig.enabled) {
+    const spawnConfig = getSpawnConfig();
+    if (!spawnConfig) {
+        errorLog('[SpawnProtection] Could not load spawn configuration.', new Error());
         return;
     }
 
-    if (spawnProtectionConfig.preventBlockBreaking) {
+    const { spawn, spawnProtection } = spawnConfig;
+    const spawnLocation = spawn?.spawnLocation;
+
+    if (!spawnProtection?.enabled || !spawnLocation) {
+        // This is the main guard. If protection is off or spawn isn't set, do nothing.
+        return;
+    }
+
+    // --- EVENT-BASED PROTECTIONS ---
+
+    if (spawnProtection.preventBlockBreaking) {
         world.beforeEvents.playerBreakBlock.subscribe((event) => {
-            if (isWithinSpawnProtection(event.block.location, event.block.dimension.id) && !canBypass(event.player)) {
+            if (!event.player) return;
+            if (isWithinSpawnProtection(event.block.location, event.dimension.id) && !canBypass(event.player)) {
                 event.cancel = true;
             }
         });
     }
 
-    if (spawnProtectionConfig.preventBlockPlacing) {
+    if (spawnProtection.preventBlockPlacing) {
         world.beforeEvents.playerPlaceBlock.subscribe((event) => {
-            if (isWithinSpawnProtection(event.block.location, event.block.dimension.id) && !canBypass(event.player)) {
+            if (!event.player) return;
+            if (isWithinSpawnProtection(event.block.location, event.dimension.id) && !canBypass(event.player)) {
                 event.cancel = true;
             }
         });
     }
 
-    if (spawnProtectionConfig.preventExplosions) {
+    if (spawnProtection.preventExplosions) {
         world.beforeEvents.explosion.subscribe((event) => {
-            const spawnDimension = getConfig().spawn.spawnLocation?.dimensionId;
-            if (!spawnDimension || event.dimension.id !== spawnDimension) {return;}
-
-            const initialImpactedBlocks = event.getImpactedBlocks();
-            const protectedBlocks = initialImpactedBlocks.filter(block => isWithinSpawnProtection(block.location, event.dimension.id));
-
-            if (protectedBlocks.length > 0) {
-                const finalImpactedBlocks = initialImpactedBlocks.filter(block => !protectedBlocks.includes(block));
-                event.setImpactedBlocks(finalImpactedBlocks);
-            }
+            if (event.dimension.id !== spawnLocation.dimensionId) return;
+            const finalImpactedBlocks = event.getImpactedBlocks().filter(block =>
+                !isWithinSpawnProtection(block.location, event.dimension.id)
+            );
+            event.setImpactedBlocks(finalImpactedBlocks);
         });
     }
 
-    if (spawnProtectionConfig.preventBlockInteraction) {
+    if (spawnProtection.preventBlockInteraction) {
         world.beforeEvents.playerInteractWithBlock.subscribe((event) => {
-            if (isWithinSpawnProtection(event.block.location, event.block.dimension.id) && !canBypass(event.player)) {
+            if (!event.player) return;
+            if (isWithinSpawnProtection(event.block.location, event.dimension.id) && !canBypass(event.player)) {
                 event.cancel = true;
             }
         });
     }
 
-    if (spawnProtectionConfig.preventFire) {
+    if (spawnProtection.preventFire) {
         world.beforeEvents.itemUseOn.subscribe((event) => {
-            const { source, itemStack, block } = event;
-            if (!(source instanceof Player) || !block) {return;}
-
-            if (itemStack.typeId === 'minecraft:flint_and_steel' || itemStack.typeId === 'minecraft:lava_bucket') {
-                if (isWithinSpawnProtection(block.location, block.dimension.id) && !canBypass(source)) {
+            if (!(event.source instanceof Player) || !event.block) return;
+            const item = event.itemStack;
+            if (item.typeId === 'minecraft:flint_and_steel' || item.typeId === 'minecraft:fire_charge') {
+                if (isWithinSpawnProtection(event.block.location, event.block.dimension.id) && !canBypass(event.source)) {
                     event.cancel = true;
                 }
             }
         });
     }
 
-    if (spawnProtectionConfig.preventPvP || spawnProtectionConfig.preventPvE) {
+    if (spawnProtection.preventPvP || spawnProtection.preventPvE) {
         world.beforeEvents.entityHurt.subscribe((event) => {
+            if (!event.hurtEntity?.dimension) return;
+            if (!isWithinSpawnProtection(event.hurtEntity.location, event.hurtEntity.dimension.id)) return;
+
             const { hurtEntity, damageSource } = event;
-            const damagingEntity = damageSource.damagingEntity;
-
-            // Add a guard to ensure the hurt entity and its dimension are valid
-            if (!hurtEntity?.dimension) {return;}
-
-            if (!isWithinSpawnProtection(hurtEntity.location, hurtEntity.dimension.id)) {return;}
 
             // PvP Protection
-            if (spawnProtectionConfig.preventPvP && hurtEntity instanceof Player && damagingEntity instanceof Player && !canBypass(damagingEntity)) {
-                event.cancel = true;
+            if (spawnProtection.preventPvP && hurtEntity instanceof Player && damageSource.damagingEntity instanceof Player) {
+                if (!canBypass(damageSource.damagingEntity)) event.cancel = true;
                 return;
             }
 
-            // PvE Protection (Player getting hurt by non-player)
-            if (spawnProtectionConfig.preventPvE && hurtEntity instanceof Player && damagingEntity && !(damagingEntity instanceof Player)) {
-                event.cancel = true;
-                return;
-            }
-        });
-    }
-
-    if (spawnProtectionConfig.preventMobSpawning) {
-        world.beforeEvents.mobSpawn.subscribe((event) => {
-            if (isWithinSpawnProtection(event.location, event.dimension.id)) {
-                event.cancel = true;
-            }
-        });
-    }
-
-    if (spawnProtectionConfig.preventItemDropping) {
-        world.beforeEvents.itemDrop.subscribe((event) => {
-            const { source } = event;
-            if (!(source instanceof Player)) {return;}
-
-            if (isWithinSpawnProtection(source.location, source.dimension.id) && !canBypass(source)) {
-                event.cancel = true;
-            }
-        });
-    }
-
-    if (spawnProtectionConfig.preventItemPickup) {
-        world.beforeEvents.itemPickup.subscribe((event) => {
-            if (isWithinSpawnProtection(event.item.location, event.item.dimension.id) && !canBypass(event.player)) {
-                event.cancel = true;
-            }
-        });
-    }
-
-
-    if (spawnProtectionConfig.preventHungerLoss) {
-        system.runInterval(() => {
-            for (const player of world.getAllPlayers()) {
-                if (isWithinSpawnProtection(player.location, player.dimension.id)) {
-                    player.getComponent('minecraft:food').resetToDefaultValue();
+            // PvE Protection (Player Immortality)
+            if (spawnProtection.preventPvE && hurtEntity instanceof Player) {
+                const bypassCauses = [EntityDamageCause.void, EntityDamageCause.suicide];
+                if (!bypassCauses.includes(damageSource.cause)) {
+                    event.cancel = true;
                 }
             }
-        }, 20); // Run every second
+        });
     }
+
+    if (spawnProtection.preventItemDropping) {
+        world.beforeEvents.itemDrop.subscribe((event) => {
+            if (event.source instanceof Player) {
+                if (isWithinSpawnProtection(event.source.location, event.source.dimension.id) && !canBypass(event.source)) {
+                    event.cancel = true;
+                }
+            }
+        });
+    }
+
+    if (spawnProtection.preventItemPickup) {
+        world.beforeEvents.itemPickup.subscribe((event) => {
+            // Check if the entity picking up the item is a player
+            if (event.player) {
+                 if (isWithinSpawnProtection(event.item.location, event.item.dimension.id) && !canBypass(event.player)) {
+                    event.cancel = true;
+                }
+            }
+        });
+    }
+
+    // --- INTERVAL-BASED PROTECTIONS ---
+
+    system.runInterval(() => {
+        const currentSpawnConfig = getSpawnConfig();
+        const protection = currentSpawnConfig?.spawnProtection;
+        const loc = currentSpawnConfig?.spawn?.spawnLocation;
+
+        if (!protection?.enabled || !loc) return;
+
+        for (const player of world.getAllPlayers()) {
+            if (!isWithinSpawnProtection(player.location, player.dimension.id)) continue;
+
+            // Hunger Loss Prevention
+            if (protection.preventHungerLoss) {
+                player.getComponent('minecraft:food')?.resetToDefaultValue();
+            }
+        }
+
+        // Mob Spawning Prevention (Cleanup Routine)
+        if (protection.preventMobSpawning) {
+            try {
+                const entitiesInSpawn = world.getDimension(loc.dimensionId).getEntities({
+                    location: loc,
+                    maxDistance: protection.protectionRadius,
+                    families: ["monster"], // Specifically target hostile mobs
+                    excludeFamilies: ["player", "inanimate"],
+                });
+
+                for (const entity of entitiesInSpawn) {
+                    if (isWithinSpawnProtection(entity.location, entity.dimension.id)) {
+                        entity.kill();
+                    }
+                }
+            } catch (e) {
+                errorLog(`[SpawnProtection] Error during mob cleanup: ${e}`);
+            }
+        }
+    }, 40); // Run every 2 seconds
 }
 
 export { initialize as initializeSpawnProtection };

--- a/AddonExeBP/scripts/spawnConfig.js
+++ b/AddonExeBP/scripts/spawnConfig.js
@@ -1,0 +1,27 @@
+export const spawnConfig = {
+    // --- Spawn Settings ---
+    spawn: {
+        cooldownSeconds: 60,
+        teleportWarmupSeconds: 10,
+        // Default spawn location. Can be set manually here (e.g., { x: 0, y: 100, z: 0, dimensionId: 'minecraft:overworld' }) or with the in-game /setspawn command.
+        spawnLocation: null
+    },
+
+    // --- Spawn Protection Settings ---
+    spawnProtection: {
+        enabled: true,
+        protectionRadius: 32,
+        allowAdminBypass: true,
+        preventPvP: true,
+        preventPvE: true,
+        preventMobSpawning: true,
+        preventBlockBreaking: true,
+        preventBlockPlacing: true,
+        preventExplosions: true,
+        preventBlockInteraction: true,
+        preventFire: true,
+        preventHungerLoss: true,
+        preventItemDropping: false,
+        preventItemPickup: false
+    }
+};


### PR DESCRIPTION
As requested, this commit adds 'spawnset' as a new alias for the '/setspawn' command. This provides a more intuitive alternative for users wanting to set the world spawn.

---
name: Pull Request
about: Propose changes to the AddonExe
title: "Brief description of changes (e.g., Fix: Resolve fly detection false positive)"
labels: ''
assignees: ''

---

**Description of Changes:**
<!--
Provide a detailed description of the changes introduced by this PR.
What problem does it solve? How does it solve it?
What are the key modifications?
Link to any related issues here, e.g., "Fixes #123".
-->

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

**Checklist:**
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] My code follows the project's coding style and guidelines.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code where necessary.
- [ ] I have made corresponding changes to the documentation if needed.
- [ ] My changes do not generate new ESLint warnings or errors.
- [ ] I have tested my changes thoroughly.

---

By submitting this pull request, you agree to license your contribution under the project's [MIT License](https://github.com/SjnExe/AddonExe/blob/main/LICENSE).
