### PR TITLE
Fix world and spawn protections, UI coordinates format, and execution errors

### DIFF
--- a/src/core/events/eventManager.ts
+++ b/src/core/events/eventManager.ts
@@ -16,7 +16,9 @@ import {
     handleBeforePlayerBreakBlock,
     handleBeforePlayerPlaceBlock,
     handlePlayerInteractWithBlock,
-    handlePlayerInteractWithEntity
+    handlePlayerInteractWithEntity,
+    handleBeforeItemDrop,
+    handleBeforeItemPickup
 } from './protectionEvents.js';
 
 const cleanupActions: (() => void)[] = [];
@@ -55,6 +57,26 @@ export function initializeEventManager() {
     registerEvent(mc.world.beforeEvents.playerInteractWithBlock, handlePlayerInteractWithBlock, 'playerInteractWithBlock');
     registerEvent(mc.world.beforeEvents.playerInteractWithEntity, handlePlayerInteractWithEntity, 'playerInteractWithEntity');
     registerEvent(mc.world.afterEvents.entitySpawn, handleBeforeEntitySpawn, 'entitySpawn');
+    // Fallback for different version if needed, or cast to any
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+    if ((mc.world.beforeEvents as any).itemDrop !== undefined) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+        registerEvent((mc.world.beforeEvents as any).itemDrop, handleBeforeItemDrop, 'itemDrop');
+    } else {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+        registerEvent((mc.world.beforeEvents as any).playerDropItem, handleBeforeItemDrop, 'playerDropItem');
+    }
+
+    // playerPickUpItem doesn't always exist in beforeEvents. We will check beforeEvents, then afterEvents, but afterEvents can't cancel.
+    // However, @minecraft/server has `beforeEvents.playerInteractWithItem` and `beforeEvents.playerInteractWithBlock`.
+    // Actually, in newer @minecraft/server, it's `beforeEvents.playerPickUpItem` or `beforeEvents.itemDrop`
+
+
+    // Attempt pickup
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (mc.world.beforeEvents.entityItemPickup !== undefined) {
+        registerEvent(mc.world.beforeEvents.entityItemPickup, handleBeforeItemPickup, 'entityItemPickup');
+    }
 
     // Other Events
     registerEvent(mc.world.beforeEvents.chatSend, handleBeforeChatSend, 'beforeChatSend');

--- a/src/core/events/protectionEvents.ts
+++ b/src/core/events/protectionEvents.ts
@@ -29,7 +29,9 @@ export function handleBeforePlayerBreakBlock(event: mc.PlayerBreakBlockBeforeEve
     if (flags.preventBlockBreaking) {
         if (!canBypass(player)) {
             event.cancel = true;
-            player.onScreenDisplay.setActionBar('§cYou cannot break blocks here.');
+            mc.system.run(() => {
+                player.onScreenDisplay.setActionBar('§cYou cannot break blocks here.');
+            });
         }
     }
 }
@@ -42,7 +44,9 @@ export function handleBeforePlayerPlaceBlock(event: mc.PlayerPlaceBlockBeforeEve
     if (flags.preventBlockPlacing) {
         if (!canBypass(player)) {
             event.cancel = true;
-            player.onScreenDisplay.setActionBar('§cYou cannot place blocks here.');
+            mc.system.run(() => {
+                player.onScreenDisplay.setActionBar('§cYou cannot place blocks here.');
+            });
         }
     }
 }
@@ -90,7 +94,9 @@ export function handlePlayerInteractWithBlock(event: mc.PlayerInteractWithBlockB
     if (flags.preventBlockInteraction) {
         if (!canBypass(player)) {
             event.cancel = true;
-            player.onScreenDisplay.setActionBar('§cYou cannot interact with blocks here.');
+            mc.system.run(() => {
+                player.onScreenDisplay.setActionBar('§cYou cannot interact with blocks here.');
+            });
         }
     }
 }
@@ -104,25 +110,72 @@ export function handlePlayerInteractWithEntity(event: mc.PlayerInteractWithEntit
     // If desired, add custom flags for entities. For now, we skip.
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function handleBeforeItemDrop(event: any) {
+    // Handling depends on the actual event structure. It's either itemDrop or playerDropItem
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const p = event.source || event.player;
+    if (!isDefined(p)) return;
+    const player = p as mc.Player;
+
+    const flags = getProtectionFlags(player.location, player.dimension.id);
+    if (flags.preventItemDropping) {
+        if (!canBypass(player)) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            event.cancel = true;
+            mc.system.run(() => {
+                player.onScreenDisplay.setActionBar('§cYou cannot drop items here.');
+            });
+        }
+    }
+}
+
+export function handleBeforeItemPickup(event: mc.EntityItemPickupBeforeEvent) {
+    const entity = event.entity;
+    if (entity.typeId !== 'minecraft:player') return;
+    const player = entity as mc.Player;
+
+    const flags = getProtectionFlags(player.location, player.dimension.id);
+    if (flags.preventItemPickup) {
+        if (!canBypass(player)) {
+            event.cancel = true;
+            mc.system.run(() => {
+                player.onScreenDisplay.setActionBar('§cYou cannot pick up items here.');
+            });
+        }
+    }
+}
+
 export function handleBeforeEntitySpawn(event: mc.EntitySpawnAfterEvent) {
     const { entity } = event;
     if (!isDefined(entity)) return;
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+        const isValid = typeof (entity as any).isValid === 'function' ? (entity as any).isValid() : (entity as any).isValid;
+        if (!isValid) return;
 
-    // If hostile spawning is prevented
-    if (entity.typeId !== 'minecraft:player') {
-        const familyTypes = entity.getComponent('minecraft:type_family');
-        if (familyTypes?.hasTypeFamily('monster')) {
-            const flags = getProtectionFlags(entity.location, entity.dimension.id);
-            if (flags.preventHostileMobSpawning) {
-                // Cannot cancel afterEvent, so we despawn
-                mc.system.run(() => {
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                    const isValid = typeof (entity as any).isValid === 'function' ? (entity as any).isValid() : (entity as any).isValid;
-                    if (isValid) {
-                        entity.remove();
-                    }
-                });
+        // If hostile spawning is prevented
+        if (entity.typeId !== 'minecraft:player') {
+            const familyTypes = entity.getComponent('minecraft:type_family');
+            if (familyTypes?.hasTypeFamily('monster')) {
+                const flags = getProtectionFlags(entity.location, entity.dimension.id);
+                if (flags.preventHostileMobSpawning) {
+                    // Cannot cancel afterEvent, so we despawn
+                    mc.system.run(() => {
+                        try {
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+                            const isStillValid = typeof (entity as any).isValid === 'function' ? (entity as any).isValid() : (entity as any).isValid;
+                            if (isStillValid) {
+                                entity.remove();
+                            }
+                        } catch {
+                            // ignore
+                        }
+                    });
+                }
             }
         }
+    } catch {
+        // Ignore InvalidEntityError
     }
 }

--- a/src/core/protectionService.ts
+++ b/src/core/protectionService.ts
@@ -9,6 +9,8 @@ export type ProtectionFlags = {
     preventBlockPlacing: boolean;
     preventExplosions: boolean;
     preventBlockInteraction: boolean;
+    preventItemPickup: boolean;
+    preventItemDropping: boolean;
 };
 
 const defaultFlags: ProtectionFlags = {
@@ -18,7 +20,9 @@ const defaultFlags: ProtectionFlags = {
     preventBlockBreaking: false,
     preventBlockPlacing: false,
     preventExplosions: false,
-    preventBlockInteraction: false
+    preventBlockInteraction: false,
+    preventItemPickup: false,
+    preventItemDropping: false
 };
 
 /**
@@ -66,6 +70,8 @@ export function getProtectionFlags(location: Vector3, dimensionId: string): Prot
                 activeFlags.preventBlockPlacing = activeFlags.preventBlockPlacing || zone.flags.preventBlockPlacing;
                 activeFlags.preventExplosions = activeFlags.preventExplosions || zone.flags.preventExplosions;
                 activeFlags.preventBlockInteraction = activeFlags.preventBlockInteraction || zone.flags.preventBlockInteraction;
+                activeFlags.preventItemPickup = activeFlags.preventItemPickup || zone.flags.preventItemPickup;
+                activeFlags.preventItemDropping = activeFlags.preventItemDropping || zone.flags.preventItemDropping;
             }
         }
     }
@@ -98,6 +104,8 @@ export function getProtectionFlags(location: Vector3, dimensionId: string): Prot
                     activeFlags.preventBlockPlacing = activeFlags.preventBlockPlacing || spawnConfig.spawnProtection.preventBlockPlacing;
                     activeFlags.preventExplosions = activeFlags.preventExplosions || spawnConfig.spawnProtection.preventExplosions;
                     activeFlags.preventBlockInteraction = activeFlags.preventBlockInteraction || spawnConfig.spawnProtection.preventBlockInteraction;
+                    activeFlags.preventItemPickup = activeFlags.preventItemPickup || spawnConfig.spawnProtection.preventItemPickup;
+                    activeFlags.preventItemDropping = activeFlags.preventItemDropping || spawnConfig.spawnProtection.preventItemDropping;
                 }
             }
         }

--- a/src/core/spawnConfig.default.ts
+++ b/src/core/spawnConfig.default.ts
@@ -25,7 +25,9 @@ export const spawnConfig = {
         preventBlockBreaking: true,
         preventBlockPlacing: true,
         preventExplosions: true,
-        preventBlockInteraction: true
+        preventBlockInteraction: true,
+        preventItemPickup: true,
+        preventItemDropping: true
     }
 };
 

--- a/src/features/essentials/ui/worldProtectionPanel.ts
+++ b/src/features/essentials/ui/worldProtectionPanel.ts
@@ -65,14 +65,16 @@ export class WorldProtectionPanelHandler implements IPanelHandler {
             const dimIndex = zone ? Math.max(0, dimensions.indexOf(zone.dimension)) : 0;
             form.dropdown('Dimension', dimensions, { defaultValueIndex: dimIndex });
 
-            // Coordinates
-            form.textField('Min X', 'e.g., -100', { defaultValue: zone?.box.min.x.toString() ?? '' });
-            form.textField('Min Y', 'e.g., -64', { defaultValue: zone?.box.min.y.toString() ?? '-64' });
-            form.textField('Min Z', 'e.g., -100', { defaultValue: zone?.box.min.z.toString() ?? '' });
+            // Use context.formValues to restore state on error
+            // Ensure backwards compatibility by falling back to zone or empty
+            const restoredValues = context.formValues as unknown[] | undefined;
 
-            form.textField('Max X', 'e.g., 100', { defaultValue: zone?.box.max.x.toString() ?? '' });
-            form.textField('Max Y', 'e.g., 320', { defaultValue: zone?.box.max.y.toString() ?? '320' });
-            form.textField('Max Z', 'e.g., 100', { defaultValue: zone?.box.max.z.toString() ?? '' });
+            const defPos1 = restoredValues ? (restoredValues[3] as string) : (zone ? `${zone.box.min.x} ${zone.box.min.y} ${zone.box.min.z}` : '');
+            const defPos2 = restoredValues ? (restoredValues[4] as string) : (zone ? `${zone.box.max.x} ${zone.box.max.y} ${zone.box.max.z}` : '');
+
+            // Coordinates
+            form.textField('Position 1 (x y z)', 'e.g., -100 -64 -100', { defaultValue: defPos1 });
+            form.textField('Position 2 (x y z)', 'e.g., 100 320 100', { defaultValue: defPos2 });
 
             // Flags
             const flags = zone?.flags ?? {
@@ -82,19 +84,23 @@ export class WorldProtectionPanelHandler implements IPanelHandler {
                 preventBlockBreaking: false,
                 preventBlockPlacing: false,
                 preventExplosions: false,
-                preventBlockInteraction: false
+                preventBlockInteraction: false,
+                preventItemPickup: false,
+                preventItemDropping: false
             };
 
-            form.toggle('Prevent PvP', { defaultValue: flags.preventPvP });
-            form.toggle('Prevent Hostile Damage', { defaultValue: flags.preventHostileDamage });
-            form.toggle('Prevent Hostile Mob Spawning', { defaultValue: flags.preventHostileMobSpawning });
-            form.toggle('Prevent Block Breaking', { defaultValue: flags.preventBlockBreaking });
-            form.toggle('Prevent Block Placing', { defaultValue: flags.preventBlockPlacing });
-            form.toggle('Prevent Explosions', { defaultValue: flags.preventExplosions });
-            form.toggle('Prevent Block Interaction', { defaultValue: flags.preventBlockInteraction });
+            form.toggle('Prevent PvP', { defaultValue: restoredValues ? (restoredValues[5] as boolean) : flags.preventPvP });
+            form.toggle('Prevent Hostile Damage', { defaultValue: restoredValues ? (restoredValues[6] as boolean) : flags.preventHostileDamage });
+            form.toggle('Prevent Hostile Mob Spawning', { defaultValue: restoredValues ? (restoredValues[7] as boolean) : flags.preventHostileMobSpawning });
+            form.toggle('Prevent Block Breaking', { defaultValue: restoredValues ? (restoredValues[8] as boolean) : flags.preventBlockBreaking });
+            form.toggle('Prevent Block Placing', { defaultValue: restoredValues ? (restoredValues[9] as boolean) : flags.preventBlockPlacing });
+            form.toggle('Prevent Explosions', { defaultValue: restoredValues ? (restoredValues[10] as boolean) : flags.preventExplosions });
+            form.toggle('Prevent Block Interaction', { defaultValue: restoredValues ? (restoredValues[11] as boolean) : flags.preventBlockInteraction });
+            form.toggle('Prevent Item Pickup', { defaultValue: restoredValues ? (restoredValues[12] as boolean) : flags.preventItemPickup });
+            form.toggle('Prevent Item Dropping', { defaultValue: restoredValues ? (restoredValues[13] as boolean) : flags.preventItemDropping });
 
             if (isEdit) {
-                form.toggle('§cDelete Zone§r', { defaultValue: false });
+                form.toggle('§cDelete Zone§r', { defaultValue: restoredValues ? (restoredValues[14] as boolean) : false });
             }
 
             return Promise.resolve(form);
@@ -135,34 +141,51 @@ export class WorldProtectionPanelHandler implements IPanelHandler {
             const dimensions = ['minecraft:overworld', 'minecraft:nether', 'minecraft:the_end'];
             const dimension = dimensions[values[2] as number] as string;
 
-            const minX = parseFloat(values[3] as string);
-            const minY = parseFloat(values[4] as string);
-            const minZ = parseFloat(values[5] as string);
+            const pos1Str = (values[3] as string).trim();
+            const pos2Str = (values[4] as string).trim();
 
-            const maxX = parseFloat(values[6] as string);
-            const maxY = parseFloat(values[7] as string);
-            const maxZ = parseFloat(values[8] as string);
+            const parseCoords = (str: string) => {
+                const parts = str.split(/[,\s]+/).map(p => parseFloat(p));
+                if (parts.length >= 3 && !isNaN(parts[0]!) && !isNaN(parts[1]!) && !isNaN(parts[2]!)) {
+                    return { x: parts[0]!, y: parts[1]!, z: parts[2]! };
+                }
+                return null;
+            };
+
+            const pos1 = parseCoords(pos1Str);
+            const pos2 = parseCoords(pos2Str);
 
             // Validation
-            if (!newId || !newName || isNaN(minX) || isNaN(minY) || isNaN(minZ) || isNaN(maxX) || isNaN(maxY) || isNaN(maxZ)) {
-                player.sendMessage('§cInvalid input. Please ensure all coordinates are numbers and ID/Name are provided.');
-                return Promise.resolve();
+            if (!newId || !newName || !pos1 || !pos2) {
+                player.sendMessage('§cInvalid input. Please ensure coordinates are formatted correctly (x y z) and ID/Name are provided.');
+                // Re-open with values preserved
+                return showPanel(player, panelId, { ...context, formValues: values });
             }
 
+            const minX = Math.min(pos1.x, pos2.x);
+            const minY = Math.min(pos1.y, pos2.y);
+            const minZ = Math.min(pos1.z, pos2.z);
+
+            const maxX = Math.max(pos1.x, pos2.x);
+            const maxY = Math.max(pos1.y, pos2.y);
+            const maxZ = Math.max(pos1.z, pos2.z);
+
             const flags = {
-                preventPvP: values[9] as boolean,
-                preventHostileDamage: values[10] as boolean,
-                preventHostileMobSpawning: values[11] as boolean,
-                preventBlockBreaking: values[12] as boolean,
-                preventBlockPlacing: values[13] as boolean,
-                preventExplosions: values[14] as boolean,
-                preventBlockInteraction: values[15] as boolean
+                preventPvP: values[5] as boolean,
+                preventHostileDamage: values[6] as boolean,
+                preventHostileMobSpawning: values[7] as boolean,
+                preventBlockBreaking: values[8] as boolean,
+                preventBlockPlacing: values[9] as boolean,
+                preventExplosions: values[10] as boolean,
+                preventBlockInteraction: values[11] as boolean,
+                preventItemPickup: values[12] as boolean,
+                preventItemDropping: values[13] as boolean
             };
 
             const config = getWorldProtectionConfig();
 
             if (isEdit) {
-                const isDelete = values[16] as boolean;
+                const isDelete = values[14] as boolean;
                 const oldZoneId = context.selectedItemId!.replace('zone_', '');
 
                 if (isDelete) {

--- a/src/features/essentials/worldProtectionConfig.default.ts
+++ b/src/features/essentials/worldProtectionConfig.default.ts
@@ -14,6 +14,8 @@ export type WorldProtectionZone = {
         preventBlockPlacing: boolean;
         preventExplosions: boolean;
         preventBlockInteraction: boolean;
+        preventItemPickup: boolean;
+        preventItemDropping: boolean;
     };
 };
 


### PR DESCRIPTION
Fixes issues with world and spawn protection features.

1. Updates the World Protection Panel to use 2 input strings for coordinate ranges instead of 6 separate inputs, with robust parsing logic and state preservation on errors.
2. Implements the previously unused "Prevent Item Dropping" and "Prevent Item Pickup" settings.
3. Fixes `Restricted Execution Error` for UI actions triggered by before events by executing them inside a `system.run()` loop.
4. Handles `InvalidEntityError` safely during the `entitySpawn` event logic.

---
*PR created automatically by Jules for task [1523563221906396269](https://jules.google.com/task/1523563221906396269) started by @SjnExe*