### PR TITLE
Fix world and spawn protection UI and logic

### DIFF
--- a/src/core/protectionService.ts
+++ b/src/core/protectionService.ts
@@ -1,6 +1,5 @@
 import { getSpawnConfig, getWorldProtectionConfig } from './configurations.js';
 import type { Vector3 } from '@minecraft/server';
-import { isDefined, isNumber } from '@lib/guards.js';
 
 export type ProtectionFlags = {
     preventPvP: boolean;
@@ -75,17 +74,20 @@ export function getProtectionFlags(location: Vector3, dimensionId: string): Prot
     const spawnConfig = getSpawnConfig();
     if (spawnConfig.spawnProtection.enabled) {
         const spawnLoc = spawnConfig.spawn.spawnLocation;
+        const x = Number(spawnLoc.x);
+        const z = Number(spawnLoc.z);
+
         // Verify spawn location has coordinates
-        if (isDefined(spawnLoc.x) && isDefined(spawnLoc.z) && isNumber(spawnLoc.x) && isNumber(spawnLoc.z)) {
+        if (!isNaN(x) && !isNaN(z)) {
             // Spawn protection uses the configured dimension (or Overworld if undefined, though it defaults to Overworld)
             const spawnDimension = spawnLoc.dimensionId || 'minecraft:overworld';
             if (dimensionId === spawnDimension) {
-                const radius = spawnConfig.spawnProtection.protectionRadius;
+                const radius = Number(spawnConfig.spawnProtection.protectionRadius) || 0;
 
                 // Construct Bounding Box for Spawn Protection (infinite Y axis realistically bounded by world limits)
                 // Spawn column on X and Z axes
-                const minSpawn = { x: spawnLoc.x - radius, y: -64, z: spawnLoc.z - radius };
-                const maxSpawn = { x: spawnLoc.x + radius, y: 320, z: spawnLoc.z + radius };
+                const minSpawn = { x: x - radius, y: -64, z: z - radius };
+                const maxSpawn = { x: x + radius, y: 320, z: z + radius };
 
                 if (isWithinBox(location, minSpawn, maxSpawn)) {
                     // Combine spawn protection flags

--- a/src/core/ui/configPanelRegistry.ts
+++ b/src/core/ui/configPanelRegistry.ts
@@ -351,6 +351,13 @@ export const configPanelSchema: ConfigCategory[] = [
                 description: 'How long a player must stand still before teleporting to spawn.'
             },
             {
+                key: 'spawn.spawnLocation.dimensionId',
+                label: 'Spawn Dimension',
+                type: 'dropdown',
+                options: ['minecraft:overworld', 'minecraft:nether', 'minecraft:the_end'],
+                description: 'The dimension where spawn is located.'
+            },
+            {
                 key: 'spawn.spawnLocation.x',
                 label: 'Spawn X Coordinate',
                 type: 'textField',

--- a/src/core/ui/panels/configPanel.ts
+++ b/src/core/ui/panels/configPanel.ts
@@ -3,7 +3,7 @@ import { ActionFormResponse, ModalFormData, ModalFormResponse } from '@minecraft
 
 import { refreshXrayCache } from '@features/anticheat/xrayDetection.js';
 
-import { getConfig, resetConfigSection } from '@core/configManager.js';
+import { resetConfigSection } from '@core/configManager.js';
 import { errorLog } from '@core/logger.js';
 import { getValueFromPath, setValueByPath } from '@core/objectUtils.js';
 import { getOrCreatePlayer, type PlayerData } from '@core/playerDataManager.js';
@@ -391,9 +391,6 @@ export class ConfigPanelHandler implements IPanelHandler {
         }
 
         if (isDefined(category) && isDefined(values)) {
-            // Cast settings to ConfigSetting[] to match the type
-            const updates = this.processFormValues(category.settings as unknown as ConfigSetting[], values);
-
             const configSource = isNonEmptyString(category.configSource) ? category.configSource : 'main';
             // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
             const handlers = uiConfigHandlers as any;
@@ -401,6 +398,11 @@ export class ConfigPanelHandler implements IPanelHandler {
             const handler = handlers[configSource] as { get: () => unknown; save: (cfg: unknown) => void } | undefined;
 
             if (isDefined(handler)) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const config = handler.get() as Record<string, any>;
+                // Cast settings to ConfigSetting[] to match the type
+                const updates = this.processFormValues(category.settings as unknown as ConfigSetting[], values, config);
+
                 this.saveConfigUpdates(handler, configSource, updates);
                 player.sendMessage('§2Configuration saved.');
 
@@ -419,7 +421,8 @@ export class ConfigPanelHandler implements IPanelHandler {
         return showPanel(player, 'configCategoryPanel', { ...context, page: 1 });
     }
 
-    private processFormValues(settings: ConfigSetting[], values: unknown[]): Record<string, unknown> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private processFormValues(settings: ConfigSetting[], values: unknown[], config: Record<string, any>): Record<string, unknown> {
         const updates: Record<string, unknown> = {};
         // Filter settings to match buildModal logic
         const validSettings = settings.filter((s) => ['toggle', 'textField', 'dropdown'].includes(s.type));
@@ -432,12 +435,15 @@ export class ConfigPanelHandler implements IPanelHandler {
                 value = setting.key === 'logLevel' ? selectedIndex : options[selectedIndex];
             } else if (setting.type === 'textField') {
                 const strVal = value as string;
-                const current = getValueFromPath(getConfig(), setting.key);
-                if (typeof current === 'number') {
+                const current = getValueFromPath(config, setting.key);
+                if (typeof current === 'number' || (setting.key.includes('.x') || setting.key.includes('.y') || setting.key.includes('.z') || setting.key.includes('Radius') || setting.key.includes('Seconds') || setting.key.includes('Cost') || setting.key.includes('Length') || setting.key.includes('Percent') || setting.key.includes('Interval'))) {
                     if (!Number.isNaN(Number(strVal)) && isNonEmptyString(strVal) && strVal.trim() !== '') {
                         value = Number(strVal);
-                    } else {
-                        // Skip update if input is invalid for a number field
+                    } else if (current === undefined && strVal.trim() === '') {
+                        // Allow resetting to undefined
+                        value = undefined;
+                    } else if (strVal.trim() !== '') {
+                        // Skip update if input is invalid for a number field, but allow empty strings if current is undefined
                         continue;
                     }
                 }

--- a/src/features/essentials/ui/worldProtectionPanel.ts
+++ b/src/features/essentials/ui/worldProtectionPanel.ts
@@ -1,5 +1,5 @@
 import * as mc from '@minecraft/server';
-import { ActionFormData, ModalFormData, ModalFormResponse } from '@minecraft/server-ui';
+import { ActionFormData, ActionFormResponse, ModalFormData, ModalFormResponse } from '@minecraft/server-ui';
 
 import { getWorldProtectionConfig, saveWorldProtectionConfig } from '@core/configurations.js';
 import { showPanel } from '@core/uiManager.js';
@@ -102,12 +102,33 @@ export class WorldProtectionPanelHandler implements IPanelHandler {
         return Promise.resolve(undefined);
     }
 
-    handleResponse(player: mc.Player, panelId: string, response: ModalFormResponse, context: UIContext): Promise<void> {
-        if (response.canceled || !response.formValues) return Promise.resolve();
+    async handleResponse(player: mc.Player, panelId: string, response: ActionFormResponse | ModalFormResponse, context: UIContext): Promise<void> {
+        if (response.canceled) return Promise.resolve();
+
+        if (panelId === 'worldProtectionListPanel') {
+            const actionResponse = response as ActionFormResponse;
+            if (typeof actionResponse.selection === 'number') {
+                const items = await this.getItems(player, panelId, context);
+                if (items && actionResponse.selection >= 0 && actionResponse.selection < items.length) {
+                    const item = items[actionResponse.selection];
+                    if (item && item.actionType === 'openPanel') {
+                        return showPanel(player, item.actionValue, {
+                            ...context,
+                            page: 1,
+                            selectedItemId: item.id
+                        });
+                    }
+                }
+            }
+            return Promise.resolve();
+        }
+
+        const modalResponse = response as ModalFormResponse;
+        if (!modalResponse.formValues) return Promise.resolve();
 
         if (panelId === 'addWorldProtectionPanel' || panelId === 'editWorldProtectionPanel') {
             const isEdit = panelId === 'editWorldProtectionPanel';
-            const values = response.formValues;
+            const values = modalResponse.formValues;
 
             const newId = (values[0] as string).trim();
             const newName = (values[1] as string).trim();


### PR DESCRIPTION
Fixes the "Add New Zone" button inside the world protection panel that was closing the UI rather than launching the add form. Also addresses issues with spawn protection by converting coordinate inputs properly and adding a dimension dropdown.

---
*PR created automatically by Jules for task [17979175729863227083](https://jules.google.com/task/17979175729863227083) started by @SjnExe*