### PR TITLE
fix: Update isValid usage to property

### DIFF
--- a/src/core/__tests__/Economy.test.ts
+++ b/src/core/__tests__/Economy.test.ts
@@ -68,7 +68,7 @@ const mockPlayer = (id: string, name: string) =>
     ({
         id,
         name,
-        isValid: () => true,
+        isValid: true,
         sendMessage: vi.fn(),
         getGameMode: vi.fn(),
         getComponent: vi.fn()

--- a/src/core/__tests__/__mocks__/minecraftMock.ts
+++ b/src/core/__tests__/__mocks__/minecraftMock.ts
@@ -100,7 +100,7 @@ export class Player {
     playSound = vi.fn();
     getDynamicProperty = vi.fn();
     setDynamicProperty = vi.fn();
-    isValid = vi.fn().mockReturnValue(true);
+    isValid = true;
     triggerEvent = vi.fn();
     getComponent = vi.fn();
 }

--- a/src/core/configurations.ts
+++ b/src/core/configurations.ts
@@ -12,6 +12,7 @@ import { reloadRanks } from './rankManager.js';
 import type { auctionHouseConfig } from '@features/auctionHouse/auctionHouseConfig.default.js';
 import type { dailyRewardsConfig } from '@features/dailyRewards/dailyRewardsConfig.default.js';
 import type { economyConfig } from '@features/economy/economyConfig.js';
+import type { WorldProtectionConfig } from '@features/essentials/worldProtectionConfig.default.js';
 import type { shopConfig } from '@features/shop/shopConfig.js';
 import type { friendConfig } from '@features/social/friendConfig.js';
 import type { teamConfig } from '@features/teams/teamConfig.js';
@@ -32,7 +33,6 @@ export type FriendConfig = typeof friendConfig;
 export type SidebarConfig = typeof sidebarConfig;
 export type AuctionHouseConfig = typeof auctionHouseConfig;
 export type DailyRewardsConfig = typeof dailyRewardsConfig;
-import type { WorldProtectionConfig } from '@features/essentials/worldProtectionConfig.default.js';
 
 let kitsConfigManager: ConfigManager<KitsConfig>,
     shopConfigManager: ConfigManager<ShopConfig>,

--- a/src/core/events/eventManager.ts
+++ b/src/core/events/eventManager.ts
@@ -9,17 +9,17 @@ import handleItemUse from './itemUse.js';
 import handlePlayerDimensionChange from './playerDimensionChange.js';
 import handlePlayerLeave from './playerLeave.js';
 import { handlePlayerSpawn } from './playerSpawn.js';
-import { handleScriptEventReceive } from './scriptEventReceive.js';
 import {
     handleBeforeEntitySpawn,
     handleBeforeExplosion,
+    handleBeforeItemDrop,
+    handleBeforeItemPickup,
     handleBeforePlayerBreakBlock,
     handleBeforePlayerPlaceBlock,
     handlePlayerInteractWithBlock,
-    handlePlayerInteractWithEntity,
-    handleBeforeItemDrop,
-    handleBeforeItemPickup
+    handlePlayerInteractWithEntity
 } from './protectionEvents.js';
+import { handleScriptEventReceive } from './scriptEventReceive.js';
 
 const cleanupActions: (() => void)[] = [];
 
@@ -58,7 +58,7 @@ export function initializeEventManager() {
     registerEvent(mc.world.beforeEvents.playerInteractWithEntity, handlePlayerInteractWithEntity, 'playerInteractWithEntity');
     registerEvent(mc.world.afterEvents.entitySpawn, handleBeforeEntitySpawn, 'entitySpawn');
     // Fallback for different version if needed, or cast to any
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
     if ((mc.world.beforeEvents as any).itemDrop !== undefined) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
         registerEvent((mc.world.beforeEvents as any).itemDrop, handleBeforeItemDrop, 'itemDrop');
@@ -70,7 +70,6 @@ export function initializeEventManager() {
     // playerPickUpItem doesn't always exist in beforeEvents. We will check beforeEvents, then afterEvents, but afterEvents can't cancel.
     // However, @minecraft/server has `beforeEvents.playerInteractWithItem` and `beforeEvents.playerInteractWithBlock`.
     // Actually, in newer @minecraft/server, it's `beforeEvents.playerPickUpItem` or `beforeEvents.itemDrop`
-
 
     // Attempt pickup
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition

--- a/src/core/events/protectionEvents.ts
+++ b/src/core/events/protectionEvents.ts
@@ -1,8 +1,8 @@
-import * as mc from '@minecraft/server';
+import { getSpawnConfig } from '@core/configurations.js';
+import { getOrCreatePlayer } from '@core/playerDataManager.js';
 import { getProtectionFlags } from '@core/protectionService.js';
 import { isDefined } from '@lib/guards.js';
-import { getOrCreatePlayer } from '@core/playerDataManager.js';
-import { getSpawnConfig } from '@core/configurations.js';
+import * as mc from '@minecraft/server';
 
 function canBypass(player: mc.Player): boolean {
     // Check if admin bypass is allowed globally or in spawn configuration
@@ -150,8 +150,7 @@ export function handleBeforeEntitySpawn(event: mc.EntitySpawnAfterEvent) {
     const { entity } = event;
     if (!isDefined(entity)) return;
     try {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        const isValid = typeof (entity as any).isValid === 'function' ? (entity as any).isValid() : (entity as any).isValid;
+        const isValid = entity.isValid;
         if (!isValid) return;
 
         // If hostile spawning is prevented
@@ -163,8 +162,7 @@ export function handleBeforeEntitySpawn(event: mc.EntitySpawnAfterEvent) {
                     // Cannot cancel afterEvent, so we despawn
                     mc.system.run(() => {
                         try {
-                            // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                            const isStillValid = typeof (entity as any).isValid === 'function' ? (entity as any).isValid() : (entity as any).isValid;
+                            const isStillValid = entity.isValid;
                             if (isStillValid) {
                                 entity.remove();
                             }

--- a/src/core/floatingTextManager.ts
+++ b/src/core/floatingTextManager.ts
@@ -116,8 +116,7 @@ function* updateLoopJob() {
             // Batch query once per dimension
             const allEntities = dimension.getEntities({ type: 'exe:floating_text' });
             for (const entity of allEntities) {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                if (!(entity as any).isValid()) continue;
+                if (!entity.isValid) continue;
                 for (const tag of entity.getTags()) {
                     if (tag.startsWith('ft_')) {
                         const id = tag.slice(3);
@@ -135,12 +134,7 @@ function* updateLoopJob() {
                     lastResolvedText.set(textConfig.id, resolved);
                     const entity = entitiesMap.get(textConfig.id);
 
-                    if (
-                        isDefined(entity) &&
-                        typeof entity.isValid === 'function' &&
-                        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                        (entity as any).isValid()
-                    ) {
+                    if (isDefined(entity) && entity.isValid) {
                         entity.nameTag = resolved.replaceAll(String.raw`\n`, '\n');
                     }
                 }
@@ -189,8 +183,7 @@ function pruneOrphanedTexts() {
             const dimension = mc.world.getDimension(dimId);
             const entities = dimension.getEntities({ type: 'exe:floating_text' });
             for (const entity of entities) {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                if (!(entity as any).isValid()) continue;
+                if (!entity.isValid) continue;
                 let isTracked = false;
                 for (const tag of entity.getTags()) {
                     if (tag.startsWith('ft_')) {
@@ -233,8 +226,7 @@ function spawnAllTexts() {
             // Batch query all floating texts in this dimension
             const entities = dimension.getEntities({ type: 'exe:floating_text' });
             for (const entity of entities) {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                if (!(entity as any).isValid()) continue;
+                if (!entity.isValid) continue;
                 for (const tag of entity.getTags()) {
                     if (tag.startsWith('ft_')) {
                         const id = tag.slice(3);
@@ -250,12 +242,7 @@ function spawnAllTexts() {
         for (const textConfig of texts) {
             if (dimensionValid) {
                 const entity = entityMap.get(textConfig.id);
-                if (
-                    isDefined(entity) &&
-                    typeof entity.isValid === 'function' &&
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                    (entity as any).isValid()
-                ) {
+                if (isDefined(entity) && entity.isValid) {
                     const isCorrectLocation =
                         Math.abs(entity.location.x - textConfig.location.x) < 0.1 &&
                         Math.abs(entity.location.y - textConfig.location.y) < 0.1 &&
@@ -285,8 +272,7 @@ function spawnText(textConfig: FloatingTextConfig) {
             });
 
             for (const entity of entities) {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                if (!(entity as any).isValid()) continue;
+                if (!entity.isValid) continue;
                 entity.remove();
                 removedViaApi = true;
             }
@@ -329,12 +315,7 @@ async function findEntityWithRetries(dimension: mc.Dimension, query: mc.EntityQu
     for (let i = 0; i < maxRetries; i++) {
         const entities = dimension.getEntities(query);
         const entity = entities.length > 0 ? entities[0] : undefined;
-        if (
-            isDefined(entity) &&
-            typeof entity.isValid === 'function' &&
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            (entity as any).isValid()
-        ) {
+        if (isDefined(entity) && entity.isValid) {
             return entity;
         }
         await new Promise<void>((resolve) => mc.system.runTimeout(resolve, delayBetweenRetries));
@@ -500,12 +481,7 @@ export function despawnText(id: string) {
         // Iterate and remove all matches, just in case duplication occurred
         let found = false;
         for (const entity of entities) {
-            if (
-                isDefined(entity) &&
-                typeof entity.isValid === 'function' &&
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                (entity as any).isValid()
-            ) {
+            if (isDefined(entity) && entity.isValid) {
                 entity.remove();
                 found = true;
             }

--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -16,8 +16,8 @@ import {
     loadSidebarConfig,
     loadSpawnConfig,
     loadTeamConfig,
-    loadXrayConfig,
-    loadWorldProtectionConfig
+    loadWorldProtectionConfig,
+    loadXrayConfig
 } from './configurations.js';
 import { dataManager, loadPersistentData } from './dataManager.js';
 import { cleanupEventManager, initializeEventManager } from './events/eventManager.js';

--- a/src/core/mobDeathEvents.ts
+++ b/src/core/mobDeathEvents.ts
@@ -4,6 +4,7 @@ import * as mc from '@minecraft/server';
 import { getTeamByPlayer } from '@features/teams/teamManager.js';
 import { isNumber } from '@lib/guards.js';
 
+import { saveLastLocation } from '@features/teleportation/teleportUtils.js';
 import { getConfig } from './configManager.js';
 import { getEconomyConfig } from './configurations.js';
 import * as lastHitManager from './lastHitManager.js';
@@ -12,7 +13,6 @@ import { getPlayerFromCache } from './playerCache.js';
 import { getPlayer, incrementDeathCount, incrementKillCount, incrementKillStreak, incrementPlayerBalance, resetKillStreak } from './playerDataManager.js';
 import { handlePvPDeath } from './pvpManager.js';
 import { formatCurrency } from './utils.js';
-import { saveLastLocation } from '@features/teleportation/teleportUtils.js';
 
 mc.world.afterEvents.entityDie.subscribe((event: mc.EntityDieAfterEvent) => {
     const { deadEntity, damageSource } = event;

--- a/src/core/protectionService.ts
+++ b/src/core/protectionService.ts
@@ -1,5 +1,5 @@
-import { getSpawnConfig, getWorldProtectionConfig } from './configurations.js';
 import type { Vector3 } from '@minecraft/server';
+import { getSpawnConfig, getWorldProtectionConfig } from './configurations.js';
 
 export type ProtectionFlags = {
     preventPvP: boolean;
@@ -41,11 +41,7 @@ function isWithinBox(location: Vector3, min: Vector3, max: Vector3): boolean {
     const maxY = Math.max(min.y, max.y);
     const maxZ = Math.max(min.z, max.z);
 
-    return (
-        location.x >= minX && location.x <= maxX &&
-        location.y >= minY && location.y <= maxY &&
-        location.z >= minZ && location.z <= maxZ
-    );
+    return location.x >= minX && location.x <= maxX && location.y >= minY && location.y <= maxY && location.z >= minZ && location.z <= maxZ;
 }
 
 /**

--- a/src/core/sidebarManager.ts
+++ b/src/core/sidebarManager.ts
@@ -47,8 +47,7 @@ function updateSidebars() {
 
     for (const player of players) {
         try {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-            if (typeof player.isValid === 'function' && !((player as any).isValid() as boolean)) continue;
+            if (!player.isValid) continue;
 
             const pData = getPlayer(player.id);
             if (!isDefined(pData)) continue;

--- a/src/core/teleportLogic.ts
+++ b/src/core/teleportLogic.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call */
 import { isDefined, isNumber } from '@lib/guards.js';
 import { Vector3Utils } from '@minecraft/math';
 import * as mc from '@minecraft/server';
@@ -55,8 +54,7 @@ export function startTeleportWarmup(player: mc.Player, durationSeconds: number, 
 
     intervalId = mc.system.runInterval(() => {
         try {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-            if (!(player as any).isValid()) {
+            if (!player.isValid) {
                 cancel();
                 return;
             }

--- a/src/core/ui/panelBuilder.ts
+++ b/src/core/ui/panelBuilder.ts
@@ -3,11 +3,11 @@ import { ActionFormData, ModalFormData } from '@minecraft/server-ui';
 
 import { getConfig } from '@core/configManager.js';
 import { errorLog } from '@core/logger.js';
+import { getValueFromPath } from '@core/objectUtils.js';
 import { getPlayerFromCache } from '@core/playerCache.js';
 import { getOrCreatePlayer, loadPlayerData } from '@core/playerDataManager.js';
 import { getPlayerRank } from '@core/rankManager.js';
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
-import { getValueFromPath } from '@core/objectUtils.js';
 import { panelRouter } from './PanelRouter.js';
 import { panelDefinitions } from './panelRegistry.js';
 import { MainConfig, PanelDefinition, PanelItem, UIContext } from './types.js';
@@ -39,7 +39,7 @@ export function getStaticMenuItems(panelDef: PanelDefinition, permissionLevel: n
             icon: 'textures/gui/controls/left.png',
             permissionLevel: 1024,
             actionType: 'openPanel',
-            actionValue: (isDefined(context) && isNonEmptyString(context.returnPanel)) ? context.returnPanel : (panelDef.parentPanelId as string)
+            actionValue: isDefined(context) && isNonEmptyString(context.returnPanel) ? context.returnPanel : (panelDef.parentPanelId as string)
         });
     }
     return resultItems;

--- a/src/core/ui/panels/configPanel.ts
+++ b/src/core/ui/panels/configPanel.ts
@@ -436,7 +436,18 @@ export class ConfigPanelHandler implements IPanelHandler {
             } else if (setting.type === 'textField') {
                 const strVal = value as string;
                 const current = getValueFromPath(config, setting.key);
-                if (typeof current === 'number' || (setting.key.includes('.x') || setting.key.includes('.y') || setting.key.includes('.z') || setting.key.includes('Radius') || setting.key.includes('Seconds') || setting.key.includes('Cost') || setting.key.includes('Length') || setting.key.includes('Percent') || setting.key.includes('Interval'))) {
+                if (
+                    typeof current === 'number' ||
+                    setting.key.includes('.x') ||
+                    setting.key.includes('.y') ||
+                    setting.key.includes('.z') ||
+                    setting.key.includes('Radius') ||
+                    setting.key.includes('Seconds') ||
+                    setting.key.includes('Cost') ||
+                    setting.key.includes('Length') ||
+                    setting.key.includes('Percent') ||
+                    setting.key.includes('Interval')
+                ) {
                     if (!Number.isNaN(Number(strVal)) && isNonEmptyString(strVal) && strVal.trim() !== '') {
                         value = Number(strVal);
                     } else if (current === undefined && strVal.trim() === '') {

--- a/src/core/ui/panels/generalPanel.ts
+++ b/src/core/ui/panels/generalPanel.ts
@@ -11,7 +11,14 @@ import { IPanelHandler } from '@ui/types.js';
 
 export class GeneralPanelHandler implements IPanelHandler {
     canHandle(panelId: string): boolean {
-        return panelId === 'mainPanel' || panelId === 'economyMainPanel' || panelId === 'socialMainPanel' || panelId === 'profileMainPanel' || panelId === 'bountyActionsPanel' || panelId === 'bountyListPanel';
+        return (
+            panelId === 'mainPanel' ||
+            panelId === 'economyMainPanel' ||
+            panelId === 'socialMainPanel' ||
+            panelId === 'profileMainPanel' ||
+            panelId === 'bountyActionsPanel' ||
+            panelId === 'bountyListPanel'
+        );
     }
 
     getItems(player: mc.Player, panelId: string, _context: UIContext): Promise<PanelItem[]> {

--- a/src/core/ui/panels/index.ts
+++ b/src/core/ui/panels/index.ts
@@ -1,5 +1,6 @@
 import { BountyPanelHandler } from '@features/economy/ui/bountyPanel.js';
 import { EconomyPanelHandler } from '@features/economy/ui/economyPanel.js';
+import { WorldProtectionPanelHandler } from '@features/essentials/ui/worldProtectionPanel.js';
 import { KitPanelHandler } from '@features/kits/ui/kitPanel.js';
 import { ModerationPanelHandler } from '@features/moderation/ui/moderationPanel.js';
 import { XrayPanelHandler } from '@features/moderation/ui/xrayPanel.js';
@@ -17,7 +18,6 @@ import { InfoPanelHandler } from './infoPanel.js';
 import { PlayerPanelHandler } from './playerPanel.js';
 import { RankPanelHandler } from './rankPanel.js';
 import { SidebarPanelHandler } from './sidebarPanel.js';
-import { WorldProtectionPanelHandler } from '@features/essentials/ui/worldProtectionPanel.js';
 
 export function initialize() {
     // Core Handlers

--- a/src/core/utils/formatting.ts
+++ b/src/core/utils/formatting.ts
@@ -9,7 +9,7 @@
  * @param text The string to strip color codes from.
  */
 export function stripColorCodes(text: string): string {
-    return text.replace(/§[0-9a-fk-or]/ig, '');
+    return text.replace(/§[0-9a-fk-or]/gi, '');
 }
 
 export function formatString(template: string, context: Record<string, string | number | boolean>): string {

--- a/src/core/utils/player.ts
+++ b/src/core/utils/player.ts
@@ -76,12 +76,7 @@ export function resolveTarget(input: string, executor: mc.Player): mc.Player[] {
 export function isValidPlayer(player: mc.Player): boolean {
     if (!isDefined(player)) return false;
     try {
-        if (typeof player.isValid === 'function') {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-            return (player as any).isValid() as boolean;
-        }
-
-        return true;
+        return player.isValid;
     } catch {
         return false;
     }

--- a/src/features/anticheat/itemCheck.ts
+++ b/src/features/anticheat/itemCheck.ts
@@ -29,8 +29,7 @@ function* checkInventoryGenerator(config: AnticheatConfig) {
         // Optimization: Use cached players
         const players = getAllPlayersFromCache();
         for (const player of players) {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            if ((player as any).isValid()) {
+            if (player.isValid) {
                 checkPlayerInventory(player, config.itemCheck);
             }
             yield;

--- a/src/features/anticheat/movementCheck.ts
+++ b/src/features/anticheat/movementCheck.ts
@@ -41,8 +41,8 @@ function* checkPlayersGenerator(config: AnticheatConfig) {
         const players = getAllPlayersFromCache();
         for (const player of players) {
             // Process one player per tick/slice
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-            if ((player as any).isValid()) {
+
+            if (player.isValid) {
                 // Run checks
                 if (config.movementCheck.enabled === true) {
                     checkMovement(player, config.movementCheck);

--- a/src/features/essentials/spawnProtection.ts
+++ b/src/features/essentials/spawnProtection.ts
@@ -16,8 +16,7 @@ export function initializeSpawnProtection() {
 
         for (const player of players) {
             try {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-                const isValid = typeof (player as any).isValid === 'function' ? (player as any).isValid() : (player as any).isValid;
+                const isValid = player.isValid;
                 if (!isValid) continue;
 
                 const flags = getProtectionFlags(player.location, player.dimension.id);
@@ -39,7 +38,6 @@ export function initializeSpawnProtection() {
                     player.removeTag('exe:in_hostile_protection');
                     player.triggerEvent('exe:enable_hostile_damage');
                 }
-
             } catch (error) {
                 debugLog(`Protection evaluation error for ${player.name}: ${String(error)}`);
             }

--- a/src/features/essentials/ui/worldProtectionPanel.ts
+++ b/src/features/essentials/ui/worldProtectionPanel.ts
@@ -2,8 +2,8 @@ import * as mc from '@minecraft/server';
 import { ActionFormData, ActionFormResponse, ModalFormData, ModalFormResponse } from '@minecraft/server-ui';
 
 import { getWorldProtectionConfig, saveWorldProtectionConfig } from '@core/configurations.js';
-import { showPanel } from '@core/uiManager.js';
 import { IPanelHandler, PanelItem, UIContext } from '@core/ui/types.js';
+import { showPanel } from '@core/uiManager.js';
 import { WorldProtectionZone } from '../worldProtectionConfig.default.js';
 
 export class WorldProtectionPanelHandler implements IPanelHandler {
@@ -51,7 +51,7 @@ export class WorldProtectionPanelHandler implements IPanelHandler {
             let zone: WorldProtectionZone | undefined;
             if (isEdit && context.selectedItemId) {
                 const zoneId = context.selectedItemId.replace('zone_', '');
-                zone = config.zones.find(z => z.id === zoneId);
+                zone = config.zones.find((z) => z.id === zoneId);
                 if (!zone) return Promise.resolve(undefined);
             }
 
@@ -69,8 +69,8 @@ export class WorldProtectionPanelHandler implements IPanelHandler {
             // Ensure backwards compatibility by falling back to zone or empty
             const restoredValues = context.formValues as unknown[] | undefined;
 
-            const defPos1 = restoredValues ? (restoredValues[3] as string) : (zone ? `${zone.box.min.x} ${zone.box.min.y} ${zone.box.min.z}` : '');
-            const defPos2 = restoredValues ? (restoredValues[4] as string) : (zone ? `${zone.box.max.x} ${zone.box.max.y} ${zone.box.max.z}` : '');
+            const defPos1 = restoredValues ? (restoredValues[3] as string) : zone ? `${zone.box.min.x} ${zone.box.min.y} ${zone.box.min.z}` : '';
+            const defPos2 = restoredValues ? (restoredValues[4] as string) : zone ? `${zone.box.max.x} ${zone.box.max.y} ${zone.box.max.z}` : '';
 
             // Coordinates
             form.textField('Position 1 (x y z)', 'e.g., -100 -64 -100', { defaultValue: defPos1 });
@@ -145,7 +145,7 @@ export class WorldProtectionPanelHandler implements IPanelHandler {
             const pos2Str = (values[4] as string).trim();
 
             const parseCoords = (str: string) => {
-                const parts = str.split(/[,\s]+/).map(p => parseFloat(p));
+                const parts = str.split(/[,\s]+/).map((p) => parseFloat(p));
                 if (parts.length >= 3 && !isNaN(parts[0]!) && !isNaN(parts[1]!) && !isNaN(parts[2]!)) {
                     return { x: parts[0]!, y: parts[1]!, z: parts[2]! };
                 }
@@ -189,10 +189,10 @@ export class WorldProtectionPanelHandler implements IPanelHandler {
                 const oldZoneId = context.selectedItemId!.replace('zone_', '');
 
                 if (isDelete) {
-                    config.zones = config.zones.filter(z => z.id !== oldZoneId);
+                    config.zones = config.zones.filter((z) => z.id !== oldZoneId);
                     player.sendMessage(`§aDeleted protection zone: ${oldZoneId}`);
                 } else {
-                    const zoneIndex = config.zones.findIndex(z => z.id === oldZoneId);
+                    const zoneIndex = config.zones.findIndex((z) => z.id === oldZoneId);
                     if (zoneIndex > -1) {
                         config.zones[zoneIndex] = {
                             id: newId,
@@ -208,7 +208,7 @@ export class WorldProtectionPanelHandler implements IPanelHandler {
                     }
                 }
             } else {
-                if (config.zones.some(z => z.id === newId)) {
+                if (config.zones.some((z) => z.id === newId)) {
                     player.sendMessage(`§cZone ID '${newId}' already exists.`);
                     return Promise.resolve();
                 }

--- a/src/features/teams/ui/teamPanel.ts
+++ b/src/features/teams/ui/teamPanel.ts
@@ -1,9 +1,9 @@
 import * as mc from '@minecraft/server';
 import { ActionFormData, ActionFormResponse, ModalFormData, ModalFormResponse } from '@minecraft/server-ui';
 
+import { getConfig } from '@core/configManager.js';
 import { getPlayerFromCache } from '@core/playerCache.js';
 import { getPlayer } from '@core/playerDataManager.js';
-import { getConfig } from '@core/configManager.js';
 import { getPlayerRank } from '@core/rankManager.js';
 import { getStaticMenuItems } from '@core/ui/panelBuilder.js';
 import { panelDefinitions } from '@core/ui/panelRegistry.js';

--- a/src/features/teleportation/teleportUtils.ts
+++ b/src/features/teleportation/teleportUtils.ts
@@ -12,12 +12,7 @@ import { isDefined } from '@lib/guards.js';
 export function saveLastLocation(player: mc.Player, reason: 'death' | 'teleport' = 'teleport') {
     if (!isDefined(player)) return;
 
-    if (typeof player.isValid === 'function') {
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-        if (!(player as any).isValid()) return;
-    } else if (typeof player.isValid === 'boolean' && !player.isValid) {
-        return;
-    }
+    if (!player.isValid) return;
 
     // Check if Back system is globally enabled
     const backConfig = getConfig().back as { enabled?: boolean; saveOnDeath?: boolean; saveOnTeleport?: boolean } | undefined;


### PR DESCRIPTION
Update `isValid` usage to property

In recent versions of `@minecraft/server`, `isValid` has been changed from a method to a boolean property. This commit updates all usages of `isValid()` to `isValid` across the codebase to resolve `TypeError: not a function` during intervals such as teleport warmup.

---
*PR created automatically by Jules for task [4604868448178384517](https://jules.google.com/task/4604868448178384517) started by @SjnExe*