### PR TITLE
Refactor core imports to use absolute aliases

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -26,7 +26,7 @@ _Goal: Set up the types folder and configuration._
 
 _Goal: Enforce absolute aliases within the core directory._
 
-- [ ] **Enforce Absolute Aliases in `src/core/`:** Scan the `src/core/` directory and replace all relative imports with absolute aliases defined in `tsconfig.json`.
+- [x] **Enforce Absolute Aliases in `src/core/`:** Scan the `src/core/` directory and replace all relative imports with absolute aliases defined in `tsconfig.json`.
 
 ---
 
@@ -95,6 +95,6 @@ _Goal: Point all tools to the new `build/` directory and verify the entire syste
 
 _(Update this section whenever you perform a handover to keep track of state and any important discoveries)_
 
-- **Current Status:** Session 1a completed. Created shared types folder and updated tsconfig.json.
-- **Completed Sessions:** Session 1a.
-- **Next Steps:** Begin Session 1b (Core Absolute Aliases Refactoring).
+- **Current Status:** Session 1b completed. All absolute aliases in `src/core/` were converted and tests passed (after leaving `src/core/ui/panels/index.ts` with local imports to avoid circular dependencies that crash Vite tests).
+- **Completed Sessions:** Session 1a, Session 1b.
+- **Next Steps:** Begin Session 1c (Features Absolute Aliases Refactoring).

--- a/src/core/__tests__/BountyManager.test.ts
+++ b/src/core/__tests__/BountyManager.test.ts
@@ -28,7 +28,7 @@ vi.mock('../logger.js', () => ({
     errorLog: vi.fn()
 }));
 
-const { placeBounty, getBounty } = await import('../bountyManager.js');
+const { placeBounty, getBounty } = await import('@core/bountyManager.js');
 
 describe('BountyManager', () => {
     beforeEach(() => {

--- a/src/core/__tests__/CommandManager.test.ts
+++ b/src/core/__tests__/CommandManager.test.ts
@@ -28,7 +28,7 @@ vi.mock('../logger.js', () => ({
     infoLog: vi.fn()
 }));
 
-const { commandManager } = await import('../commands/commandManager.js');
+const { commandManager } = await import('@commands/commandManager.js');
 
 describe('CommandManager', () => {
     // Explicitly cast to unknown then Player to avoid type mismatches if strict compliance is enforced,

--- a/src/core/__tests__/ConfigManager.test.ts
+++ b/src/core/__tests__/ConfigManager.test.ts
@@ -33,7 +33,7 @@ vi.mock('../configurations.js', () => ({
     configResetCallbacks: {}
 }));
 
-const { initializeConfigManager, getConfig, updateConfig, onConfigUpdated } = await import('../configManager.js');
+const { initializeConfigManager, getConfig, updateConfig, onConfigUpdated } = await import('@core/configManager.js');
 
 describe('ConfigManager', () => {
     beforeEach(() => {

--- a/src/core/__tests__/Economy.test.ts
+++ b/src/core/__tests__/Economy.test.ts
@@ -61,7 +61,7 @@ vi.mock('../storage/StorageManager.js', () => ({
 }));
 
 // Import module under test
-const { cleanupPlayerDataManager, createPendingPayment, getBalance, getOrCreatePlayer, getPendingPayment, incrementPlayerBalance, transfer } = await import('../playerDataManager.js');
+const { cleanupPlayerDataManager, createPendingPayment, getBalance, getOrCreatePlayer, getPendingPayment, incrementPlayerBalance, transfer } = await import('@core/playerDataManager.js');
 
 // Helper to mock a player
 const mockPlayer = (id: string, name: string) =>

--- a/src/core/__tests__/PunishmentManager.test.ts
+++ b/src/core/__tests__/PunishmentManager.test.ts
@@ -1,6 +1,6 @@
+import { addPunishment, getPunishment, loadPunishments, removePunishment } from '@features/moderation/punishmentManager.js';
 import * as mc from '@minecraft/server';
 import { vi } from 'vitest';
-import { addPunishment, getPunishment, loadPunishments, removePunishment } from '../../features/moderation/punishmentManager.js';
 
 // Mock dependencies
 vi.mock('../configManager.js', () => ({

--- a/src/core/__tests__/UI-Actions.test.ts
+++ b/src/core/__tests__/UI-Actions.test.ts
@@ -1,6 +1,6 @@
+import { uiActionFunctions } from '@ui/actionRegistry.js';
+import { panelDefinitions } from '@ui/panelRegistry.js';
 import { vi } from 'vitest';
-import { uiActionFunctions } from '../ui/actionRegistry.js';
-import { panelDefinitions } from '../ui/panelRegistry.js';
 
 vi.mock('../configManager.js', () => ({
     getConfig: vi.fn().mockReturnValue({}),

--- a/src/core/__tests__/UI-Duplicates.test.ts
+++ b/src/core/__tests__/UI-Duplicates.test.ts
@@ -1,4 +1,4 @@
-import { panelDefinitions } from '../ui/panelRegistry.js';
+import { panelDefinitions } from '@ui/panelRegistry.js';
 
 describe('UI Duplicates Integrity', () => {
     it('should not have duplicate button IDs within the same panel', () => {

--- a/src/core/__tests__/UI-DynamicPanels.test.ts
+++ b/src/core/__tests__/UI-DynamicPanels.test.ts
@@ -1,7 +1,7 @@
 import * as mc from '@minecraft/server';
+import { UIContext } from '@ui/panelRegistry.js';
+import { PlayerPanelHandler } from '@ui/panels/playerPanel.js';
 import { vi } from 'vitest';
-import { UIContext } from '../ui/panelRegistry.js';
-import { PlayerPanelHandler } from '../ui/panels/playerPanel.js';
 
 vi.mock('../configManager.js', () => ({
     getConfig: vi.fn().mockReturnValue({})

--- a/src/core/__tests__/UI-Handlers.test.ts
+++ b/src/core/__tests__/UI-Handlers.test.ts
@@ -1,7 +1,7 @@
 import * as mc from '@minecraft/server';
+import { UIContext } from '@ui/panelRegistry.js';
+import { PlayerPanelHandler } from '@ui/panels/playerPanel.js';
 import { vi } from 'vitest';
-import { UIContext } from '../ui/panelRegistry.js';
-import { PlayerPanelHandler } from '../ui/panels/playerPanel.js';
 
 vi.mock('../configManager.js', () => ({
     getConfig: vi.fn().mockReturnValue({})

--- a/src/core/__tests__/UI-Permissions.test.ts
+++ b/src/core/__tests__/UI-Permissions.test.ts
@@ -1,4 +1,4 @@
-import { panelDefinitions } from '../ui/panelRegistry.js';
+import { panelDefinitions } from '@ui/panelRegistry.js';
 
 describe('UI Permissions Integrity', () => {
     it('should have appropriate permission levels for potentially destructive or admin actions', () => {

--- a/src/core/__tests__/UI.test.ts
+++ b/src/core/__tests__/UI.test.ts
@@ -1,6 +1,6 @@
+import { panelDefinitions } from '@ui/panelRegistry.js';
+import { panelRouter } from '@ui/PanelRouter.js';
 import { vi } from 'vitest';
-import { panelDefinitions } from '../ui/panelRegistry.js';
-import { panelRouter } from '../ui/PanelRouter.js';
 
 // Mock Config
 vi.mock('../configManager.js', () => ({
@@ -25,7 +25,7 @@ vi.mock('../bountyManager.js', () => ({
 }));
 
 // Import panels (trigger registration)
-const { initialize } = await import('../ui/panels/index.js');
+const { initialize } = await import('@ui/panels/index.js');
 initialize();
 
 describe('UI Integrity Check', () => {

--- a/src/core/bountyManager.ts
+++ b/src/core/bountyManager.ts
@@ -3,9 +3,9 @@
  * @module bountyManager
  */
 
-import { debugLog, errorLog } from './logger.js';
-import * as playerDataManager from './playerDataManager.js';
-import { StorageManager } from './storage/StorageManager.js';
+import { debugLog, errorLog } from '@core/logger.js';
+import * as playerDataManager from '@core/playerDataManager.js';
+import { StorageManager } from '@core/storage/StorageManager.js';
 
 const bountyDataKey = 'exe:bountyData';
 const storage = new StorageManager(bountyDataKey);

--- a/src/core/configLoader.ts
+++ b/src/core/configLoader.ts
@@ -1,4 +1,4 @@
-import { errorLog } from './logger.js';
+import { errorLog } from '@core/logger.js';
 
 /**
  * Dynamically loads a configuration module.

--- a/src/core/configManager.ts
+++ b/src/core/configManager.ts
@@ -1,11 +1,11 @@
 import * as mc from '@minecraft/server';
 
+import { loadConfig as asyncLoadConfig } from '@core/configLoader.js';
+import createConfigManager, { ConfigManager } from '@core/configManagerFactory.js';
+import { deepClone } from '@core/objectUtils.js';
 import { isDefined } from '@lib/guards.js';
-import { loadConfig as asyncLoadConfig } from './configLoader.js';
-import createConfigManager, { ConfigManager } from './configManagerFactory.js';
-import { deepClone } from './objectUtils.js';
 
-import type { config as Config } from '../config.default.js';
+import type { config as Config } from '@core/../config.default.js';
 
 let mainConfigManager: ConfigManager<typeof Config>;
 const updateCallbacks: ((config: typeof Config) => void)[] = [];
@@ -56,7 +56,7 @@ export const updateMultipleConfig = (updates: Record<string, unknown>) => {
 };
 
 export async function resetConfigSection(sectionKey: string, player?: mc.Player): Promise<{ success: boolean; message: string }> {
-    const { configResetRegistry, configResetCallbacks } = await import('./configurations.js');
+    const { configResetRegistry, configResetCallbacks } = await import('@core/configurations.js');
 
     if (sectionKey === 'all') {
         const resetPromises = [mainConfigManager.reset()];
@@ -114,4 +114,4 @@ export async function resetConfigSection(sectionKey: string, player?: mc.Player)
     }
 }
 
-export { type config as Config } from '../config.default.js';
+export { type config as Config } from '@core/../config.default.js';

--- a/src/core/configManagerFactory.ts
+++ b/src/core/configManagerFactory.ts
@@ -1,7 +1,7 @@
+import { debugLog, errorLog } from '@core/logger.js';
+import { deepClone, deepMerge, mergeObjectMaps, mergeRanks, reconcileConfig, setValueByPath } from '@core/objectUtils.js';
+import { StorageManager } from '@core/storage/StorageManager.js';
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
-import { debugLog, errorLog } from './logger.js';
-import { deepClone, deepMerge, mergeObjectMaps, mergeRanks, reconcileConfig, setValueByPath } from './objectUtils.js';
-import { StorageManager } from './storage/StorageManager.js';
 
 /**
  * Creates a configuration manager for a specific configuration type.

--- a/src/core/configurations.ts
+++ b/src/core/configurations.ts
@@ -3,24 +3,24 @@ import * as mc from '@minecraft/server';
 import { restartAnnouncer } from '@features/essentials/commands/announcement.js';
 import { initializeSpawnProtection } from '@features/essentials/spawnProtection.js';
 
-import { loadConfig as asyncLoadConfig } from './configLoader.js';
-import { getConfig } from './configManager.js';
-import createConfigManager, { ConfigManager } from './configManagerFactory.js';
-import { setLockState } from './playerDataManager.js';
-import { reloadRanks } from './rankManager.js';
+import { loadConfig as asyncLoadConfig } from '@core/configLoader.js';
+import { getConfig } from '@core/configManager.js';
+import createConfigManager, { ConfigManager } from '@core/configManagerFactory.js';
+import { setLockState } from '@core/playerDataManager.js';
+import { reloadRanks } from '@core/rankManager.js';
 
+import type ranksConfig from '@core/ranksConfig.default.js';
+import type { config as sidebarConfig } from '@core/sidebarConfig.default.js';
+import type { spawnConfig } from '@core/spawnConfig.default.js';
+import type { xrayConfig } from '@core/xrayConfig.default.js';
 import type { auctionHouseConfig } from '@features/auctionHouse/auctionHouseConfig.default.js';
 import type { dailyRewardsConfig } from '@features/dailyRewards/dailyRewardsConfig.default.js';
 import type { economyConfig } from '@features/economy/economyConfig.js';
 import type { WorldProtectionConfig } from '@features/essentials/worldProtectionConfig.default.js';
+import type { kitsConfig } from '@features/kits/kitsConfig.default.js';
 import type { shopConfig } from '@features/shop/shopConfig.js';
 import type { friendConfig } from '@features/social/friendConfig.js';
 import type { teamConfig } from '@features/teams/teamConfig.js';
-import type { kitsConfig } from '../features/kits/kitsConfig.default.js';
-import type ranksConfig from './ranksConfig.default.js';
-import type { config as sidebarConfig } from './sidebarConfig.default.js';
-import type { spawnConfig } from './spawnConfig.default.js';
-import type { xrayConfig } from './xrayConfig.default.js';
 
 export type KitsConfig = typeof kitsConfig;
 export type ShopConfig = typeof shopConfig;

--- a/src/core/cooldownManager.ts
+++ b/src/core/cooldownManager.ts
@@ -1,8 +1,8 @@
 import * as mc from '@minecraft/server';
 
+import { getConfig } from '@core/configManager.js';
+import { debugLog, errorLog } from '@core/logger.js';
 import { isDefined, isNumber } from '@lib/guards.js';
-import { getConfig } from './configManager.js';
-import { debugLog, errorLog } from './logger.js';
 
 const cooldownDbKey = 'exe:cooldowns';
 const saveIntervalTicks = 6000; // Every 5 minutes

--- a/src/core/dataManager.ts
+++ b/src/core/dataManager.ts
@@ -1,11 +1,11 @@
 import * as mc from '@minecraft/server';
 
+import { getConfig } from '@core/configManager.js';
+import { initializeLeaderboard } from '@core/leaderboardManager.js';
+import { debugLog, infoLog } from '@core/logger.js';
+import { getAllPlayerData, isNameIdMapDirty, loadNameIdMap, saveNameIdMap, savePlayerData } from '@core/playerDataManager.js';
+import { clearTrackedInterval, setTrackedInterval } from '@core/timerManager.js';
 import { isDefined } from '@lib/guards.js';
-import { getConfig } from './configManager.js';
-import { initializeLeaderboard } from './leaderboardManager.js';
-import { debugLog, infoLog } from './logger.js';
-import { getAllPlayerData, isNameIdMapDirty, loadNameIdMap, saveNameIdMap, savePlayerData } from './playerDataManager.js';
-import { clearTrackedInterval, setTrackedInterval } from './timerManager.js';
 
 let autoSaveIntervalId: number | undefined;
 

--- a/src/core/events/entityDie.ts
+++ b/src/core/events/entityDie.ts
@@ -1,15 +1,15 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import * as mc from '@minecraft/server';
 
+import * as bountyManager from '@core/bountyManager.js';
+import { getConfig } from '@core/configManager.js';
+import * as lastHitManager from '@core/lastHitManager.js';
+import { debugLog, errorLog } from '@core/logger.js';
+import * as playerCache from '@core/playerCache.js';
+import { getOrCreatePlayer, incrementPlayerBalance, setPlayerLastDeathLocation } from '@core/playerDataManager.js';
 import * as teamManager from '@features/teams/teamManager.js';
 import { saveLastLocation } from '@features/teleportation/teleportUtils.js';
 import { isDefined } from '@lib/guards.js';
-import * as bountyManager from '../bountyManager.js';
-import { getConfig } from '../configManager.js';
-import * as lastHitManager from '../lastHitManager.js';
-import { debugLog, errorLog } from '../logger.js';
-import * as playerCache from '../playerCache.js';
-import { getOrCreatePlayer, incrementPlayerBalance, setPlayerLastDeathLocation } from '../playerDataManager.js';
 
 export const eventName = 'entityDie';
 

--- a/src/core/events/entityHurt.ts
+++ b/src/core/events/entityHurt.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import * as mc from '@minecraft/server';
 
-import * as lastHitManager from '../lastHitManager.js';
+import * as lastHitManager from '@core/lastHitManager.js';
 
 export const eventName = 'entityHurt';
 

--- a/src/core/events/eventManager.ts
+++ b/src/core/events/eventManager.ts
@@ -1,14 +1,14 @@
 import * as mc from '@minecraft/server';
 
-import { errorLog } from '../logger.js';
+import { errorLog } from '@core/logger.js';
 
-import handleBeforeChatSend from './beforeChatSend.js';
-import handleEntityDie from './entityDie.js';
-import handleEntityHurt from './entityHurt.js';
-import handleItemUse from './itemUse.js';
-import handlePlayerDimensionChange from './playerDimensionChange.js';
-import handlePlayerLeave from './playerLeave.js';
-import { handlePlayerSpawn } from './playerSpawn.js';
+import handleBeforeChatSend from '@core/events/beforeChatSend.js';
+import handleEntityDie from '@core/events/entityDie.js';
+import handleEntityHurt from '@core/events/entityHurt.js';
+import handleItemUse from '@core/events/itemUse.js';
+import handlePlayerDimensionChange from '@core/events/playerDimensionChange.js';
+import handlePlayerLeave from '@core/events/playerLeave.js';
+import { handlePlayerSpawn } from '@core/events/playerSpawn.js';
 import {
     handleBeforeEntityHurt,
     handleBeforeEntitySpawn,
@@ -19,8 +19,8 @@ import {
     handleBeforePlayerPlaceBlock,
     handlePlayerInteractWithBlock,
     handlePlayerInteractWithEntity
-} from './protectionEvents.js';
-import { handleScriptEventReceive } from './scriptEventReceive.js';
+} from '@core/events/protectionEvents.js';
+import { handleScriptEventReceive } from '@core/events/scriptEventReceive.js';
 
 const cleanupActions: (() => void)[] = [];
 

--- a/src/core/events/itemUse.ts
+++ b/src/core/events/itemUse.ts
@@ -1,7 +1,7 @@
 import * as mc from '@minecraft/server';
 
-import * as playerDataManager from '../playerDataManager.js';
-import { showPanel } from '../uiManager.js';
+import * as playerDataManager from '@core/playerDataManager.js';
+import { showPanel } from '@ui/../uiManager.js';
 
 export const eventName = 'itemUse';
 

--- a/src/core/events/playerDimensionChange.ts
+++ b/src/core/events/playerDimensionChange.ts
@@ -1,9 +1,9 @@
 import * as mc from '@minecraft/server';
 
-import { getConfig } from '../configManager.js';
-import { debugLog, errorLog } from '../logger.js';
-import * as playerDataManager from '../playerDataManager.js';
-import { getLockState } from '../playerDataManager.js';
+import { getConfig } from '@core/configManager.js';
+import { debugLog, errorLog } from '@core/logger.js';
+import * as playerDataManager from '@core/playerDataManager.js';
+import { getLockState } from '@core/playerDataManager.js';
 
 export const eventName = 'playerDimensionChange';
 

--- a/src/core/events/playerLeave.ts
+++ b/src/core/events/playerLeave.ts
@@ -1,11 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import * as mc from '@minecraft/server';
 
-import { getConfig } from '../configManager.js';
-import { debugLog } from '../logger.js';
-import * as playerCache from '../playerCache.js';
-import * as playerDataManager from '../playerDataManager.js';
-import { formatString } from '../utils.js';
+import { getConfig } from '@core/configManager.js';
+import { debugLog } from '@core/logger.js';
+import * as playerCache from '@core/playerCache.js';
+import * as playerDataManager from '@core/playerDataManager.js';
+import { formatString } from '@core/utils.js';
 
 export const eventName = 'playerLeave';
 

--- a/src/core/events/playerSpawn.ts
+++ b/src/core/events/playerSpawn.ts
@@ -1,15 +1,15 @@
 import * as mc from '@minecraft/server';
 
+import { getConfig } from '@core/configManager.js';
+import { getKitsConfig } from '@core/configurations.js';
+import { frozenTag, vanishedTag } from '@core/constants.js';
+import { getKit, giveKitItems } from '@core/kitsManager.js';
+import { debugLog, infoLog } from '@core/logger.js';
+import { sendMessage } from '@core/messaging.js';
+import { getOrCreatePlayer, updatePlayerData } from '@core/playerDataManager.js';
+import { getPlayerRank, updatePlayerNameTag } from '@core/rankManager.js';
+import { formatLocation, formatString } from '@core/utils.js';
 import { checkAndKickBannedPlayer } from '@features/moderation/punishmentManager.js';
-import { getConfig } from '../configManager.js';
-import { getKitsConfig } from '../configurations.js';
-import { frozenTag, vanishedTag } from '../constants.js';
-import { getKit, giveKitItems } from '../kitsManager.js';
-import { debugLog, infoLog } from '../logger.js';
-import { sendMessage } from '../messaging.js';
-import { getOrCreatePlayer, updatePlayerData } from '../playerDataManager.js';
-import { getPlayerRank, updatePlayerNameTag } from '../rankManager.js';
-import { formatLocation, formatString } from '../utils.js';
 
 export function handlePlayerJoin(player: mc.Player) {
     const pData = getOrCreatePlayer(player);

--- a/src/core/events/scriptEventReceive.ts
+++ b/src/core/events/scriptEventReceive.ts
@@ -2,12 +2,12 @@ import * as mc from '@minecraft/server';
 
 import { CommandExecutor } from '@commands/commandManager.js';
 
+import { getConfig, updateConfig } from '@core/configManager.js';
+import { errorLog, infoLog, warnLog } from '@core/logger.js';
+import { updateAllPlayerRanks } from '@core/main.js';
+import * as rankManager from '@core/rankManager.js';
+import { startRestart } from '@core/restartManager.js';
 import { isNonEmptyString } from '@lib/guards.js';
-import { getConfig, updateConfig } from '../configManager.js';
-import { errorLog, infoLog, warnLog } from '../logger.js';
-import { updateAllPlayerRanks } from '../main.js';
-import * as rankManager from '../rankManager.js';
-import { startRestart } from '../restartManager.js';
 
 export function handleScriptEventReceive(event: mc.ScriptEventCommandMessageAfterEvent) {
     const { id, sourceEntity } = event;

--- a/src/core/featureDependencies.ts
+++ b/src/core/featureDependencies.ts
@@ -1,6 +1,6 @@
+import { getConfig, onConfigUpdated, updateConfig } from '@core/configManager.js';
+import { debugLog } from '@core/logger.js';
 import { isDefined } from '@lib/guards.js';
-import { getConfig, onConfigUpdated, updateConfig } from './configManager.js';
-import { debugLog } from './logger.js';
 
 function checkDependencies(config: unknown) {
     // Define dependencies: Feature -> Dependency

--- a/src/core/floatingTextManager.ts
+++ b/src/core/floatingTextManager.ts
@@ -1,9 +1,9 @@
 import * as mc from '@minecraft/server';
 
+import { debugLog, errorLog } from '@core/logger.js';
+import { isDeepEqual } from '@core/objectUtils.js';
+import * as sidebarManager from '@core/sidebarManager.js';
 import { isDefined, isNonEmptyString, isNumber } from '@lib/guards.js';
-import { debugLog, errorLog } from './logger.js';
-import { isDeepEqual } from './objectUtils.js';
-import * as sidebarManager from './sidebarManager.js';
 
 // Workaround for strange TS Boolean type inference on resolveGlobalPlaceholders
 const sm = sidebarManager as { resolveGlobalPlaceholders: (t: string) => string };

--- a/src/core/helpfulLinksManager.ts
+++ b/src/core/helpfulLinksManager.ts
@@ -1,6 +1,6 @@
+import { getConfig, updateMultipleConfig } from '@core/configManager.js';
+import { debugLog } from '@core/logger.js';
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
-import { getConfig, updateMultipleConfig } from './configManager.js';
-import { debugLog } from './logger.js';
 
 export interface HelpfulLink {
     title: string;

--- a/src/core/itemSerializer.ts
+++ b/src/core/itemSerializer.ts
@@ -1,7 +1,7 @@
 import * as mc from '@minecraft/server';
 
+import { errorLog } from '@core/logger.js';
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
-import { errorLog } from './logger.js';
 
 export interface SerializedEnchantment {
     id: string;

--- a/src/core/kitAdminManager.ts
+++ b/src/core/kitAdminManager.ts
@@ -1,6 +1,6 @@
-import { getKitsConfig, saveKitsConfig } from './configurations.js';
-import { ItemInfo } from './kitItemsManager.js';
-import { debugLog } from './logger.js';
+import { getKitsConfig, saveKitsConfig } from '@core/configurations.js';
+import { ItemInfo } from '@core/kitItemsManager.js';
+import { debugLog } from '@core/logger.js';
 
 export interface Kit {
     enabled: boolean;

--- a/src/core/kitItemsManager.ts
+++ b/src/core/kitItemsManager.ts
@@ -1,9 +1,9 @@
 import * as mc from '@minecraft/server';
 
+import { getKitsConfig, saveKitsConfig } from '@core/configurations.js';
+import { Kit } from '@core/kitAdminManager.js';
+import { debugLog, errorLog } from '@core/logger.js';
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
-import { getKitsConfig, saveKitsConfig } from './configurations.js';
-import { Kit } from './kitAdminManager.js';
-import { debugLog, errorLog } from './logger.js';
 
 const MAX_KIT_SLOTS = 36;
 

--- a/src/core/kitsManager.ts
+++ b/src/core/kitsManager.ts
@@ -1,13 +1,13 @@
 import * as mc from '@minecraft/server';
 
+import { getConfig } from '@core/configManager.js';
+import { getKitsConfig } from '@core/configurations.js';
+import { Kit } from '@core/kitAdminManager.js';
+import { ItemInfo } from '@core/kitItemsManager.js';
+import { errorLog } from '@core/logger.js';
+import { getOrCreatePlayer, incrementPlayerBalance, savePlayerData, setKitCooldown } from '@core/playerDataManager.js';
+import { formatCooldown } from '@core/utils.js';
 import { isDefined, isNonEmptyString, isNumber } from '@lib/guards.js';
-import { getConfig } from './configManager.js';
-import { getKitsConfig } from './configurations.js';
-import { Kit } from './kitAdminManager.js';
-import { ItemInfo } from './kitItemsManager.js';
-import { errorLog } from './logger.js';
-import { getOrCreatePlayer, incrementPlayerBalance, savePlayerData, setKitCooldown } from './playerDataManager.js';
-import { formatCooldown } from './utils.js';
 
 interface KitInfo {
     name: string;

--- a/src/core/leaderboardManager.ts
+++ b/src/core/leaderboardManager.ts
@@ -1,9 +1,9 @@
 import * as mc from '@minecraft/server';
 
+import { getConfig } from '@core/configManager.js';
+import { debugLog, errorLog } from '@core/logger.js';
+import { clearTrackedInterval, setTrackedInterval } from '@core/timerManager.js';
 import { isDefined, isNonEmptyString, isNumber } from '@lib/guards.js';
-import { getConfig } from './configManager.js';
-import { debugLog, errorLog } from './logger.js';
-import { clearTrackedInterval, setTrackedInterval } from './timerManager.js';
 
 const leaderboardKey = 'exe:economyLeaderboard';
 

--- a/src/core/main.ts
+++ b/src/core/main.ts
@@ -1,11 +1,7 @@
 import * as mc from '@minecraft/server';
 
 import { loadCommands } from '@core/commands/index.js';
-import { initializeXrayDetection } from '@features/anticheat/xrayDetection.js';
-import { restartAnnouncer } from '@features/essentials/commands/announcement.js';
-import { cleanupSpawnProtection, initializeSpawnProtection } from '@features/essentials/spawnProtection.js';
-import { isNonEmptyString } from '@lib/guards.js';
-import { getConfig, initializeConfigManager } from './configManager.js';
+import { getConfig, initializeConfigManager } from '@core/configManager.js';
 import {
     loadAuctionHouseConfig,
     loadDailyRewardsConfig,
@@ -18,20 +14,24 @@ import {
     loadTeamConfig,
     loadWorldProtectionConfig,
     loadXrayConfig
-} from './configurations.js';
-import { dataManager, loadPersistentData } from './dataManager.js';
-import { cleanupEventManager, initializeEventManager } from './events/eventManager.js';
-import { initializeFeatureDependencies } from './featureDependencies.js';
-import { cleanup as cleanupFloatingText } from './floatingTextManager.js';
-import { cleanupLeaderboardManager } from './leaderboardManager.js';
-import { errorLog, infoLog, setLogLevel } from './logger.js';
-import { initializeMigration } from './migrationManager.js';
-import { cleanupPlayerDataManager } from './playerDataManager.js';
-import * as rankManager from './rankManager.js';
-import * as sidebarManager from './sidebarManager.js';
-import { cleanupTimers, startSystemTimers } from './timerManager.js';
-import { initialize as initializeUIPanels } from './ui/panels/index.js';
-import { reinitializeOnlinePlayers } from './utils.js';
+} from '@core/configurations.js';
+import { dataManager, loadPersistentData } from '@core/dataManager.js';
+import { cleanupEventManager, initializeEventManager } from '@core/events/eventManager.js';
+import { initializeFeatureDependencies } from '@core/featureDependencies.js';
+import { cleanup as cleanupFloatingText } from '@core/floatingTextManager.js';
+import { cleanupLeaderboardManager } from '@core/leaderboardManager.js';
+import { errorLog, infoLog, setLogLevel } from '@core/logger.js';
+import { initializeMigration } from '@core/migrationManager.js';
+import { cleanupPlayerDataManager } from '@core/playerDataManager.js';
+import * as rankManager from '@core/rankManager.js';
+import * as sidebarManager from '@core/sidebarManager.js';
+import { cleanupTimers, startSystemTimers } from '@core/timerManager.js';
+import { reinitializeOnlinePlayers } from '@core/utils.js';
+import { initializeXrayDetection } from '@features/anticheat/xrayDetection.js';
+import { restartAnnouncer } from '@features/essentials/commands/announcement.js';
+import { cleanupSpawnProtection, initializeSpawnProtection } from '@features/essentials/spawnProtection.js';
+import { isNonEmptyString } from '@lib/guards.js';
+import { initialize as initializeUIPanels } from '@ui/panels/index.js';
 
 const VERSION = '0.7.0'; // Current Addon Version
 
@@ -83,7 +83,7 @@ export async function initializeAddon() {
 
     initializeMigration();
 
-    const { initializePlayerCache } = await import('./playerCache.js');
+    const { initializePlayerCache } = await import('@core/playerCache.js');
     initializePlayerCache();
 
     initializeFeatureDependencies();

--- a/src/core/messaging.ts
+++ b/src/core/messaging.ts
@@ -1,7 +1,7 @@
 import * as mc from '@minecraft/server';
 
+import { warnLog } from '@core/logger.js';
 import { isDefined } from '@lib/guards.js';
-import { warnLog } from './logger.js';
 
 /**
  * Sends a consistently formatted message to a player or the entire world.

--- a/src/core/migrationManager.ts
+++ b/src/core/migrationManager.ts
@@ -1,7 +1,7 @@
 import * as mc from '@minecraft/server';
 
+import { debugLog, errorLog, infoLog } from '@core/logger.js';
 import { isNonEmptyString } from '@lib/guards.js';
-import { debugLog, errorLog, infoLog } from './logger.js';
 
 /**
  * The current data version of the addon.

--- a/src/core/mobDeathEvents.ts
+++ b/src/core/mobDeathEvents.ts
@@ -4,15 +4,15 @@ import * as mc from '@minecraft/server';
 import { getTeamByPlayer } from '@features/teams/teamManager.js';
 import { isNumber } from '@lib/guards.js';
 
+import { getConfig } from '@core/configManager.js';
+import { getEconomyConfig } from '@core/configurations.js';
+import * as lastHitManager from '@core/lastHitManager.js';
+import { infoLog } from '@core/logger.js';
+import { getPlayerFromCache } from '@core/playerCache.js';
+import { getPlayer, incrementDeathCount, incrementKillCount, incrementKillStreak, incrementPlayerBalance, resetKillStreak } from '@core/playerDataManager.js';
+import { handlePvPDeath } from '@core/pvpManager.js';
+import { formatCurrency } from '@core/utils.js';
 import { saveLastLocation } from '@features/teleportation/teleportUtils.js';
-import { getConfig } from './configManager.js';
-import { getEconomyConfig } from './configurations.js';
-import * as lastHitManager from './lastHitManager.js';
-import { infoLog } from './logger.js';
-import { getPlayerFromCache } from './playerCache.js';
-import { getPlayer, incrementDeathCount, incrementKillCount, incrementKillStreak, incrementPlayerBalance, resetKillStreak } from './playerDataManager.js';
-import { handlePvPDeath } from './pvpManager.js';
-import { formatCurrency } from './utils.js';
 
 mc.world.afterEvents.entityDie.subscribe((event: mc.EntityDieAfterEvent) => {
     const { deadEntity, damageSource } = event;

--- a/src/core/playerDataManager.ts
+++ b/src/core/playerDataManager.ts
@@ -1,15 +1,15 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import * as mc from '@minecraft/server';
 
+import { getConfig } from '@core/configManager.js';
+import { getEconomyConfig } from '@core/configurations.js';
+import { SerializedItem } from '@core/itemSerializer.js';
+import { updateAndSaveLeaderboard } from '@core/leaderboardManager.js';
+import { debugLog, errorLog, infoLog } from '@core/logger.js';
+import { getAllPlayersFromCache, getPlayerFromCache } from '@core/playerCache.js';
+import { StorageManager } from '@core/storage/StorageManager.js';
+import { formatCurrency } from '@core/utils/economy.js';
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
-import { getConfig } from './configManager.js';
-import { getEconomyConfig } from './configurations.js';
-import { SerializedItem } from './itemSerializer.js';
-import { updateAndSaveLeaderboard } from './leaderboardManager.js';
-import { debugLog, errorLog, infoLog } from './logger.js';
-import { getAllPlayersFromCache, getPlayerFromCache } from './playerCache.js';
-import { StorageManager } from './storage/StorageManager.js';
-import { formatCurrency } from './utils/economy.js';
 
 const playerPropertyPrefix = 'exe:player.';
 // Legacy keys (kept for migration)

--- a/src/core/protectionService.ts
+++ b/src/core/protectionService.ts
@@ -1,5 +1,5 @@
+import { getSpawnConfig, getWorldProtectionConfig } from '@core/configurations.js';
 import type { Vector3 } from '@minecraft/server';
-import { getSpawnConfig, getWorldProtectionConfig } from './configurations.js';
 
 export type ProtectionFlags = {
     preventPvP: boolean;

--- a/src/core/pvpManager.ts
+++ b/src/core/pvpManager.ts
@@ -1,10 +1,10 @@
 import * as mc from '@minecraft/server';
 
-import { getEconomyConfig } from './configurations.js';
-import { sendMessage } from './messaging.js';
-import { getPlayerFromCache } from './playerCache.js';
-import { getPlayer, incrementPlayerBalance } from './playerDataManager.js';
-import { formatCurrency } from './utils.js';
+import { getEconomyConfig } from '@core/configurations.js';
+import { sendMessage } from '@core/messaging.js';
+import { getPlayerFromCache } from '@core/playerCache.js';
+import { getPlayer, incrementPlayerBalance } from '@core/playerDataManager.js';
+import { formatCurrency } from '@core/utils.js';
 
 // --- Interfaces --- //
 

--- a/src/core/rankDb.ts
+++ b/src/core/rankDb.ts
@@ -1,6 +1,6 @@
+import { getRanksConfig, saveRanksConfig } from '@core/configurations.js';
+import { RankDefinition } from '@core/ranksConfig.default.js';
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
-import { getRanksConfig, saveRanksConfig } from './configurations.js';
-import { RankDefinition } from './ranksConfig.default.js';
 
 /**
  * Gets all ranks from the config.

--- a/src/core/rankManager.ts
+++ b/src/core/rankManager.ts
@@ -1,11 +1,11 @@
 import * as mc from '@minecraft/server';
 
-import { config as Config } from '../config.default.js';
+import { config as Config } from '@core/../config.default.js';
 
+import { getRanksConfig } from '@core/configurations.js';
+import { debugLog, errorLog } from '@core/logger.js';
+import { RankDefinition } from '@core/ranksConfig.default.js';
 import { isDefined } from '@lib/guards.js';
-import { getRanksConfig } from './configurations.js';
-import { debugLog, errorLog } from './logger.js';
-import { RankDefinition } from './ranksConfig.default.js';
 
 let sortedRanks: RankDefinition[] = [];
 

--- a/src/core/restartManager.ts
+++ b/src/core/restartManager.ts
@@ -1,7 +1,7 @@
 import * as mc from '@minecraft/server';
 
 import { CommandExecutor } from '@commands/commandManager.js';
-import { getAllPlayersFromCache } from './playerCache.js';
+import { getAllPlayersFromCache } from '@core/playerCache.js';
 
 export function startRestart(_initiator?: CommandExecutor | mc.Entity) {
     const players = getAllPlayersFromCache();

--- a/src/core/rulesManager.ts
+++ b/src/core/rulesManager.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
-import { getConfig, updateMultipleConfig } from './configManager.js';
-import { debugLog } from './logger.js';
+import { getConfig, updateMultipleConfig } from '@core/configManager.js';
+import { debugLog } from '@core/logger.js';
 
 /**
  * Gets the current list of rules from the main configuration.

--- a/src/core/sidebarManager.ts
+++ b/src/core/sidebarManager.ts
@@ -1,16 +1,16 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 import * as mc from '@minecraft/server';
 
+import { getConfig } from '@core/configManager.js';
+import { getSidebarConfig } from '@core/configurations.js';
+import { getLeaderboard } from '@core/leaderboardManager.js';
+import { debugLog } from '@core/logger.js';
 import { getAllPlayersFromCache, getPlayerCount } from '@core/playerCache.js';
+import { getPlayTime, getPlayer, getSidebarVisible } from '@core/playerDataManager.js';
+import { getPlayerRank } from '@core/rankManager.js';
+import { formatCurrency, formatDuration } from '@core/utils.js';
 import { getTeamByPlayer } from '@features/teams/teamManager.js';
 import { isDefined, isNumber } from '@lib/guards.js';
-import { getConfig } from './configManager.js';
-import { getSidebarConfig } from './configurations.js';
-import { getLeaderboard } from './leaderboardManager.js';
-import { debugLog } from './logger.js';
-import { getPlayTime, getPlayer, getSidebarVisible } from './playerDataManager.js';
-import { getPlayerRank } from './rankManager.js';
-import { formatCurrency, formatDuration } from './utils.js';
 
 let sidebarInterval: number | undefined;
 

--- a/src/core/storage/StorageManager.ts
+++ b/src/core/storage/StorageManager.ts
@@ -1,6 +1,6 @@
 import * as mc from '@minecraft/server';
 
-import { errorLog } from '../logger.js';
+import { errorLog } from '@core/logger.js';
 
 const CHUNK_SIZE = 30_000; // Safe limit below 32kb
 

--- a/src/core/teleportLogic.ts
+++ b/src/core/teleportLogic.ts
@@ -1,10 +1,10 @@
+import { errorLog } from '@core/logger.js';
+import { setActionBarOverride } from '@core/sidebarManager.js';
+import { playSound } from '@core/utils/sound.js';
+import { getCountdownColor } from '@core/utils/ui.js';
 import { isDefined, isNumber } from '@lib/guards.js';
 import { Vector3Utils } from '@minecraft/math';
 import * as mc from '@minecraft/server';
-import { errorLog } from './logger.js';
-import { setActionBarOverride } from './sidebarManager.js';
-import { playSound } from './utils/sound.js';
-import { getCountdownColor } from './utils/ui.js';
 
 export function startTeleportWarmup(player: mc.Player, durationSeconds: number, onWarmupComplete: () => void, teleportName = 'teleport', onCancel?: () => void): void {
     if (durationSeconds <= 0) {

--- a/src/core/timerManager.ts
+++ b/src/core/timerManager.ts
@@ -1,6 +1,6 @@
 import * as mc from '@minecraft/server';
 
-import { debugLog } from './logger.js';
+import { debugLog } from '@core/logger.js';
 
 /**
  * A manager to track and clear system timers (run and runInterval)

--- a/src/core/ui/PanelRouter.ts
+++ b/src/core/ui/PanelRouter.ts
@@ -1,4 +1,4 @@
-import { IPanelHandler } from './types.js';
+import { IPanelHandler } from '@ui/types.js';
 
 class PanelRouter {
     private readonly handlers: IPanelHandler[] = [];

--- a/src/core/ui/actionRegistry.ts
+++ b/src/core/ui/actionRegistry.ts
@@ -18,7 +18,7 @@ import { mutePlayer, unmutePlayer } from '@features/moderation/commands/mute.js'
 import * as reportManager from '@features/moderation/reportManager.js';
 import * as tpaManager from '@features/teleportation/tpaManager.js';
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
-import { UIContext } from './panelRegistry.js';
+import { UIContext } from '@ui/panelRegistry.js';
 
 interface ReportContext {
     targetReport: { id: string };

--- a/src/core/ui/panelBuilder.ts
+++ b/src/core/ui/panelBuilder.ts
@@ -8,9 +8,9 @@ import { getPlayerFromCache } from '@core/playerCache.js';
 import { getOrCreatePlayer, loadPlayerData } from '@core/playerDataManager.js';
 import { getPlayerRank } from '@core/rankManager.js';
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
-import { panelRouter } from './PanelRouter.js';
-import { panelDefinitions } from './panelRegistry.js';
-import { MainConfig, PanelDefinition, PanelItem, UIContext } from './types.js';
+import { panelRouter } from '@ui/PanelRouter.js';
+import { panelDefinitions } from '@ui/panelRegistry.js';
+import { MainConfig, PanelDefinition, PanelItem, UIContext } from '@ui/types.js';
 
 export function getStaticMenuItems(panelDef: PanelDefinition, permissionLevel: number, context?: UIContext): PanelItem[] {
     const config = getConfig() as unknown as MainConfig;

--- a/src/core/ui/panelHandlers.ts
+++ b/src/core/ui/panelHandlers.ts
@@ -1,8 +1,8 @@
 import * as mc from '@minecraft/server';
 import { ActionFormResponse, ModalFormResponse } from '@minecraft/server-ui';
 
-import { panelRouter } from './PanelRouter.js';
-import { UIContext } from './types.js';
+import { panelRouter } from '@ui/PanelRouter.js';
+import { UIContext } from '@ui/types.js';
 
 export async function handleFormResponse(player: mc.Player, panelId: string, response: ActionFormResponse | ModalFormResponse, context: UIContext) {
     // 1. Router Check (Modular System)

--- a/src/core/ui/panelRegistry.ts
+++ b/src/core/ui/panelRegistry.ts
@@ -3,9 +3,9 @@
  * It is used by the uiManager and its sub-modules to dynamically generate UI forms.
  */
 
-import { PanelDefinition } from './types.js';
+import { PanelDefinition } from '@ui/types.js';
 
-export * from './types.js';
+export * from '@ui/types.js';
 
 // --- PANEL REGISTRIES ---
 
@@ -872,4 +872,4 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
     }
 };
 
-export { configPanelSchema } from './configPanelRegistry.js';
+export { configPanelSchema } from '@ui/configPanelRegistry.js';

--- a/src/core/ui/systemRegistry.ts
+++ b/src/core/ui/systemRegistry.ts
@@ -1,5 +1,5 @@
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
-import { configPanelSchema } from './configPanelRegistry.js';
+import { configPanelSchema } from '@ui/configPanelRegistry.js';
 
 export interface SystemDefinition {
     /** Unique identifier for the system (used for reset logic). */

--- a/src/core/ui/uiUtils.ts
+++ b/src/core/ui/uiUtils.ts
@@ -28,7 +28,7 @@ import { kitsConfig } from '@features/kits/kitsConfig.default.js';
 import { shopConfig } from '@features/shop/shopConfig.js';
 import { teamConfig } from '@features/teams/teamConfig.js';
 import * as mc from '@minecraft/server';
-import { PanelItem, UIContext } from './types.js';
+import { PanelItem, UIContext } from '@ui/types.js';
 
 type SpawnConfig = typeof spawnConfig;
 type EconomyConfig = typeof economyConfig;
@@ -39,7 +39,7 @@ type KitsConfig = typeof kitsConfig;
 type ShopConfig = typeof shopConfig;
 type AuctionHouseConfig = typeof auctionHouseConfig;
 
-import { getSystemRegistry, SystemDefinition } from './systemRegistry.js';
+import { getSystemRegistry, SystemDefinition } from '@ui/systemRegistry.js';
 
 export const itemsPerPage = 8;
 

--- a/src/core/uiManager.ts
+++ b/src/core/uiManager.ts
@@ -1,12 +1,12 @@
 import * as mc from '@minecraft/server';
 
 import { getCooldown, setCooldownCustom } from '@core/cooldownManager.js';
+import { debugLog, errorLog } from '@core/logger.js';
+import * as utils from '@core/utils.js';
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
-import { debugLog, errorLog } from './logger.js';
-import { buildPanelForm } from './ui/panelBuilder.js';
-import { handleFormResponse } from './ui/panelHandlers.js';
-import { panelDefinitions, UIContext } from './ui/panelRegistry.js';
-import * as utils from './utils.js';
+import { buildPanelForm } from '@ui/panelBuilder.js';
+import { handleFormResponse } from '@ui/panelHandlers.js';
+import { panelDefinitions, UIContext } from '@ui/panelRegistry.js';
 
 /**
  * Main entry point for showing a UI panel to a player.

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,11 +1,11 @@
-export * from './utils/economy.js';
-export * from './utils/formatting.js';
-export * from './utils/item.js';
-export * from './utils/location.js';
-export * from './utils/player.js';
-export * from './utils/sanitization.js';
-export * from './utils/sound.js';
-export * from './utils/time.js';
-export * from './utils/ui.js';
+export * from '@core/utils/economy.js';
+export * from '@core/utils/formatting.js';
+export * from '@core/utils/item.js';
+export * from '@core/utils/location.js';
+export * from '@core/utils/player.js';
+export * from '@core/utils/sanitization.js';
+export * from '@core/utils/sound.js';
+export * from '@core/utils/time.js';
+export * from '@core/utils/ui.js';
 // Explicitly re-export reinitializeOnlinePlayers if it's not being picked up by *
-export { reinitializeOnlinePlayers } from './utils/player.js';
+export { reinitializeOnlinePlayers } from '@core/utils/player.js';

--- a/src/core/utils/economy.ts
+++ b/src/core/utils/economy.ts
@@ -1,4 +1,4 @@
-import { getEconomyConfig } from '../configurations.js';
+import { getEconomyConfig } from '@core/configurations.js';
 
 interface EconomyConfig {
     currencySymbol?: string;

--- a/src/core/utils/sound.ts
+++ b/src/core/utils/sound.ts
@@ -1,6 +1,6 @@
+import { getConfig } from '@core/configManager.js';
+import { errorLog } from '@core/logger.js';
 import * as mc from '@minecraft/server';
-import { getConfig } from '../configManager.js';
-import { errorLog } from '../logger.js';
 
 interface SoundEventConfig {
     soundEvents?: {


### PR DESCRIPTION
Replaced relative imports in `src/core/` with absolute aliases per session 1b of plan.md.

---
*PR created automatically by Jules for task [7412243564186248310](https://jules.google.com/task/7412243564186248310) started by @SjnExe*