### PR TITLE
Update Node engine requirement to >=24.0.0 and tsconfig resolution to NodeNext

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,5 +102,8 @@
         "typescript": "latest",
         "typescript-eslint": "latest",
         "vitest": "latest"
+    },
+    "engines": {
+        "node": ">=24.0.0"
     }
 }

--- a/src/core/__tests__/Economy.test.ts
+++ b/src/core/__tests__/Economy.test.ts
@@ -3,7 +3,7 @@ import { vi } from 'vitest';
 
 // Create mock functions outside
 // eslint-disable-next-line
-const { mockStorageLoad, mockStorageSave, mockLoadPlayerData, mockGetPlayer, mockIncrementPlayerBalance } = vi.hoisted(() => ({
+const { mockStorageLoad, mockStorageSave } = vi.hoisted(() => ({
     mockStorageLoad: vi.fn(),
     mockStorageSave: vi.fn(),
     mockLoadPlayerData: vi.fn(),

--- a/src/core/__tests__/PunishmentManager.test.ts
+++ b/src/core/__tests__/PunishmentManager.test.ts
@@ -77,7 +77,7 @@ describe('PunishmentManager', () => {
         // StorageManager(key) -> load() -> getDynamicProperty(key).
         // It returns parsed JSON.
 
-        (mc.world.getDynamicProperty as any).mockImplementation((key) => {
+        (mc.world.getDynamicProperty as any).mockImplementation((key: string) => {
             if (key === 'exe:punishments') {
                 return JSON.stringify(legacyData);
             }

--- a/src/features/anticheat/__tests__/MovementCheck.test.ts
+++ b/src/features/anticheat/__tests__/MovementCheck.test.ts
@@ -32,8 +32,8 @@ describe('MovementCheck', () => {
         initializePlayerCache();
 
         // Capture interval callback
-        (mc.system.runInterval as any).mockImplementation((cb) => {
-            intervalCallback = cb as () => void;
+        (mc.system.runInterval as any).mockImplementation((cb: () => void) => {
+            intervalCallback = cb;
             return 1;
         });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
     "compilerOptions": {
         "target": "ES2023",
-        "module": "Node16",
-        "moduleResolution": "Node16",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
         "strict": true,
         "noUncheckedIndexedAccess": true,
         "noImplicitReturns": true,


### PR DESCRIPTION
Updates Node engine requirement to LTS 24 and migrates the TypeScript build to use NodeNext resolution. Fixes resulting type issues.

---
*PR created automatically by Jules for task [9071637979968805031](https://jules.google.com/task/9071637979968805031) started by @SjnExe*