### PR TITLE
fix(ci): make dependency updater CI-aware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,11 @@
                 "@minecraft/common": "latest",
                 "@minecraft/core-build-tasks": "latest",
                 "@minecraft/creator-tools": "latest",
-                "@minecraft/debug-utilities": "1.0.0-beta.1.26.0-stable",
-                "@minecraft/diagnostics": "1.0.0-beta.1.26.0-stable",
+                "@minecraft/debug-utilities": "1.0.0-beta.1.26.1-stable",
                 "@minecraft/math": "latest",
-                "@minecraft/server": "2.6.0-beta.1.26.0-stable",
-                "@minecraft/server-gametest": "1.0.0-beta.1.26.0-stable",
-                "@minecraft/server-ui": "2.1.0-beta.1.26.0-stable",
+                "@minecraft/server": "2.6.0-beta.1.26.1-stable",
+                "@minecraft/server-gametest": "1.0.0-beta.1.26.1-stable",
+                "@minecraft/server-ui": "2.1.0-beta.1.26.1-stable",
                 "@minecraft/vanilla-data": "latest",
                 "@types/jest": "latest",
                 "@types/node": "latest",
@@ -3898,25 +3897,14 @@
             }
         },
         "node_modules/@minecraft/debug-utilities": {
-            "version": "1.0.0-beta.1.26.0-stable",
-            "resolved": "https://registry.npmjs.org/@minecraft/debug-utilities/-/debug-utilities-1.0.0-beta.1.26.0-stable.tgz",
-            "integrity": "sha512-ieF5fyDEWZ03ySGb1Qh1hyDDM5DuvuxQdGpCJWz3egYjJ4MLoI02Ucb982Fj+HDJlMB1vljzYrB+188S+/iPWg==",
+            "version": "1.0.0-beta.1.26.1-stable",
+            "resolved": "https://registry.npmjs.org/@minecraft/debug-utilities/-/debug-utilities-1.0.0-beta.1.26.1-stable.tgz",
+            "integrity": "sha512-s16FfD6MuEQnrZvhAbIp8XAYHDNoh+Vheis6B8Z0uzgPkXz1DIkHYc0qFQJtUu7FnLyXsrIvZHnORTG0tBD2IQ==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "@minecraft/common": "^1.0.0",
                 "@minecraft/server": "^1.17.0 || ^2.0.0"
-            }
-        },
-        "node_modules/@minecraft/diagnostics": {
-            "version": "1.0.0-beta.1.26.0-stable",
-            "resolved": "https://registry.npmjs.org/@minecraft/diagnostics/-/diagnostics-1.0.0-beta.1.26.0-stable.tgz",
-            "integrity": "sha512-G5QpzSoGHCes52/qkVL46lb9iynKBZsaNX+zpK++OLWoTW1sKPPrV+YhKa3K448qNg+Hqt7RcquScnjD90zFMQ==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "@minecraft/common": "^1.0.0",
-                "@minecraft/server-admin": "^1.0.0-beta.1.26.0-stable"
             }
         },
         "node_modules/@minecraft/math": {
@@ -3930,9 +3918,9 @@
             }
         },
         "node_modules/@minecraft/server": {
-            "version": "2.6.0-beta.1.26.0-stable",
-            "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-2.6.0-beta.1.26.0-stable.tgz",
-            "integrity": "sha512-I8GFHqE4LNnmI5FnCpCGjbURHbdzYJdZtJ9vqfjlJ8TkWKlrrJVQpIr6IDghG0jon1Zv0zMJUWprpo6wsedkVg==",
+            "version": "2.6.0-beta.1.26.1-stable",
+            "resolved": "https://registry.npmjs.org/@minecraft/server/-/server-2.6.0-beta.1.26.1-stable.tgz",
+            "integrity": "sha512-AyZE4l4xoua2E0E1QUwXJN7ZAVB2wm6hkBT5kkFuWmBoaeRUODe2KwB3mLymARS+keCGCI5i2RVFis5X1vP8tg==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
@@ -3940,34 +3928,26 @@
                 "@minecraft/vanilla-data": ">=1.20.70"
             }
         },
-        "node_modules/@minecraft/server-admin": {
-            "version": "1.0.0-beta.11940b24",
-            "resolved": "https://registry.npmjs.org/@minecraft/server-admin/-/server-admin-1.0.0-beta.11940b24.tgz",
-            "integrity": "sha512-UZ8YyB8mvF31f22+uM67gJums9d6NDgz9AQ2l4a++EHUP9uen0m3aaBaqM9RyumJpRBJbv/hslAKOyeDT01qew==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/@minecraft/server-gametest": {
-            "version": "1.0.0-beta.1.26.0-stable",
-            "resolved": "https://registry.npmjs.org/@minecraft/server-gametest/-/server-gametest-1.0.0-beta.1.26.0-stable.tgz",
-            "integrity": "sha512-R9GC5Gha2xlA1ESE8T+hCVuw9OyYvHP+Y1z1Ty7Pu1VxYm7WCuN5MShLKkUTGPvhlyE0+2hXq+Cu5g8Lx5V3Tg==",
+            "version": "1.0.0-beta.1.26.1-stable",
+            "resolved": "https://registry.npmjs.org/@minecraft/server-gametest/-/server-gametest-1.0.0-beta.1.26.1-stable.tgz",
+            "integrity": "sha512-eYvQuB2dKRHtpRq/fM+69n8gpWxRaKVBDM0EglYurS7VQwtdePelQDTseFBut+UFApnnbO0hi3zwXwQtdGRwjw==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "@minecraft/common": "^1.0.0",
-                "@minecraft/server": "^1.17.0 || ^2.0.0 || ^2.6.0-beta.1.26.0-stable"
+                "@minecraft/server": "^1.17.0 || ^2.0.0 || ^2.6.0-beta.1.26.1-stable"
             }
         },
         "node_modules/@minecraft/server-ui": {
-            "version": "2.1.0-beta.1.26.0-stable",
-            "resolved": "https://registry.npmjs.org/@minecraft/server-ui/-/server-ui-2.1.0-beta.1.26.0-stable.tgz",
-            "integrity": "sha512-fhqI+CcMBj5YvaVz/yBZn+uL2/bjklC2tNjTVX4nO48MywN2gehTSkO+V6FqaKTsnEXJ7kPkXiSdBnsZ0KSfKw==",
+            "version": "2.1.0-beta.1.26.1-stable",
+            "resolved": "https://registry.npmjs.org/@minecraft/server-ui/-/server-ui-2.1.0-beta.1.26.1-stable.tgz",
+            "integrity": "sha512-Mi0NQSBT4afehsuaqLh4mEXupWkWoKY0ILLXk2lGs/zyksYEua934hJXnj3BUsvuQNoIGOukzLy2qSCsfL2n+w==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
                 "@minecraft/common": "^1.0.0",
-                "@minecraft/server": "^2.0.0 || ^2.6.0-beta.1.26.0-stable"
+                "@minecraft/server": "^2.0.0 || ^2.6.0-beta.1.26.1-stable"
             }
         },
         "node_modules/@minecraft/vanilla-data": {

--- a/package.json
+++ b/package.json
@@ -47,11 +47,11 @@
         "@minecraft/common": "latest",
         "@minecraft/core-build-tasks": "latest",
         "@minecraft/creator-tools": "latest",
-        "@minecraft/debug-utilities": "1.0.0-beta.1.26.0-stable",
+        "@minecraft/debug-utilities": "1.0.0-beta.1.26.1-stable",
         "@minecraft/math": "latest",
-        "@minecraft/server": "2.6.0-beta.1.26.0-stable",
-        "@minecraft/server-gametest": "1.0.0-beta.1.26.0-stable",
-        "@minecraft/server-ui": "2.1.0-beta.1.26.0-stable",
+        "@minecraft/server": "2.6.0-beta.1.26.1-stable",
+        "@minecraft/server-gametest": "1.0.0-beta.1.26.1-stable",
+        "@minecraft/server-ui": "2.1.0-beta.1.26.1-stable",
         "@minecraft/vanilla-data": "latest",
         "@types/jest": "latest",
         "@types/node": "latest",
@@ -129,10 +129,10 @@
     },
     "overrides": {
         "@minecraft/common": "latest",
-        "@minecraft/debug-utilities": "1.0.0-beta.1.26.0-stable",
-        "@minecraft/server": "2.6.0-beta.1.26.0-stable",
-        "@minecraft/server-gametest": "1.0.0-beta.1.26.0-stable",
-        "@minecraft/server-ui": "2.1.0-beta.1.26.0-stable",
+        "@minecraft/debug-utilities": "1.0.0-beta.1.26.1-stable",
+        "@minecraft/server": "2.6.0-beta.1.26.1-stable",
+        "@minecraft/server-gametest": "1.0.0-beta.1.26.1-stable",
+        "@minecraft/server-ui": "2.1.0-beta.1.26.1-stable",
         "@minecraft/vanilla-data": "latest"
     }
 }

--- a/scripts/update-mc-deps.js
+++ b/scripts/update-mc-deps.js
@@ -116,7 +116,9 @@ async function main() {
         if (isCI) {
             console.warn(`${colors.yellow}Updates available for Minecraft dependencies:${colors.reset}`);
             for (const u of updates) console.warn(`  ${u}`);
-            console.warn(`${colors.blue}Skipping auto-update in CI environment. Run 'npm install' locally to update.${colors.reset}`);
+            console.warn(
+                `${colors.blue}Skipping auto-update in CI environment. Run 'npm install' locally to update.${colors.reset}`
+            );
             // Exit with 0 so CI doesn't fail
             process.exit(0);
         } else {

--- a/scripts/update-mc-deps.js
+++ b/scripts/update-mc-deps.js
@@ -39,7 +39,7 @@ async function fetchPackageVersion(pkg) {
     }
 }
 
-async function updatePackageJson(updates) {
+async function updatePackageJson(updates, dryRun = false) {
     try {
         await fs.access(packageJsonPath, constants.F_OK);
     } catch {
@@ -76,6 +76,11 @@ async function updatePackageJson(updates) {
             const currentVersion = devDeps[pkg];
 
             if (currentVersion !== newVersion) {
+                // Only update the object in memory if we are going to write it or if we need to report it.
+                // If dryRun is true, we still want to report what WOULD change.
+
+                // We update the local object so we can print the report, but we won't write if dryRun is true.
+                // Actually, let's keep the logic simple: update the object, just don't write to file.
                 devDeps[pkg] = newVersion;
 
                 // Update overrides if the package exists there
@@ -90,8 +95,10 @@ async function updatePackageJson(updates) {
     }
 
     if (packageJsonUpdated) {
-        const indentation = 4;
-        await fs.writeFile(packageJsonPath, JSON.stringify(packageJson, undefined, indentation) + '\n');
+        if (!dryRun) {
+            const indentation = 4;
+            await fs.writeFile(packageJsonPath, JSON.stringify(packageJson, undefined, indentation) + '\n');
+        }
         return true;
     }
 
@@ -99,19 +106,28 @@ async function updatePackageJson(updates) {
 }
 
 async function main() {
-    console.log(`${colors.blue}Checking Minecraft dependencies...${colors.reset}`);
+    const isCI = !!process.env.CI;
+    console.log(`${colors.blue}Checking Minecraft dependencies...${isCI ? '(CI Mode)' : ''}${colors.reset}`);
 
     const updates = [];
-    const pkgUpdated = await updatePackageJson(updates);
+    const pkgUpdated = await updatePackageJson(updates, isCI);
 
     if (pkgUpdated) {
-        console.log(`${colors.green}Updated Minecraft dependencies:${colors.reset}`);
-        for (const u of updates) console.log(`  ${u}`);
-        console.log(
-            `${colors.yellow}Dependencies updated. Please run 'npm install' again to install the new versions.${colors.reset}`
-        );
-        // Exit with 1 to indicate changes were made (useful for CI/hooks)
-        process.exit(1);
+        if (isCI) {
+            console.warn(`${colors.yellow}Updates available for Minecraft dependencies:${colors.reset}`);
+            for (const u of updates) console.warn(`  ${u}`);
+            console.warn(`${colors.blue}Skipping auto-update in CI environment. Run 'npm install' locally to update.${colors.reset}`);
+            // Exit with 0 so CI doesn't fail
+            process.exit(0);
+        } else {
+            console.log(`${colors.green}Updated Minecraft dependencies:${colors.reset}`);
+            for (const u of updates) console.log(`  ${u}`);
+            console.log(
+                `${colors.yellow}Dependencies updated. Please run 'npm install' again to install the new versions.${colors.reset}`
+            );
+            // Exit with 1 to indicate changes were made (useful for local hooks)
+            process.exit(1);
+        }
     } else {
         console.log(`${colors.green}All Minecraft dependencies are up to date.${colors.reset}`);
         process.exit(0);


### PR DESCRIPTION
This PR modifies the `scripts/update-mc-deps.js` script to handle CI environments gracefully.

Previously, the script would check for updates to `@minecraft/*` dependencies, and if found, it would modify `package.json` and exit with code 1 to force a user re-install. This behavior caused `npm ci` to fail in CI pipelines because `preinstall` scripts must not modify the dependency tree or fail during a clean install.

The script now checks `process.env.CI`. If true:
1. It logs available updates as warnings.
2. It does **not** modify `package.json`.
3. It exits with code 0, allowing the build to proceed with the locked versions.

This change also includes the actual update of `@minecraft/server` and other dependencies to their latest versions, resolving the immediate update need.

---
*PR created automatically by Jules for task [16486104819350973590](https://jules.google.com/task/16486104819350973590) started by @SjnExe*