### PR TITLE
Fix check-dependencies.js manifest.json path

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -83,7 +83,7 @@ _Goal: Point all tools to the new `build/` directory and verify the entire syste
 
 - [x] **Validation Tools:** Update `package.json` scripts for Minecraft Creator Tools (`mct validate`) to look at the `build/` directory instead of the root or `packs/` (e.g., using `-i build`).
 - [x] **GitHub Actions Update:** Modify `.github/workflows/build.yml` so that it copies the final assets from the `build/` directory to the staging directory for deployment/packaging instead of `packs/`.
-- [ ] **Pre-commit Hooks:** Check and update any lint-staged or pre-commit hooks in `package.json` if they are looking at incorrect paths.
+- [x] **Pre-commit Hooks:** Check and update any lint-staged or pre-commit hooks in `package.json` if they are looking at incorrect paths.
 - [x] **Verify Build:** Run a full clean build (`npm run build`) to ensure tsup correctly compiles the project and the `*Config.js` files are editable and present in `build/behavior/scripts/`.
 - [x] **Verify Aliases:** Verify that all imports are correctly resolving using the `@alias` format.
 - [x] **Verify UI Logic:** Run pre-commit/test scripts to ensure UI logic changes for the "Reset Config" button have not introduced any regressions.

--- a/scripts/check-dependencies.js
+++ b/scripts/check-dependencies.js
@@ -6,14 +6,14 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const packageJsonPath = path.join(__dirname, '../package.json');
-const manifestJsonPath = path.join(__dirname, '../packs/behavior/manifest.json');
+const manifestJsonPath = path.join(__dirname, '../build/behavior/manifest.json');
 
 async function main() {
     try {
         await Promise.all([fs.access(packageJsonPath), fs.access(manifestJsonPath)]);
     } catch {
         // If manifest doesn't exist yet (e.g. pre-build), skip check or warn
-        console.warn('Could not find package.json or packs/behavior/manifest.json. Skipping dependency check.');
+        console.warn('Could not find package.json or build/behavior/manifest.json. Skipping dependency check.');
         process.exit(0);
     }
 


### PR DESCRIPTION
Fixed the `scripts/check-dependencies.js` path to point to `build/behavior/manifest.json` instead of `packs/behavior/manifest.json`, because packs is now considered source code. Checked that `npm run test` and `npm run validate` still work and updated `plan.md` to reflect the final changes.

---
*PR created automatically by Jules for task [13844212883744834794](https://jules.google.com/task/13844212883744834794) started by @SjnExe*