### PR TITLE
Fix: Correct script API usage in managers

### DIFF
--- a/AddonExeBP/scripts/core/floatingTextManager.js
+++ b/AddonExeBP/scripts/core/floatingTextManager.js
@@ -16,7 +16,7 @@ let retrySpawnIntervalId;
 function scheduleNextUpdate(textConfig) {
     // If a timeout already exists for this text, clear it before scheduling a new one.
     if (updateTimeouts.has(textConfig.id)) {
-        mc.system.clearTimeout(updateTimeouts.get(textConfig.id));
+        mc.system.clearRun(updateTimeouts.get(textConfig.id));
         updateTimeouts.delete(textConfig.id);
     }
 
@@ -314,7 +314,7 @@ function createText(player, id, text) {
 async function despawnText(id) {
     // Clean up internal script state to prevent respawns.
     if (pendingDespawns.has(id)) {
-        mc.system.clearTimeout(pendingDespawns.get(id));
+        mc.system.clearRun(pendingDespawns.get(id));
         pendingDespawns.delete(id);
     }
     unloadedChunkQueue.delete(id);
@@ -353,7 +353,7 @@ async function despawnText(id) {
 async function respawnText(id) {
     // Cancel any pending command-based despawn to prevent race conditions
     if (pendingDespawns.has(id)) {
-        mc.system.clearTimeout(pendingDespawns.get(id));
+        mc.system.clearRun(pendingDespawns.get(id));
         pendingDespawns.delete(id);
         debugLog(`[FloatingText] Canceled pending despawn for ID: ${id} due to respawn.`);
     }
@@ -382,7 +382,7 @@ async function deleteText(player, id) {
 
     // Stop any scheduled updates for this text.
     if (updateTimeouts.has(id)) {
-        mc.system.clearTimeout(updateTimeouts.get(id));
+        mc.system.clearRun(updateTimeouts.get(id));
         updateTimeouts.delete(id);
     }
 
@@ -425,23 +425,23 @@ function cleanup() {
 
     // Clear main interval loops
     if (expirationIntervalId) {
-        mc.system.clearTimeout(expirationIntervalId);
+        mc.system.clearRun(expirationIntervalId);
         expirationIntervalId = undefined; // Use undefined to signify it's cleared
     }
     if (retrySpawnIntervalId) {
-        mc.system.clearTimeout(retrySpawnIntervalId);
+        mc.system.clearRun(retrySpawnIntervalId);
         retrySpawnIntervalId = undefined;
     }
 
     // Clear all pending update timeouts for individual texts
     for (const timeoutId of updateTimeouts.values()) {
-        mc.system.clearTimeout(timeoutId);
+        mc.system.clearRun(timeoutId);
     }
     updateTimeouts.clear();
 
     // Clear any pending despawn timeouts
     for (const timeoutId of pendingDespawns.values()) {
-        mc.system.clearTimeout(timeoutId);
+        mc.system.clearRun(timeoutId);
     }
     pendingDespawns.clear();
 

--- a/AddonExeBP/scripts/modules/commands/commandManager.js
+++ b/AddonExeBP/scripts/modules/commands/commandManager.js
@@ -64,7 +64,7 @@ class CommandManager {
                 console.warn(`[CommandManager] Command '${command.name}' cannot be run from the console.`); // eslint-disable-line no-console
                 return;
             }
-            mc.system.runJob(() => {
+            mc.system.run(() => {
                 try {
                     command.execute(executor, args);
                 } catch (error) {
@@ -95,7 +95,7 @@ class CommandManager {
         }
 
         // Execute Command
-        mc.system.runJob(() => {
+        mc.system.run(() => {
             try {
                 command.execute(player, args);
             } catch (error) {


### PR DESCRIPTION
This commit addresses two `TypeError` exceptions that were occurring due to outdated Minecraft Bedrock Scripting API calls.

- In `floatingTextManager.js`, all instances of `mc.system.clearTimeout()` have been replaced with the correct `mc.system.clearRun()` to prevent errors when clearing scheduled tasks.

- In `commandManager.js`, the `mc.system.runJob()` calls, which were incorrectly used with standard callback functions, have been replaced with `mc.system.run()` to ensure proper command execution without causing a native type conversion failure.

---
name: Pull Request
about: Propose changes to the AddonExe
title: "Brief description of changes (e.g., Fix: Resolve fly detection false positive)"
labels: ''
assignees: ''

---

**Description of Changes:**
<!--
Provide a detailed description of the changes introduced by this PR.
What problem does it solve? How does it solve it?
What are the key modifications?
Link to any related issues here, e.g., "Fixes #123".
-->

**How Has This Been Tested?**
<!--
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

**Checklist:**
- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] My code follows the project's coding style and guidelines.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code where necessary.
- [ ] I have made corresponding changes to the documentation if needed.
- [ ] My changes do not generate new ESLint warnings or errors.
- [ ] I have tested my changes thoroughly.

---

By submitting this pull request, you agree to license your contribution under the project's [MIT License](https://github.com/SjnExe/AddonExe/blob/main/LICENSE).
