### PR TITLE
Fix reset confirmation and success message

### DIFF
--- a/AddonExeBP/scripts/core/uiManager.js
+++ b/AddonExeBP/scripts/core/uiManager.js
@@ -811,12 +811,12 @@ async function handleFormResponse(player, panelId, response, context) {
 
             const finalConfirmResponse = await utils.uiWait(player, finalConfirmForm);
 
-            if (finalConfirmResponse.canceled || finalConfirmResponse.formValues[0].toLowerCase() !== 'confirm') {
+            if (finalConfirmResponse.canceled || finalConfirmResponse.formValues[0].trim().toLowerCase() !== 'confirm') {
                 player.sendMessage('§cFinal confirmation failed. Reset canceled.');
                 return showPanel(player, 'configResetPanel', { ...context, page });
             }
 
-            const result = resetConfigSection(selectedSystem.id);
+            const result = await resetConfigSection(selectedSystem.id);
             player.sendMessage(`§2${result.message}`);
             return showPanel(player, 'configResetPanel', { ...context, page: 1 });
         }
@@ -845,12 +845,12 @@ async function handleFormResponse(player, panelId, response, context) {
 
                 const finalConfirmResponse = await utils.uiWait(player, finalConfirmForm);
 
-                if (finalConfirmResponse.canceled || finalConfirmResponse.formValues[0].toLowerCase() !== 'confirm') {
+                if (finalConfirmResponse.canceled || finalConfirmResponse.formValues[0].trim().toLowerCase() !== 'confirm') {
                     player.sendMessage('§cFinal confirmation failed. Reset canceled.');
                     return showPanel(player, 'configResetPanel', { ...context, page });
                 }
 
-                const result = resetConfigSection('all');
+                const result = await resetConfigSection('all');
                 player.sendMessage(`§2${result.message}`);
                 return showPanel(player, 'configResetPanel', { ...context, page: 1 });
             }


### PR DESCRIPTION
- Trim whitespace from the confirmation input to allow for inputs like ' confirm '.
- Await the `resetConfigSection` function to ensure the success message is displayed correctly.

---
name: Pull Request
about: Propose changes to the AddonExe
title: "Brief description of changes (e.g., Fix: Resolve fly detection false positive)"
labels: ''
assignees: ''

---

**Description of Changes:**
<!--
Provide a detailed description of the changes introduced by this PR.
What problem does it solve? How does it solve it?
What are the key modifications?
Link to any related issues here, e.g., "Fixes #123".
-->

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

**Checklist:**
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] My code follows the project's coding style and guidelines.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code where necessary.
- [ ] I have made corresponding changes to the documentation if needed.
- [ ] My changes do not generate new ESLint warnings or errors.
- [ ] I have tested my changes thoroughly.

---

By submitting this pull request, you agree to license your contribution under the project's [MIT License](https://github.com/SjnExe/AddonExe/blob/main/LICENSE).
