### PR TITLE
fix(ui): Export getMenuItems to resolve script error

### DIFF
--- a/AddonExeBP/scripts/core/ui/panelBuilder.js
+++ b/AddonExeBP/scripts/core/ui/panelBuilder.js
@@ -41,7 +41,7 @@ function addPaginationButtons(form, page, totalItems) {
     }
 }
 
-function getMenuItems(panelDef, permissionLevel) {
+export function getMenuItems(panelDef, permissionLevel) {
     const config = getConfig();
     const items = (panelDef.items || [])
         .filter(item => {


### PR DESCRIPTION
The script was failing on startup with a `SyntaxError: Could not find export 'getMenuItems' in module 'core/ui/panelBuilder.js'`.

This was caused by the `getMenuItems` function in `panelBuilder.js` not being exported, while it was being imported and used by `panelHandlers.js`.

This commit resolves the issue by adding the `export` keyword to the `getMenuItems` function definition, making it accessible to other modules.

---
name: Pull Request
about: Propose changes to the AddonExe
title: "Brief description of changes (e.g., Fix: Resolve fly detection false positive)"
labels: ''
assignees: ''

---

**Description of Changes:**
<!--
Provide a detailed description of the changes introduced by this PR.
What problem does it solve? How does it solve it?
What are the key modifications?
Link to any related issues here, e.g., "Fixes #123".
-->

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

**Checklist:**
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] My code follows the project's coding style and guidelines.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code where necessary.
- [ ] I have made corresponding changes to the documentation if needed.
- [ ] My changes do not generate new ESLint warnings or errors.
- [ ] I have tested my changes thoroughly.

---

By submitting this pull request, you agree to license your contribution under the project's [MIT License](https://github.com/SjnExe/AddonExe/blob/main/LICENSE).
