### PR TITLE
Fix UI panels closing immediately by calling UI panel registration

### DIFF
--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -30,6 +30,7 @@ import { cleanupPlayerDataManager } from './playerDataManager.js';
 import * as rankManager from './rankManager.js';
 import * as sidebarManager from './sidebarManager.js';
 import { cleanupTimers, startSystemTimers } from './timerManager.js';
+import { initialize as initializeUIPanels } from './ui/panels/index.js';
 import { reinitializeOnlinePlayers } from './utils.js';
 
 const VERSION = '0.7.0'; // Current Addon Version
@@ -101,6 +102,7 @@ export async function initializeAddon() {
 
 function initializeManagers() {
     rankManager.initialize();
+    initializeUIPanels();
 }
 
 /**


### PR DESCRIPTION
Fix UI panels closing immediately by calling UI panel registration.

The `initialize` function from `src/core/ui/panels/index.js` which registers all modular UI panel handlers via `panelRouter.register()` was never being invoked. This caused the UI panels to be correctly visualized using the static definitions but close instantly whenever a button was pressed, as there were no registered handlers.

Added a call to `initializeUIPanels()` within `initializeManagers()` in `src/core/main.ts` to ensure UI interactions map to their respective actions/handlers correctly.

---
*PR created automatically by Jules for task [17018889391728550763](https://jules.google.com/task/17018889391728550763) started by @SjnExe*