### PR TITLE
Fix chat formatting, console logging, and player list UI icons

### DIFF
--- a/src/core/events/beforeChatSend.ts
+++ b/src/core/events/beforeChatSend.ts
@@ -2,8 +2,11 @@ import * as mc from '@minecraft/server';
 
 import { commandManager } from '@core/commands/commandManager.js';
 import { getConfig } from '@core/configManager.js';
+import { rawLog } from '@core/logger.js';
 import { getPlayerFromCache } from '@core/playerCache.js';
 import { getPlayer } from '@core/playerDataManager.js';
+import { getPlayerRank } from '@core/rankManager.js';
+import { stripColorCodes } from '@core/utils/formatting.js';
 
 /**
  * Handles chat messages before they are sent.
@@ -25,8 +28,28 @@ export default function handleBeforeChatSend(event: mc.ChatSendBeforeEvent) {
         return;
     }
 
-    // Rank Formatting handled by rankManager/main config usually
-    // ...
+    // Apply Rank Formatting
+    const rank = getPlayerRank(player, config);
+    const chatFormatting = rank.chatFormatting;
+    if (chatFormatting) {
+        event.cancel = true; // Cancel default broadcast
+        const prefix = chatFormatting.prefixText ? `§e[§r${chatFormatting.prefixText}§e]§r ` : '';
+        const nameColor = chatFormatting.nameColor || '§7';
+        const msgColor = chatFormatting.messageColor || '§f';
+        const formattedMessage = `${prefix}${nameColor}${player.name}§r: ${msgColor}${event.message}§r`;
+
+        mc.world.sendMessage(formattedMessage);
+
+        // Chat to Console
+        if (config.chat.logToConsole === true) {
+            rawLog(stripColorCodes(formattedMessage));
+        }
+    } else {
+        // Fallback Chat to Console if no custom formatting
+        if (config.chat.logToConsole === true) {
+            rawLog(`[CHAT] ${player.name}: ${event.message}`);
+        }
+    }
 
     // Mentions
     if (config.chat.allowMentions === true && event.message.includes('@')) {

--- a/src/core/ui/panels/playerPanel.ts
+++ b/src/core/ui/panels/playerPanel.ts
@@ -9,6 +9,7 @@ import { panelDefinitions } from '@core/ui/panelRegistry.js';
 import { IPanelHandler, PanelItem, UIContext } from '@core/ui/types.js';
 import { showPanel } from '@core/uiManager.js';
 import { formatCurrency } from '@core/utils/economy.js';
+import { getPlayerIcon } from '@core/utils/ui.js';
 import { isDefined } from '@lib/guards.js';
 
 export class PlayerPanelHandler implements IPanelHandler {
@@ -25,10 +26,12 @@ export class PlayerPanelHandler implements IPanelHandler {
         if (panelId === 'playerListPanel' || panelId === 'playerManagementPanel') {
             const players = getVisiblePlayers(player);
             const playerItems: PanelItem[] = players.map((p) => {
+                const targetRank = getPlayerRank(p, config);
+                const rankText = targetRank.chatFormatting?.prefixText ? `[${targetRank.chatFormatting.prefixText}]` : `[${targetRank.name}]`;
                 return {
                     id: `player_${p.id}`,
-                    text: p.name, // Use name for now, rank prefix handled elsewhere if needed
-                    icon: 'textures/ui/steve_head',
+                    text: `${p.name}\n§r${rankText}`,
+                    icon: getPlayerIcon(p),
                     actionType: 'openPanel',
                     actionValue: 'playerActionsPanel',
                     permissionLevel: 1024

--- a/src/core/utils/formatting.ts
+++ b/src/core/utils/formatting.ts
@@ -4,6 +4,14 @@
  * @param context An object containing the values to substitute.
  * @returns The formatted string.
  */
+/**
+ * Strips Minecraft color codes from a string.
+ * @param text The string to strip color codes from.
+ */
+export function stripColorCodes(text: string): string {
+    return text.replace(/§[0-9a-fk-or]/ig, '');
+}
+
 export function formatString(template: string, context: Record<string, string | number | boolean>): string {
     if (!template) {
         return '';

--- a/src/core/utils/ui.ts
+++ b/src/core/utils/ui.ts
@@ -1,6 +1,24 @@
 import * as mc from '@minecraft/server';
 import { ActionFormData, ActionFormResponse, FormCancelationReason, MessageFormData, MessageFormResponse, ModalFormData, ModalFormResponse } from '@minecraft/server-ui';
 
+import { getConfig } from '@core/configManager.js';
+import { getPlayerRank } from '@core/rankManager.js';
+
+/**
+ * Returns an appropriate icon based on the player's permission level.
+ * @param player The player to evaluate.
+ * @returns The path to the texture icon.
+ */
+export function getPlayerIcon(player: mc.Player): string {
+    const config = getConfig();
+    const rank = getPlayerRank(player, config);
+
+    if (rank.permissionLevel < 1024) {
+        return 'textures/ui/permissions_op_crown';
+    }
+    return 'textures/ui/permissions_member_star.png';
+}
+
 /**
  * Forces the chat window to close by briefly toggling input permissions.
  * This is a known workaround for Bedrock UI behavior.

--- a/src/features/social/ui/friendPanel.ts
+++ b/src/features/social/ui/friendPanel.ts
@@ -1,9 +1,12 @@
 /* eslint-disable @typescript-eslint/require-await */
 import * as mc from '@minecraft/server';
 
+import { getConfig } from '@core/configManager.js';
 import { getPlayerFromCache } from '@core/playerCache.js';
 import { getOrCreatePlayer, getPlayer } from '@core/playerDataManager.js';
+import { getPlayerRank } from '@core/rankManager.js';
 import { IPanelHandler, PanelItem, UIContext } from '@core/ui/types.js';
+import { getPlayerIcon } from '@core/utils/ui.js';
 
 export class FriendPanelHandler implements IPanelHandler {
     canHandle(panelId: string): boolean {
@@ -44,15 +47,25 @@ export class FriendPanelHandler implements IPanelHandler {
 
         if (panelId === 'friendListPanel') {
             const friends = pData.friends ?? [];
+            const config = getConfig();
             return friends.map((fid) => {
                 const fData = getPlayer(fid);
                 // Optimization: Use cached lookup
                 const onlineP = getPlayerFromCache(fid);
                 const status = onlineP ? '§aOnline' : '§cOffline';
+
+                let rankText = '';
+                let icon = 'textures/ui/permissions_member_star.png';
+                if (onlineP) {
+                    const targetRank = getPlayerRank(onlineP, config);
+                    rankText = targetRank.chatFormatting?.prefixText ? `§r[${targetRank.chatFormatting.prefixText}]` : `§r[${targetRank.name}]`;
+                    icon = getPlayerIcon(onlineP);
+                }
+
                 return {
                     id: `friend_${fid}`,
-                    text: `${fData ? fData.name : 'Unknown'}\n${status}`,
-                    icon: 'textures/ui/steve_head',
+                    text: `${fData ? fData.name : 'Unknown'} ${status}\n${rankText}`,
+                    icon: icon,
                     actionType: 'functionCall',
                     actionValue: `manageFriend:${fid}`,
                     permissionLevel: 1024

--- a/src/features/teams/ui/teamPanel.ts
+++ b/src/features/teams/ui/teamPanel.ts
@@ -3,10 +3,13 @@ import { ActionFormData, ActionFormResponse, ModalFormData, ModalFormResponse } 
 
 import { getPlayerFromCache } from '@core/playerCache.js';
 import { getPlayer } from '@core/playerDataManager.js';
+import { getConfig } from '@core/configManager.js';
+import { getPlayerRank } from '@core/rankManager.js';
 import { getStaticMenuItems } from '@core/ui/panelBuilder.js';
 import { panelDefinitions } from '@core/ui/panelRegistry.js';
 import { IPanelHandler, PanelItem, UIContext } from '@core/ui/types.js';
 import { showPanel } from '@core/uiManager.js';
+import { getPlayerIcon } from '@core/utils/ui.js';
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
 import * as teamManager from '../teamManager.js';
 
@@ -68,11 +71,21 @@ export class TeamPanelHandler implements IPanelHandler {
 
         if (panelId === 'teamRequestsPanel') {
             if (!isDefined(team)) return baseItems;
+            const config = getConfig();
             const reqItems = team.applications.map((app) => {
+                const onlineP = getPlayerFromCache(app.playerId);
+                let rankText = '';
+                let icon = 'textures/ui/permissions_member_star.png';
+                if (onlineP) {
+                    const targetRank = getPlayerRank(onlineP, config);
+                    rankText = targetRank.chatFormatting?.prefixText ? `§r[${targetRank.chatFormatting.prefixText}]` : `§r[${targetRank.name}]`;
+                    icon = getPlayerIcon(onlineP);
+                }
+
                 const item: PanelItem = {
                     id: `req_${app.playerId}`,
-                    text: `${app.playerName}\n§7${new Date(app.timestamp).toLocaleDateString()}`,
-                    icon: 'textures/ui/steve_head',
+                    text: `${app.playerName} §7${new Date(app.timestamp).toLocaleDateString()}\n${rankText}`,
+                    icon: icon,
                     actionType: 'openPanel',
                     actionValue: 'teamRequestActionPanel',
                     permissionLevel: 1024
@@ -279,6 +292,7 @@ export class TeamPanelHandler implements IPanelHandler {
     private getTeamMembersPanelItems(team: teamManager.TeamData | undefined, baseItems: PanelItem[]): PanelItem[] {
         if (!isDefined(team)) return baseItems;
 
+        const config = getConfig();
         const memberItems = team.members.map((memberId) => {
             const pData = getPlayer(memberId);
             const onlineP = getPlayerFromCache(memberId);
@@ -290,10 +304,18 @@ export class TeamPanelHandler implements IPanelHandler {
                 role = '§eAdmin';
             }
 
+            let rankText = '';
+            let icon = 'textures/ui/permissions_member_star.png';
+            if (onlineP) {
+                const targetRank = getPlayerRank(onlineP, config);
+                rankText = targetRank.chatFormatting?.prefixText ? `§r[${targetRank.chatFormatting.prefixText}]` : `§r[${targetRank.name}]`;
+                icon = getPlayerIcon(onlineP);
+            }
+
             const item: PanelItem = {
                 id: `member_${memberId}`,
-                text: `${pData ? pData.name : 'Unknown'}\n${role} - ${status}`,
-                icon: 'textures/ui/steve_head',
+                text: `${pData ? pData.name : 'Unknown'} ${role} §8| ${status}\n${rankText}`,
+                icon: icon,
                 actionType: 'openPanel',
                 actionValue: 'teamMemberActionPanel',
                 permissionLevel: 1024


### PR DESCRIPTION
Resolves issues where chat messages didn't show ranks and wouldn't log to the console correctly. It also fixes the invalid `steve_head` texture being used across the addon's player lists (`playerPanel`, `friendPanel`, `teamPanel`), replacing them with dynamic icons (op crown or member star) depending on the player's permission level, and formats the rank correctly beneath their name on a new line.

---
*PR created automatically by Jules for task [8636730074661815705](https://jules.google.com/task/8636730074661815705) started by @SjnExe*