### PR TITLE
Optimize workflow jobs to run build in parallel with checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,6 @@ jobs:
             - run: npm run validate
 
     build:
-        needs: [lint, format, typecheck, test, validate]
         runs-on: ubuntu-latest
         timeout-minutes: 30
         steps:
@@ -196,7 +195,7 @@ jobs:
                   retention-days: 7
 
     release:
-        needs: [build]
+        needs: [build, lint, format, typecheck, test, validate]
         runs-on: ubuntu-latest
         timeout-minutes: 10
         permissions:


### PR DESCRIPTION
Updates the `.github/workflows/build.yml` file to optimize the pipeline:
1.  The `build` job now runs concurrently with other jobs such as `test`, `lint`, and `validate` by removing its `needs` attribute.
2.  The `release` job was updated to depend on all parallel checks so that a release only occurs after code quality measures successfully pass.

---
*PR created automatically by Jules for task [13282318113888374884](https://jules.google.com/task/13282318113888374884) started by @SjnExe*