### PR TITLE
Fix UI Layout Logic for Reset Settings

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -51,9 +51,9 @@ _Goal: Enforce absolute aliases in remaining directories and verify strictness._
 
 _Goal: Fix the layout issue in the configuration panel._
 
-- [ ] **Modify Panel Logic:** Edit `src/core/ui/panels/configPanel.ts`.
-- [ ] **Programmatic Placement:** Force the "Reset Settings" button/section to be the absolute last element in the configuration list.
-- [ ] **Pagination Check:** Ensure the "Reset Settings" section does not get floated or pushed to earlier pages; it should strictly be the final entry on the very last page of the multi-page menu.
+- [x] **Modify Panel Logic:** Edit `src/core/ui/panels/configPanel.ts`.
+- [x] **Programmatic Placement:** Force the "Reset Settings" button/section to be the absolute last element in the configuration list.
+- [x] **Pagination Check:** Ensure the "Reset Settings" section does not get floated or pushed to earlier pages; it should strictly be the final entry on the very last page of the multi-page menu.
 
 ---
 
@@ -96,5 +96,5 @@ _Goal: Point all tools to the new `build/` directory and verify the entire syste
 _(Update this section whenever you perform a handover to keep track of state and any important discoveries)_
 
 - **Current Status:** Session 1 completed. All absolute aliases in `src/features/` and remaining directories were converted, tested and passing.
-- **Completed Sessions:** Session 1a, Session 1b, Session 1c, Session 1d.
-- **Next Steps:** Proceed to session 2.
+- **Completed Sessions:** Session 1a, Session 1b, Session 1c, Session 1d, Session 2.
+- **Next Steps:** Proceed to session 3.

--- a/src/core/ui/panels/configPanel.ts
+++ b/src/core/ui/panels/configPanel.ts
@@ -14,7 +14,7 @@ import { showConfirmationDialog } from '@ui/components.js';
 import { configPanelSchema } from '@ui/configPanelRegistry.js';
 import { PanelItem, UIContext } from '@ui/panelRegistry.js';
 import { IPanelHandler } from '@ui/types.js';
-import { addBackButton, addPaginationItems, getPaginatedItems, getSystemsByCategory, getVisibleCategories, itemsPerPage, configHandlers as uiConfigHandlers } from '@ui/uiUtils.js';
+import { addBackButton, addPaginationItems, getPaginatedItems, getSystemsByCategory, getVisibleCategories, configHandlers as uiConfigHandlers } from '@ui/uiUtils.js';
 
 interface ConfigSetting {
     key: string;
@@ -64,28 +64,40 @@ export class ConfigPanelHandler implements IPanelHandler {
         const items: PanelItem[] = [];
         addBackButton(items, 'staffDashboardPanel');
         const categories = getVisibleCategories(pData);
+
+        if (pData.permissionLevel === 0) {
+            categories.push({
+                id: 'resetSettings',
+                title: '§l§cReset Settings§r',
+                icon: 'textures/ui/wysiwyg_reset'
+            });
+        }
+
         const paginated = getPaginatedItems(categories, (context.page as number) || 1);
         for (const cat of paginated) {
             if (!isDefined(cat)) continue;
-            items.push({
-                id: cat.id,
-                text: cat.title,
-                icon: cat.icon,
-                permissionLevel: 1,
-                actionType: 'openPanel',
-                actionValue: `configSubCategoryPanel_${cat.id}`
-            });
+
+            if (cat.id === 'resetSettings') {
+                items.push({
+                    id: 'resetSettings',
+                    text: '§l§cReset Settings§r',
+                    icon: 'textures/ui/wysiwyg_reset',
+                    permissionLevel: 0,
+                    actionType: 'openPanel',
+                    actionValue: 'configResetPanel'
+                });
+            } else {
+                items.push({
+                    id: cat.id,
+                    text: cat.title,
+                    icon: cat.icon,
+                    permissionLevel: 1,
+                    actionType: 'openPanel',
+                    actionValue: `configSubCategoryPanel_${cat.id}`
+                });
+            }
         }
-        if (pData.permissionLevel === 0) {
-            items.push({
-                id: 'resetSettings',
-                text: '§l§cReset Settings§r',
-                icon: 'textures/ui/wysiwyg_reset',
-                permissionLevel: 0,
-                actionType: 'openPanel',
-                actionValue: 'configResetPanel'
-            });
-        }
+
         addPaginationItems(items, (context.page as number) || 1, categories.length);
         return items;
     }
@@ -114,28 +126,38 @@ export class ConfigPanelHandler implements IPanelHandler {
         const items: PanelItem[] = [];
         addBackButton(items, 'configCategoryPanel');
         const categories = getVisibleCategories(pData);
+
+        categories.push({
+            id: 'resetAll',
+            title: '§l§4Reset All Systems',
+            icon: 'textures/ui/trash'
+        });
+
         const paginated = getPaginatedItems(categories, (context.page as number) || 1);
         for (const cat of paginated) {
             if (!isDefined(cat)) continue;
-            items.push({
-                id: cat.id,
-                text: `Reset ${cat.title}`,
-                icon: cat.icon,
-                permissionLevel: 0,
-                actionType: 'openPanel',
-                actionValue: `configResetCategoryPanel_${cat.id}`
-            });
+
+            if (cat.id === 'resetAll') {
+                items.push({
+                    id: 'resetAll',
+                    text: '§l§4Reset All Systems',
+                    icon: 'textures/ui/trash',
+                    permissionLevel: 0,
+                    actionType: 'functionCall',
+                    actionValue: 'resetAllConfig'
+                });
+            } else {
+                items.push({
+                    id: cat.id,
+                    text: `Reset ${cat.title}`,
+                    icon: cat.icon,
+                    permissionLevel: 0,
+                    actionType: 'openPanel',
+                    actionValue: `configResetCategoryPanel_${cat.id}`
+                });
+            }
         }
-        if (((context.page as number) || 1) >= Math.ceil(categories.length / itemsPerPage)) {
-            items.push({
-                id: 'resetAll',
-                text: '§l§4Reset All Systems',
-                icon: 'textures/ui/trash',
-                permissionLevel: 0,
-                actionType: 'functionCall',
-                actionValue: 'resetAllConfig'
-            });
-        }
+
         addPaginationItems(items, (context.page as number) || 1, categories.length);
         return items;
     }


### PR DESCRIPTION
Completed Session 2 in `plan.md` to resolve UI layout logic.
- The "Reset Settings" button now properly falls into the `getPaginatedItems` calculation so it only appears strictly on the very last page.
- Applied identical logic to the "Reset All Systems" button inside `getResetPanelItems`.
- Removed an unused import `itemsPerPage` from `configPanel.ts`.
- Checked off completed Session 2 items in `plan.md`.

---
*PR created automatically by Jules for task [2024953305889450504](https://jules.google.com/task/2024953305889450504) started by @SjnExe*