### PR TITLE
fix: increase fetch depth in lint workflow to fix shallow checkout

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,7 @@ jobs:
               uses: actions/checkout@v6
               with:
                   ref: ${{ github.head_ref || github.ref }}
+                  fetch-depth: 2
 
             - name: Set up Node.js and cache npm dependencies
               uses: actions/setup-node@v6


### PR DESCRIPTION
Increases the fetch depth from the default 1 to 2 in the .github/workflows/lint.yml checkout step. This resolves failures where actions/checkout cannot fetch specific branch references with a shallow clone, while maintaining a fast execution time (avoiding full history fetch).

---
*PR created automatically by Jules for task [1574909126531756731](https://jules.google.com/task/1574909126531756731) started by @SjnExe*