### PR TITLE
fix: update config migration logic and switch to gh cli for releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,32 +148,36 @@ jobs:
 
             - name: Publish Nightly Release
               if: steps.build_type.outputs.type == 'nightly'
-              uses: softprops/action-gh-release@v2
-              with:
-                  name: Nightly Build (Latest Dev)
-                  tag_name: nightly
-                  prerelease: true
-                  make_latest: false
-                  body: |
-                      **Latest Nightly Build**
-                      Version: `${{ env.VERSION_STRING }}`
-                      Commit: `${{ github.sha }}`
-                      Date: `${{ env.BUILD_DATE }}`
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  # Create note text
+                  cat <<EOF > release_notes.md
+                  **Latest Nightly Build**
+                  Version: \`${{ env.VERSION_STRING }}\`
+                  Commit: \`${{ github.sha }}\`
+                  Date: \`${{ env.BUILD_DATE }}\`
 
-                      *This is an automated development build. It may contain bugs.*
-                  files: |
-                      AddonExe.Nightly.${{ env.ARCHIVE_VERSION }}.mcaddon
-                      AddonExe_BP.Nightly.${{ env.ARCHIVE_VERSION }}.mcpack
+                  *This is an automated development build. It may contain bugs.*
+                  EOF
+
+                  # Use gh release create
+                  gh release create nightly \
+                      --title "Nightly Build (Latest Dev)" \
+                      --prerelease \
+                      --notes-file release_notes.md \
+                      AddonExe.Nightly.${{ env.ARCHIVE_VERSION }}.mcaddon \
+                      AddonExe_BP.Nightly.${{ env.ARCHIVE_VERSION }}.mcpack \
                       AddonExe_RP.Nightly.${{ env.ARCHIVE_VERSION }}.mcpack
 
             - name: Publish Stable Release
               if: steps.build_type.outputs.type == 'stable'
-              uses: softprops/action-gh-release@v2
-              with:
-                  files: |
-                      AddonExe.Release.${{ env.ARCHIVE_VERSION }}.mcaddon
-                      AddonExe_BP.Release.${{ env.ARCHIVE_VERSION }}.mcpack
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  # Use gh release create
+                  gh release create ${{ env.ARCHIVE_VERSION }} \
+                      --generate-notes \
+                      AddonExe.Release.${{ env.ARCHIVE_VERSION }}.mcaddon \
+                      AddonExe_BP.Release.${{ env.ARCHIVE_VERSION }}.mcpack \
                       AddonExe_RP.Release.${{ env.ARCHIVE_VERSION }}.mcpack
-                  generate_release_notes: true
-                  draft: false
-                  prerelease: false

--- a/Dev/ConfigurationExplanation.md
+++ b/Dev/ConfigurationExplanation.md
@@ -90,7 +90,7 @@ The configuration system is built on four fundamental components:
 
 This process preserves user settings across updates while adding new features.
 
-1.  **Version Mismatch Detected**: The addon detects it has been updated.
+1.  **Version Mismatch Detected**: The addon detects it has been updated. This occurs *anytime* the version string changes (e.g., from `1.2.4` to `1.2.5`, or during nightly development builds), ensuring all updates trigger the merge.
 2.  **Load Configs**: It loads the user's **Current Configuration** (from before the update) and the **New Default Configuration** from the updated `.js` file.
 3.  **The Merge (`deepMerge`)**: The manager performs a standard deep merge:
     - It starts with the **New Default Configuration** as the base.

--- a/scripts/prepare-release.js
+++ b/scripts/prepare-release.js
@@ -75,9 +75,6 @@ async function updateConfig(filePath) {
         // Update logLevel
         // Regex matches: logLevel: 2
         content = content.replaceAll(/logLevel:\s*2/g, 'logLevel: 3');
-
-        // Update isNightly
-        content = content.replaceAll(/isNightly:\s*false/g, 'isNightly: true');
     }
 
     await fs.writeFile(fullPath, content);

--- a/src/config.default.ts
+++ b/src/config.default.ts
@@ -1,7 +1,6 @@
 export const config = {
     // --- System & Core Settings ---
     version: [1, 0, 0], // This will be replaced by the release workflow
-    isNightly: false, // Updated by release workflow
     ownerPlayerNames: ['Your•Name•Here'], // Default : ['Your•Name•Here']
     commandPrefix: '!',
     serverName: '§cServerExe§r',

--- a/src/config.js
+++ b/src/config.js
@@ -5,7 +5,6 @@
 export const config = {
     // --- System & Core Settings ---
     version: [1, 0, 0], // This will be replaced by the release workflow
-    isNightly: false, // Updated by release workflow
     ownerPlayerNames: ['Your•Name•Here'], // Default : ['Your•Name•Here']
     commandPrefix: '!',
     serverName: '§cServerExe§r',

--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -45,23 +45,13 @@ export async function initializeAddon() {
     infoLog('[AddonExe] Initializing...');
 
     // Version Check & Migration Flag
-    const newVersion = VERSION.split('.').map(Number);
     const newVersionStr = VERSION;
     const lastVersionStr = mc.world.getDynamicProperty('exe:lastVersion') as string | undefined;
 
     let isMigration = true;
     if (isNonEmptyString(lastVersionStr)) {
-        const lastVersion = lastVersionStr.split('.').map(Number);
-        // Only trigger migration if Major or Minor versions differ.
-        // Array format is [Major, Minor, Patch]
-        if (
-            lastVersion.length >= 2 &&
-            newVersion.length >= 2 &&
-            lastVersion[0] === newVersion[0] &&
-            lastVersion[1] === newVersion[1]
-        ) {
-            isMigration = false;
-        }
+        // Trigger migration if the version string changes at all (Major, Minor, or Patch)
+        isMigration = lastVersionStr !== newVersionStr;
     }
 
     // Parallel Initialization of core configurations and feature modules
@@ -104,10 +94,6 @@ export async function initializeAddon() {
     restartAnnouncer();
 
     reinitializeOnlinePlayers();
-
-    if (config.isNightly) {
-        infoLog('[AddonExe] Nightly build detected.');
-    }
 
     startSystemTimers();
     infoLog('[AddonExe] Addon initialized successfully.');


### PR DESCRIPTION
- Changed `isMigration` logic in `src/core/main.ts` to use a direct string comparison (`lastVersionStr !== newVersionStr`). This ensures that patch updates and nightly builds trigger configuration merging properly.
- Completely removed `isNightly` from `config.default.ts`, `config.js`, `prepare-release.js`, and `main.ts` as it was no longer serving any useful purpose.
- Updated `Dev/ConfigurationExplanation.md` to document the new behavior.
- Updated `.github/workflows/build.yml` to replace the deprecated `softprops/action-gh-release@v2` action with native `gh release create` CLI commands to fix Node 20 deprecation warnings and CI unreliability.
- Updated `actions/upload-artifact` to `v7` and added a `retention-days: 7` limit.

---
name: Pull Request
about: Propose changes to the AddonExe
title: 'Brief description of changes (e.g., Fix: Resolve fly detection false positive)'
---

**Description of Changes:**

<!--
Provide a detailed description of the changes introduced by this PR.
What problem does it solve? How does it solve it?
What are the key modifications?
Link to any related issues here, e.g., "Fixes #123".
-->

**How Has This Been Tested?**

<!--
Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce.
-->

**Screenshots / Video (for UI or visual changes):**

<!--
If your PR changes the UI or adds visual features, please include screenshots or a video recording here.
-->

**Checklist:**

- [ ] I have read the **CONTRIBUTING.md** document.
- [ ] My code follows the project's coding style and guidelines.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code where necessary.
- [ ] I have made corresponding changes to the documentation if needed.
- [ ] My changes do not generate new ESLint warnings or errors.
- [ ] I have tested my changes thoroughly.

---

By submitting this pull request, you agree to license your contribution under the project's [MIT License](https://github.com/SjnExe/AddonExe/blob/exe/LICENSE).
