### PR TITLE
build(deps): fix dependabot alerts with transitive overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1015,16 +1015,22 @@
             "license": "MIT"
         },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "0.2.12",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-            "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "^1.4.3",
-                "@emnapi/runtime": "^1.4.3",
-                "@tybys/wasm-util": "^0.10.0"
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
             }
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -1528,25 +1534,6 @@
             },
             "engines": {
                 "node": "^20.19.0 || >=22.12.0"
-            }
-        },
-        "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "@tybys/wasm-util": "^0.10.1"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/Brooooooklyn"
-            },
-            "peerDependencies": {
-                "@emnapi/core": "^1.7.1",
-                "@emnapi/runtime": "^1.7.1"
             }
         },
         "node_modules/@rolldown/binding-win32-arm64-msvc": {
@@ -2235,6 +2222,19 @@
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+            "version": "0.2.12",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+            "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.4.3",
+                "@emnapi/runtime": "^1.4.3",
+                "@tybys/wasm-util": "^0.10.0"
             }
         },
         "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,20 @@
         "@minecraft/server": "beta",
         "@minecraft/server-gametest": "beta",
         "@minecraft/server-ui": "beta",
-        "@minecraft/vanilla-data": "latest"
+        "@minecraft/vanilla-data": "latest",
+        "@isaacs/brace-expansion": "latest",
+        "@octokit/plugin-paginate-rest": "latest",
+        "@octokit/request": "latest",
+        "@octokit/request-error": "latest",
+        "ajv": "latest",
+        "axios": "latest",
+        "brace-expansion": "latest",
+        "flatted": "latest",
+        "follow-redirects": "latest",
+        "lodash": "latest",
+        "minimatch": "latest",
+        "picomatch": "latest",
+        "yaml": "latest"
     },
     "devDependencies": {
         "@eslint/eslintrc": "latest",

--- a/package.json
+++ b/package.json
@@ -46,13 +46,13 @@
         "*.{js,ts,json,md}": "prettier --write"
     },
     "overrides": {
+        "@isaacs/brace-expansion": "latest",
         "@minecraft/common": "latest",
         "@minecraft/debug-utilities": "beta",
         "@minecraft/server": "beta",
         "@minecraft/server-gametest": "beta",
         "@minecraft/server-ui": "beta",
         "@minecraft/vanilla-data": "latest",
-        "@isaacs/brace-expansion": "latest",
         "@octokit/plugin-paginate-rest": "latest",
         "@octokit/request": "latest",
         "@octokit/request-error": "latest",


### PR DESCRIPTION
Adds necessary selective overrides for transitive dependencies flagged with security vulnerabilities by Dependabot, while keeping the explicit `@minecraft/*` beta overrides unmodified. The `package-lock.json` lockfile has been successfully preserved and updated to track these changes without causing ERESOLVE conflicts.

---
*PR created automatically by Jules for task [12215038566097671340](https://jules.google.com/task/12215038566097671340) started by @SjnExe*