### PR TITLE
docs: create plan.md for rank and permission overhaul

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,38 @@
+# Rank & Permission Overhaul Plan
+
+## Session 1: Schema & Global Migration Cleanup
+- [ ] **Define New Rank Schema:** Refactor `src/core/ranksConfig.default.ts` to replace `permissionLevel` with `priority` (lower number = higher priority). Add `groups` (array of strings), `allow` (array of node strings), and `deny` (array of node strings). Ensure every rank inherits a global `default` group.
+- [ ] **Update Player Data Model:** Modify `PlayerData` in `src/core/playerDataManager.ts` to support multiple ranks natively (e.g., replace `rankId: string` and `permissionLevel: number` with `ranks: string[]`).
+- [ ] **Strip Legacy Migrations:**
+    - Clean up `src/core/migrationManager.ts`. Remove all legacy version migration logic (`migrateToV1`, `migrateToV2`) and leave only the core version-checking skeleton.
+    - Search for and remove any other legacy data migration code across the entire codebase.
+
+## Session 2: Core Permission Engine & Cache System
+- [ ] **Create Permission Engine Module:** Create a new module (e.g., `src/core/permissionEngine.ts` or refactor `rankManager.ts`).
+- [ ] **Implement Per-Rank Caching:** Pre-calculate flattened permission node maps per rank. This map MUST be initialized with `Object.create(null)` for O(1) lookups.
+- [ ] **Implement Player Node Map Merge:** Calculate a player's final node map by merging their pre-calculated rank maps based on priority (highest priority rank dictates conflicts).
+- [ ] **Implement `hasPermission(player, node)`:**
+    - Hardcode bypass for the `Owner` rank.
+    - Support wildcards (`*`, `cmd.*`). First check for exact match, then segments.
+- [ ] **Cache Invalidation & Re-merge:** Ensure the engine recalculates specific rank maps and immediately re-merges for online players when an admin edits a rank in-game via the UI.
+- [ ] **Hardcoded Fallbacks:** Hardcode core permissions for the `Admin` rank to prevent accidental lockouts.
+
+## Session 3: Command & UI Panel Restructuring
+- [ ] **Vanilla Command Integration (/scriptevent):** Create a listener (e.g., in `src/core/events/scriptEventReceive.ts`) for `/scriptevent myaddon:add_rank <rank>` and `myaddon:remove_rank <rank>` to allow vanilla command blocks and `/function` to assign/revoke ranks.
+- [ ] **Update UI Schema & Interfaces:** Refactor `PanelItem` in `src/core/ui/types.ts` to replace `permissionLevel?: number` with `permission?: string`.
+- [ ] **Refactor Panel Definitions:** Update `src/core/ui/panelRegistry.ts` (and any other panel definition files) to use permission strings instead of integer levels.
+- [ ] **Dynamic UI Visibility Filtering:** Update the UI builders (`src/core/ui/panelBuilder.ts` or similar) to show or hide buttons/sections based on dynamic runtime evaluations of `hasPermission()` instead of integer logic.
+
+---
+
+### Handover Context
+*(To be updated after each session)*
+
+**Completed in Previous Session:**
+* None.
+
+**Current State:**
+* Initial plan created. Codebase is ready for Session 1.
+
+**Next Session Needs to Know:**
+* Execute Session 1 tasks.

--- a/plan.md
+++ b/plan.md
@@ -47,6 +47,7 @@ We are replacing the current single-rank, integer-based `permissionLevel` system
 ## Session 3: Command & UI Panel Restructuring
 - [ ] **Universal Script Event Listener:** Create a universal listener (e.g., `src/core/events/scriptEventReceive.ts`) to act as a router for `/scriptevent` commands. Implement an action handler system so new capabilities can be easily added.
 - [ ] **Rank Action Handlers:** Implement specific handlers within the universal script event listener for adding and removing ranks (e.g., parsing a payload to assign a rank to the target player).
+- [ ] **Update `.mcfunction` Files:** Modify `packs/behavior/functions/admin.mcfunction` (and any related function files like `setup.mcfunction` or `owner.mcfunction`) to replace old tag commands (`/tag @s add admin`) with the new `/scriptevent` command (e.g., `/scriptevent myaddon:action {"action":"add_rank","rank":"admin"}`) so that `/function admin` properly assigns the admin rank using the new system.
 - [ ] **Targeting Hierarchy Enforcement:** Implement a utility function to compare two players' highest priorities. Apply this check to all moderation commands and UI actions (kick, ban, mute, freeze) to prevent lower-priority staff from targeting higher-priority staff.
 - [ ] **Update UI Schema & Interfaces:** Refactor `PanelItem` in `src/core/ui/types.ts` to replace `permissionLevel?: number` with `permission?: string`.
 - [ ] **Refactor Panel Definitions:** Update `src/core/ui/panelRegistry.ts` (and any other panel definition files) to use permission strings instead of integer levels.

--- a/plan.md
+++ b/plan.md
@@ -26,7 +26,8 @@ We are replacing the current single-rank, integer-based `permissionLevel` system
 ---
 
 ## Session 1: Schema & Global Migration Cleanup
-- [ ] **Define New Rank Schema:** Refactor `src/core/ranksConfig.default.ts` to replace `permissionLevel` with `priority` (lower number = higher priority). Add `groups` (array of strings), `allow` (array of node strings), and `deny` (array of node strings). Ensure every rank inherits a global `default` group.
+- [ ] **Define New Rank Schema:** Refactor `src/core/ranksConfig.default.ts` to replace `permissionLevel` with `priority` (lower number = higher priority). Add `groups` (array of strings), `allow` (array of node strings), and `deny` (array of node strings). Ensure every rank inherits a global `default` group. Include standard properties like `chatFormatting` and `nametagPrefix`.
+- [ ] **Define Permission Groups Schema:** Create a structure (e.g., in `ranksConfig.default.ts` or a new config) to define what nodes belong to which `groups` (bundles of predefined permissions).
 - [ ] **Update Player Data Model:** Modify `PlayerData` in `src/core/playerDataManager.ts` to support multiple ranks natively (e.g., replace `rankId: string` and `permissionLevel: number` with `ranks: string[]`).
 - [ ] **Strip Legacy Migrations:**
     - Clean up `src/core/migrationManager.ts`. Remove all legacy version migration logic (`migrateToV1`, `migrateToV2`) and leave only the core version-checking skeleton.
@@ -41,12 +42,15 @@ We are replacing the current single-rank, integer-based `permissionLevel` system
     - Support wildcards (`*`, `cmd.*`). First check for exact match, then segments.
 - [ ] **Cache Invalidation & Re-merge:** Ensure the engine recalculates specific rank maps and immediately re-merges for online players when an admin edits a rank in-game via the UI.
 - [ ] **Hardcoded Fallbacks:** Hardcode core permissions for the `Admin` rank to prevent accidental lockouts.
+- [ ] **Chat Prefix & Nametag Resolution:** Update `updatePlayerNameTag` (or equivalent) to dynamically resolve a player's display prefix and chat formatting based on their highest-priority rank.
 
 ## Session 3: Command & UI Panel Restructuring
 - [ ] **Vanilla Command Integration (/scriptevent):** Create a listener (e.g., in `src/core/events/scriptEventReceive.ts`) for `/scriptevent myaddon:add_rank <rank>` and `myaddon:remove_rank <rank>` to allow vanilla command blocks and `/function` to assign/revoke ranks.
+- [ ] **Targeting Hierarchy Enforcement:** Implement a utility function to compare two players' highest priorities. Apply this check to all moderation commands and UI actions (kick, ban, mute, freeze) to prevent lower-priority staff from targeting higher-priority staff.
 - [ ] **Update UI Schema & Interfaces:** Refactor `PanelItem` in `src/core/ui/types.ts` to replace `permissionLevel?: number` with `permission?: string`.
 - [ ] **Refactor Panel Definitions:** Update `src/core/ui/panelRegistry.ts` (and any other panel definition files) to use permission strings instead of integer levels.
 - [ ] **Dynamic UI Visibility Filtering:** Update the UI builders (`src/core/ui/panelBuilder.ts` or similar) to show or hide buttons/sections based on dynamic runtime evaluations of `hasPermission()` instead of integer logic.
+- [ ] **Command Permission Verification:** Ensure all slash commands (`src/core/commands/` and `src/features/*/commands/`) check against the new string-based node system instead of `permissionLevel`.
 
 ---
 

--- a/plan.md
+++ b/plan.md
@@ -12,8 +12,9 @@ We are replacing the current single-rank, integer-based `permissionLevel` system
 * **Calculated Node Map Engine:** To ensure O(1) runtime lookups, permissions are compiled into a flat map cache when a player joins or ranks change. This dictionary MUST be initialized with `Object.create(null)` to eliminate prototype chain overhead in the Bedrock V8 engine.
 * **Wildcard Support:** The `hasPermission()` check must support wildcards (`*`, `cmd.*`). For maximum speed, it should check exact matches first, then fall back to checking segment wildcards directly against the flat map.
 * **In-Game Editing Cache Invalidations:** When an admin edits a rank in-game via the UI, the engine must quickly recalculate that specific rank's map and instantly re-merge it for any online players holding that rank.
-* **Hardcoded Fallbacks:** The `Owner` rank inherently bypasses all permission checks. The `Admin` rank has a hardcoded, uneditable set of core permissions to prevent accidental lockouts.
+* **Hardcoded Fallbacks:** The `Owner` rank inherently bypasses all permission checks (has the literal `*` wildcard internally). The `Admin` rank has a hardcoded, uneditable set of core permissions to prevent accidental lockouts.
 * **Universal Vanilla Command Integration (/scriptevent):** We are NOT doing tag syncing. To allow vanilla command blocks and `/function` to interact with the addon (including giving ranks), we will set up a universal `/scriptevent` listener (e.g., `src/core/events/scriptEventReceive.ts`). This listener will act as a router for various addon commands (e.g., listening for `/scriptevent myaddon:action {"action": "add_rank", "rank": "admin"}` targeted at a player, or a similar structured payload).
+* **Clear Node Naming Conventions:** The `Owner` rank has `*` internally which grants all permissions. However, "Owner-only" features must have explicitly named nodes (e.g., `ui.panel.owner` or `cmd.op`) instead of checking for `*`. This allows server owners to selectively grant those specific capabilities to an `Admin` via the config without making them a full `Owner`.
 
 ### 2. Codebase Clean Slate (No Data Migration)
 * **Strip All Legacy Migrations:** Because this is effectively a V1 release, ALL legacy data migration code across the entire codebase (for all features, not just ranks) must be deleted.
@@ -27,18 +28,18 @@ We are replacing the current single-rank, integer-based `permissionLevel` system
 
 ## Session 1: Schema & Global Migration Cleanup
 - [ ] **Define New Rank Schema:** Refactor `src/core/ranksConfig.default.ts` to replace `permissionLevel` with `priority` (lower number = higher priority). Add `groups` (array of strings), `allow` (array of node strings), and `deny` (array of node strings). Ensure every rank inherits a global `default` group. Include standard properties like `chatFormatting` and `nametagPrefix`.
-- [ ] **Define Permission Groups Schema:** Create a structure (e.g., in `ranksConfig.default.ts` or a new config) to define what nodes belong to which `groups` (bundles of predefined permissions).
-- [ ] **Update Player Data Model:** Modify `PlayerData` in `src/core/playerDataManager.ts` to support multiple ranks natively (e.g., replace `rankId: string` and `permissionLevel: number` with `ranks: string[]`).
+- [ ] **Define Permission Groups Schema:** Create a structure (e.g., in `ranksConfig.default.ts` or a new config) to define what nodes belong to which `groups` (bundles of predefined permissions). Standardize permission node strings (e.g. `cmd.kick`, `ui.panel.admin`, `ui.panel.owner`).
+- [ ] **Update Player Data Model:** Modify `PlayerData` in `src/core/playerDataManager.ts` to support multiple ranks natively (e.g., replace `rankId: string` and `permissionLevel: number` with `ranks: string[]`). Update creation functions to default to `['member']`.
 - [ ] **Strip Legacy Migrations:**
     - Clean up `src/core/migrationManager.ts`. Remove all legacy version migration logic (`migrateToV1`, `migrateToV2`) and leave only the core version-checking skeleton.
-    - Search for and remove any other legacy data migration code across the entire codebase.
+    - Search for and remove any other legacy data migration code across the entire codebase (e.g., legacy single-prop code in `playerDataManager.ts`).
 
 ## Session 2: Core Permission Engine & Cache System
 - [ ] **Create Permission Engine Module:** Create a new module (e.g., `src/core/permissionEngine.ts` or refactor `rankManager.ts`).
 - [ ] **Implement Per-Rank Caching:** Pre-calculate flattened permission node maps per rank. This map MUST be initialized with `Object.create(null)` for O(1) lookups.
 - [ ] **Implement Player Node Map Merge:** Calculate a player's final node map by merging their pre-calculated rank maps based on priority (highest priority rank dictates conflicts).
 - [ ] **Implement `hasPermission(player, node)`:**
-    - Hardcode bypass for the `Owner` rank.
+    - Hardcode bypass for the `Owner` rank (treat as if they have `*`).
     - Support wildcards (`*`, `cmd.*`). First check for exact match, then segments.
 - [ ] **Cache Invalidation & Re-merge:** Ensure the engine recalculates specific rank maps and immediately re-merges for online players when an admin edits a rank in-game via the UI.
 - [ ] **Hardcoded Fallbacks:** Hardcode core permissions for the `Admin` rank to prevent accidental lockouts.
@@ -50,7 +51,7 @@ We are replacing the current single-rank, integer-based `permissionLevel` system
 - [ ] **Update `.mcfunction` Files:** Modify `packs/behavior/functions/admin.mcfunction` (and any related function files like `setup.mcfunction` or `owner.mcfunction`) to replace old tag commands (`/tag @s add admin`) with the new `/scriptevent` command (e.g., `/scriptevent myaddon:action {"action":"add_rank","rank":"admin"}`) so that `/function admin` properly assigns the admin rank using the new system.
 - [ ] **Targeting Hierarchy Enforcement:** Implement a utility function to compare two players' highest priorities. Apply this check to all moderation commands and UI actions (kick, ban, mute, freeze) to prevent lower-priority staff from targeting higher-priority staff.
 - [ ] **Update UI Schema & Interfaces:** Refactor `PanelItem` in `src/core/ui/types.ts` to replace `permissionLevel?: number` with `permission?: string`.
-- [ ] **Refactor Panel Definitions:** Update `src/core/ui/panelRegistry.ts` (and any other panel definition files) to use permission strings instead of integer levels.
+- [ ] **Refactor Panel Definitions:** Update `src/core/ui/panelRegistry.ts` (and any other panel definition files) to use permission strings instead of integer levels. Convert old level checks to explicit node names (e.g. `ui.panel.owner` instead of level `0`).
 - [ ] **Dynamic UI Visibility Filtering:** Update the UI builders (`src/core/ui/panelBuilder.ts` or similar) to show or hide buttons/sections based on dynamic runtime evaluations of `hasPermission()` instead of integer logic.
 - [ ] **Command Permission Verification:** Ensure all slash commands (`src/core/commands/` and `src/features/*/commands/`) check against the new string-based node system instead of `permissionLevel`.
 

--- a/plan.md
+++ b/plan.md
@@ -1,5 +1,30 @@
 # Rank & Permission Overhaul Plan
 
+## Context & Requirements
+
+We are replacing the current single-rank, integer-based `permissionLevel` system with a highly optimized, multi-rank string-based permission node system.
+
+### 1. Core Architecture & Optimizations (The "Calculated Node Map")
+* **Multiple Ranks via JSON:** Players can hold multiple ranks simultaneously. Ranks are stored in the player's JSON data (e.g., `pData.ranks = ['member', 'vip', 'mod']`).
+* **Rank Schema:** Ranks consist of `groups` (bundles of predefined permissions), `allow` (specific nodes), `deny` (specific overriding nodes), and a `priority` integer. Every rank inherits a global `default` group.
+* **Priority & Hierarchy:** The `priority` integer replaces the old `permissionLevel`. **Lower numbers equal higher priority.** Higher priority explicitly wins all conflicts (e.g., if a high-priority rank allows a node but a low-priority rank denies it, the allow wins). Priority also determines chat prefix (highest priority rank shown) and targeting hierarchy (prevents lower staff from acting on higher staff).
+* **Per-Rank Caching (Composition Optimization):** Since many players share the exact same combination of ranks, we will cache flattened nodes *per rank* first. To calculate a player's final node map, merge their pre-calculated rank maps based on priority.
+* **Calculated Node Map Engine:** To ensure O(1) runtime lookups, permissions are compiled into a flat map cache when a player joins or ranks change. This dictionary MUST be initialized with `Object.create(null)` to eliminate prototype chain overhead in the Bedrock V8 engine.
+* **Wildcard Support:** The `hasPermission()` check must support wildcards (`*`, `cmd.*`). For maximum speed, it should check exact matches first, then fall back to checking segment wildcards directly against the flat map.
+* **In-Game Editing Cache Invalidations:** When an admin edits a rank in-game via the UI, the engine must quickly recalculate that specific rank's map and instantly re-merge it for any online players holding that rank.
+* **Hardcoded Fallbacks:** The `Owner` rank inherently bypasses all permission checks. The `Admin` rank has a hardcoded, uneditable set of core permissions to prevent accidental lockouts.
+* **Vanilla Command Integration (/scriptevent):** We are NOT doing tag syncing. To allow vanilla command blocks and `/function` to give ranks, we will set up a `/scriptevent` listener (e.g., listening for `/scriptevent myaddon:add_rank admin` targeted at a player).
+
+### 2. Codebase Clean Slate (No Data Migration)
+* **Strip All Legacy Migrations:** Because this is effectively a V1 release, ALL legacy data migration code across the entire codebase (for all features, not just ranks) must be deleted.
+* **Keep Base Skeleton:** Only the core version-checking loop and migration system framework should remain to handle future updates.
+
+### 3. Panel & UI Restructuring
+* **Dynamic Conditional UI Elements:** The `PanelItem` interface and UI builders must be refactored to replace integer level requirements with permission strings (e.g., `permission: 'ui.panel.admin'`).
+* **Visibility Filtering:** Buttons and menu sections within the `/panel` must be dynamically shown or hidden based on runtime evaluations of `hasPermission()`.
+
+---
+
 ## Session 1: Schema & Global Migration Cleanup
 - [ ] **Define New Rank Schema:** Refactor `src/core/ranksConfig.default.ts` to replace `permissionLevel` with `priority` (lower number = higher priority). Add `groups` (array of strings), `allow` (array of node strings), and `deny` (array of node strings). Ensure every rank inherits a global `default` group.
 - [ ] **Update Player Data Model:** Modify `PlayerData` in `src/core/playerDataManager.ts` to support multiple ranks natively (e.g., replace `rankId: string` and `permissionLevel: number` with `ranks: string[]`).

--- a/plan.md
+++ b/plan.md
@@ -13,7 +13,7 @@ We are replacing the current single-rank, integer-based `permissionLevel` system
 * **Wildcard Support:** The `hasPermission()` check must support wildcards (`*`, `cmd.*`). For maximum speed, it should check exact matches first, then fall back to checking segment wildcards directly against the flat map.
 * **In-Game Editing Cache Invalidations:** When an admin edits a rank in-game via the UI, the engine must quickly recalculate that specific rank's map and instantly re-merge it for any online players holding that rank.
 * **Hardcoded Fallbacks:** The `Owner` rank inherently bypasses all permission checks. The `Admin` rank has a hardcoded, uneditable set of core permissions to prevent accidental lockouts.
-* **Vanilla Command Integration (/scriptevent):** We are NOT doing tag syncing. To allow vanilla command blocks and `/function` to give ranks, we will set up a `/scriptevent` listener (e.g., listening for `/scriptevent myaddon:add_rank admin` targeted at a player).
+* **Universal Vanilla Command Integration (/scriptevent):** We are NOT doing tag syncing. To allow vanilla command blocks and `/function` to interact with the addon (including giving ranks), we will set up a universal `/scriptevent` listener (e.g., `src/core/events/scriptEventReceive.ts`). This listener will act as a router for various addon commands (e.g., listening for `/scriptevent myaddon:action {"action": "add_rank", "rank": "admin"}` targeted at a player, or a similar structured payload).
 
 ### 2. Codebase Clean Slate (No Data Migration)
 * **Strip All Legacy Migrations:** Because this is effectively a V1 release, ALL legacy data migration code across the entire codebase (for all features, not just ranks) must be deleted.
@@ -45,7 +45,8 @@ We are replacing the current single-rank, integer-based `permissionLevel` system
 - [ ] **Chat Prefix & Nametag Resolution:** Update `updatePlayerNameTag` (or equivalent) to dynamically resolve a player's display prefix and chat formatting based on their highest-priority rank.
 
 ## Session 3: Command & UI Panel Restructuring
-- [ ] **Vanilla Command Integration (/scriptevent):** Create a listener (e.g., in `src/core/events/scriptEventReceive.ts`) for `/scriptevent myaddon:add_rank <rank>` and `myaddon:remove_rank <rank>` to allow vanilla command blocks and `/function` to assign/revoke ranks.
+- [ ] **Universal Script Event Listener:** Create a universal listener (e.g., `src/core/events/scriptEventReceive.ts`) to act as a router for `/scriptevent` commands. Implement an action handler system so new capabilities can be easily added.
+- [ ] **Rank Action Handlers:** Implement specific handlers within the universal script event listener for adding and removing ranks (e.g., parsing a payload to assign a rank to the target player).
 - [ ] **Targeting Hierarchy Enforcement:** Implement a utility function to compare two players' highest priorities. Apply this check to all moderation commands and UI actions (kick, ban, mute, freeze) to prevent lower-priority staff from targeting higher-priority staff.
 - [ ] **Update UI Schema & Interfaces:** Refactor `PanelItem` in `src/core/ui/types.ts` to replace `permissionLevel?: number` with `permission?: string`.
 - [ ] **Refactor Panel Definitions:** Update `src/core/ui/panelRegistry.ts` (and any other panel definition files) to use permission strings instead of integer levels.

--- a/plan.md
+++ b/plan.md
@@ -5,29 +5,33 @@
 We are replacing the current single-rank, integer-based `permissionLevel` system with a highly optimized, multi-rank string-based permission node system.
 
 ### 1. Core Architecture & Optimizations (The "Calculated Node Map")
-* **Multiple Ranks via JSON:** Players can hold multiple ranks simultaneously. Ranks are stored in the player's JSON data (e.g., `pData.ranks = ['member', 'vip', 'mod']`).
-* **Rank Schema:** Ranks consist of `groups` (bundles of predefined permissions), `allow` (specific nodes), `deny` (specific overriding nodes), and a `priority` integer. Every rank inherits a global `default` group.
-* **Priority & Hierarchy:** The `priority` integer replaces the old `permissionLevel`. **Lower numbers equal higher priority.** Higher priority explicitly wins all conflicts (e.g., if a high-priority rank allows a node but a low-priority rank denies it, the allow wins). Priority also determines chat prefix (highest priority rank shown) and targeting hierarchy (prevents lower staff from acting on higher staff).
-* **Per-Rank Caching (Composition Optimization):** Since many players share the exact same combination of ranks, we will cache flattened nodes *per rank* first. To calculate a player's final node map, merge their pre-calculated rank maps based on priority.
-* **Calculated Node Map Engine:** To ensure O(1) runtime lookups, permissions are compiled into a flat map cache when a player joins or ranks change. This dictionary MUST be initialized with `Object.create(null)` to eliminate prototype chain overhead in the Bedrock V8 engine.
-* **Wildcard Support:** The `hasPermission()` check must support wildcards (`*`, `cmd.*`). For maximum speed, it should check exact matches first, then fall back to checking segment wildcards directly against the flat map.
-* **In-Game Editing Cache Invalidations:** When an admin edits a rank in-game via the UI, the engine must quickly recalculate that specific rank's map and instantly re-merge it for any online players holding that rank.
-* **Hardcoded Fallbacks:** The `Owner` rank inherently bypasses all permission checks (has the literal `*` wildcard internally). The `Admin` rank has a hardcoded, uneditable set of core permissions to prevent accidental lockouts.
-* **Universal Vanilla Command Integration (/scriptevent):** We are NOT doing tag syncing. To allow vanilla command blocks and `/function` to interact with the addon (including giving ranks), we will set up a universal `/scriptevent` listener (e.g., `src/core/events/scriptEventReceive.ts`). This listener will act as a router for various addon commands (e.g., listening for `/scriptevent myaddon:action {"action": "add_rank", "rank": "admin"}` targeted at a player, or a similar structured payload).
-* **Clear Node Naming Conventions:** The `Owner` rank has `*` internally which grants all permissions. However, "Owner-only" features must have explicitly named nodes (e.g., `ui.panel.owner` or `cmd.op`) instead of checking for `*`. This allows server owners to selectively grant those specific capabilities to an `Admin` via the config without making them a full `Owner`.
+
+- **Multiple Ranks via JSON:** Players can hold multiple ranks simultaneously. Ranks are stored in the player's JSON data (e.g., `pData.ranks = ['member', 'vip', 'mod']`).
+- **Rank Schema:** Ranks consist of `groups` (bundles of predefined permissions), `allow` (specific nodes), `deny` (specific overriding nodes), and a `priority` integer. Every rank inherits a global `default` group.
+- **Priority & Hierarchy:** The `priority` integer replaces the old `permissionLevel`. **Lower numbers equal higher priority.** Higher priority explicitly wins all conflicts (e.g., if a high-priority rank allows a node but a low-priority rank denies it, the allow wins). Priority also determines chat prefix (highest priority rank shown) and targeting hierarchy (prevents lower staff from acting on higher staff).
+- **Per-Rank Caching (Composition Optimization):** Since many players share the exact same combination of ranks, we will cache flattened nodes _per rank_ first. To calculate a player's final node map, merge their pre-calculated rank maps based on priority.
+- **Calculated Node Map Engine:** To ensure O(1) runtime lookups, permissions are compiled into a flat map cache when a player joins or ranks change. This dictionary MUST be initialized with `Object.create(null)` to eliminate prototype chain overhead in the Bedrock V8 engine.
+- **Wildcard Support:** The `hasPermission()` check must support wildcards (`*`, `cmd.*`). For maximum speed, it should check exact matches first, then fall back to checking segment wildcards directly against the flat map.
+- **In-Game Editing Cache Invalidations:** When an admin edits a rank in-game via the UI, the engine must quickly recalculate that specific rank's map and instantly re-merge it for any online players holding that rank.
+- **Hardcoded Fallbacks:** The `Owner` rank inherently bypasses all permission checks (has the literal `*` wildcard internally). The `Admin` rank has a hardcoded, uneditable set of core permissions to prevent accidental lockouts.
+- **Universal Vanilla Command Integration (/scriptevent):** We are NOT doing tag syncing. To allow vanilla command blocks and `/function` to interact with the addon (including giving ranks), we will set up a universal `/scriptevent` listener (e.g., `src/core/events/scriptEventReceive.ts`). This listener will act as a router for various addon commands (e.g., listening for `/scriptevent myaddon:action {"action": "add_rank", "rank": "admin"}` targeted at a player, or a similar structured payload).
+- **Clear Node Naming Conventions:** The `Owner` rank has `*` internally which grants all permissions. However, "Owner-only" features must have explicitly named nodes (e.g., `ui.panel.owner` or `cmd.op`) instead of checking for `*`. This allows server owners to selectively grant those specific capabilities to an `Admin` via the config without making them a full `Owner`.
 
 ### 2. Codebase Clean Slate (No Data Migration)
-* **Strip All Legacy Migrations:** Because this is effectively a V1 release, ALL legacy data migration code across the entire codebase (for all features, not just ranks) must be deleted.
-* **Keep Base Skeleton:** Only the core version-checking loop and migration system framework should remain to handle future updates.
-* **Graceful Data Load Fallbacks:** While formal migrations are removed, `playerDataManager.ts` must safely default missing fields (like the new `ranks` array) to `['member']` when parsing legacy JSON, preventing crashes without needing explicit migration logic.
+
+- **Strip All Legacy Migrations:** Because this is effectively a V1 release, ALL legacy data migration code across the entire codebase (for all features, not just ranks) must be deleted.
+- **Keep Base Skeleton:** Only the core version-checking loop and migration system framework should remain to handle future updates.
+- **Graceful Data Load Fallbacks:** While formal migrations are removed, `playerDataManager.ts` must safely default missing fields (like the new `ranks` array) to `['member']` when parsing legacy JSON, preventing crashes without needing explicit migration logic.
 
 ### 3. Panel & UI Restructuring
-* **Dynamic Conditional UI Elements:** The `PanelItem` interface and UI builders must be refactored to replace integer level requirements with permission strings (e.g., `permission: 'ui.panel.admin'`).
-* **Visibility Filtering:** Buttons and menu sections within the `/panel` must be dynamically shown or hidden based on runtime evaluations of `hasPermission()`.
+
+- **Dynamic Conditional UI Elements:** The `PanelItem` interface and UI builders must be refactored to replace integer level requirements with permission strings (e.g., `permission: 'ui.panel.admin'`).
+- **Visibility Filtering:** Buttons and menu sections within the `/panel` must be dynamically shown or hidden based on runtime evaluations of `hasPermission()`.
 
 ---
 
 ## Session 1: Schema & Global Migration Cleanup
+
 - [ ] **Define New Rank Schema:** Refactor `src/core/ranksConfig.default.ts` to replace `permissionLevel` with `priority` (lower number = higher priority). Add `groups` (array of strings), `allow` (array of node strings), and `deny` (array of node strings). Ensure every rank inherits a global `default` group. Include standard properties like `chatFormatting` and `nametagPrefix`.
 - [ ] **Define Permission Groups Schema:** Create a structure (e.g., in `ranksConfig.default.ts` or a new config) to define what nodes belong to which `groups` (bundles of predefined permissions). Standardize permission node strings (e.g. `cmd.kick`, `ui.panel.admin`, `ui.panel.owner`).
 - [ ] **Update Player Data Model:** Modify `PlayerData` in `src/core/playerDataManager.ts` to support multiple ranks natively (e.g., replace `rankId: string` and `permissionLevel: number` with `ranks: string[]`). Update creation and load functions to gracefully default to `['member']`.
@@ -36,6 +40,7 @@ We are replacing the current single-rank, integer-based `permissionLevel` system
     - Search for and remove any other legacy data migration code across the entire codebase (e.g., legacy single-prop code in `playerDataManager.ts`).
 
 ## Session 2: Core Permission Engine & Cache System
+
 - [ ] **Create Permission Engine Module:** Create a new module (e.g., `src/core/permissionEngine.ts` or refactor `rankManager.ts`).
 - [ ] **Implement Per-Rank Caching:** Pre-calculate flattened permission node maps per rank. This map MUST be initialized with `Object.create(null)` for O(1) lookups.
 - [ ] **Implement Player Node Map Merge:** Calculate a player's final node map by merging their pre-calculated rank maps based on priority (highest priority rank dictates conflicts).
@@ -47,6 +52,7 @@ We are replacing the current single-rank, integer-based `permissionLevel` system
 - [ ] **Chat Prefix & Nametag Resolution:** Update `updatePlayerNameTag` (or equivalent) to dynamically resolve a player's display prefix and chat formatting based on their highest-priority rank.
 
 ## Session 3: Command & UI Panel Restructuring
+
 - [ ] **Universal Script Event Listener:** Create a universal listener (e.g., `src/core/events/scriptEventReceive.ts`) to act as a router for `/scriptevent` commands. Implement an action handler system so new capabilities can be easily added.
 - [ ] **Secure the Script Event Listener:** Ensure the universal script event listener validates the `sourceType` (e.g., `MessageSourceType.Server` or `MessageSourceType.Entity`). If the source is a player, verify they have the appropriate permissions to prevent exploits.
 - [ ] **Rank Action Handlers:** Implement specific handlers within the universal script event listener for adding and removing ranks (e.g., parsing a payload to assign a rank to the target player).
@@ -60,13 +66,17 @@ We are replacing the current single-rank, integer-based `permissionLevel` system
 ---
 
 ### Handover Context
-*(To be updated after each session)*
+
+_(To be updated after each session)_
 
 **Completed in Previous Session:**
-* None.
+
+- None.
 
 **Current State:**
-* Initial plan created. Codebase is ready for Session 1.
+
+- Initial plan created. Codebase is ready for Session 1.
 
 **Next Session Needs to Know:**
-* Execute Session 1 tasks.
+
+- Execute Session 1 tasks.

--- a/plan.md
+++ b/plan.md
@@ -19,6 +19,7 @@ We are replacing the current single-rank, integer-based `permissionLevel` system
 ### 2. Codebase Clean Slate (No Data Migration)
 * **Strip All Legacy Migrations:** Because this is effectively a V1 release, ALL legacy data migration code across the entire codebase (for all features, not just ranks) must be deleted.
 * **Keep Base Skeleton:** Only the core version-checking loop and migration system framework should remain to handle future updates.
+* **Graceful Data Load Fallbacks:** While formal migrations are removed, `playerDataManager.ts` must safely default missing fields (like the new `ranks` array) to `['member']` when parsing legacy JSON, preventing crashes without needing explicit migration logic.
 
 ### 3. Panel & UI Restructuring
 * **Dynamic Conditional UI Elements:** The `PanelItem` interface and UI builders must be refactored to replace integer level requirements with permission strings (e.g., `permission: 'ui.panel.admin'`).
@@ -29,7 +30,7 @@ We are replacing the current single-rank, integer-based `permissionLevel` system
 ## Session 1: Schema & Global Migration Cleanup
 - [ ] **Define New Rank Schema:** Refactor `src/core/ranksConfig.default.ts` to replace `permissionLevel` with `priority` (lower number = higher priority). Add `groups` (array of strings), `allow` (array of node strings), and `deny` (array of node strings). Ensure every rank inherits a global `default` group. Include standard properties like `chatFormatting` and `nametagPrefix`.
 - [ ] **Define Permission Groups Schema:** Create a structure (e.g., in `ranksConfig.default.ts` or a new config) to define what nodes belong to which `groups` (bundles of predefined permissions). Standardize permission node strings (e.g. `cmd.kick`, `ui.panel.admin`, `ui.panel.owner`).
-- [ ] **Update Player Data Model:** Modify `PlayerData` in `src/core/playerDataManager.ts` to support multiple ranks natively (e.g., replace `rankId: string` and `permissionLevel: number` with `ranks: string[]`). Update creation functions to default to `['member']`.
+- [ ] **Update Player Data Model:** Modify `PlayerData` in `src/core/playerDataManager.ts` to support multiple ranks natively (e.g., replace `rankId: string` and `permissionLevel: number` with `ranks: string[]`). Update creation and load functions to gracefully default to `['member']`.
 - [ ] **Strip Legacy Migrations:**
     - Clean up `src/core/migrationManager.ts`. Remove all legacy version migration logic (`migrateToV1`, `migrateToV2`) and leave only the core version-checking skeleton.
     - Search for and remove any other legacy data migration code across the entire codebase (e.g., legacy single-prop code in `playerDataManager.ts`).
@@ -47,12 +48,13 @@ We are replacing the current single-rank, integer-based `permissionLevel` system
 
 ## Session 3: Command & UI Panel Restructuring
 - [ ] **Universal Script Event Listener:** Create a universal listener (e.g., `src/core/events/scriptEventReceive.ts`) to act as a router for `/scriptevent` commands. Implement an action handler system so new capabilities can be easily added.
+- [ ] **Secure the Script Event Listener:** Ensure the universal script event listener validates the `sourceType` (e.g., `MessageSourceType.Server` or `MessageSourceType.Entity`). If the source is a player, verify they have the appropriate permissions to prevent exploits.
 - [ ] **Rank Action Handlers:** Implement specific handlers within the universal script event listener for adding and removing ranks (e.g., parsing a payload to assign a rank to the target player).
 - [ ] **Update `.mcfunction` Files:** Modify `packs/behavior/functions/admin.mcfunction` (and any related function files like `setup.mcfunction` or `owner.mcfunction`) to replace old tag commands (`/tag @s add admin`) with the new `/scriptevent` command (e.g., `/scriptevent myaddon:action {"action":"add_rank","rank":"admin"}`) so that `/function admin` properly assigns the admin rank using the new system.
-- [ ] **Targeting Hierarchy Enforcement:** Implement a utility function to compare two players' highest priorities. Apply this check to all moderation commands and UI actions (kick, ban, mute, freeze) to prevent lower-priority staff from targeting higher-priority staff.
+- [ ] **Targeting Hierarchy Enforcement (Online & Offline):** Implement a utility function to compare two players' highest priorities. Apply this check to all moderation commands and UI actions (kick, ban, mute, freeze) to prevent lower-priority staff from targeting higher-priority staff. This must safely load offline player data if targeting an offline player.
 - [ ] **Update UI Schema & Interfaces:** Refactor `PanelItem` in `src/core/ui/types.ts` to replace `permissionLevel?: number` with `permission?: string`.
 - [ ] **Refactor Panel Definitions:** Update `src/core/ui/panelRegistry.ts` (and any other panel definition files) to use permission strings instead of integer levels. Convert old level checks to explicit node names (e.g. `ui.panel.owner` instead of level `0`).
-- [ ] **Dynamic UI Visibility Filtering:** Update the UI builders (`src/core/ui/panelBuilder.ts` or similar) to show or hide buttons/sections based on dynamic runtime evaluations of `hasPermission()` instead of integer logic.
+- [ ] **Config Refactoring:** Search for and update other configuration interfaces (like `commandSettings` in `config.default.ts`) to replace `permissionLevel: number` with `permissionNode: string`.
 - [ ] **Command Permission Verification:** Ensure all slash commands (`src/core/commands/` and `src/features/*/commands/`) check against the new string-based node system instead of `permissionLevel`.
 
 ---


### PR DESCRIPTION
Generated the `plan.md` file detailing the architectural overhaul to replace the integer-based `permissionLevel` with a highly optimized, multi-rank string-based permission node system. The plan is broken down into three distinct sessions to guide the implementation.

---
*PR created automatically by Jules for task [12523841191802392441](https://jules.google.com/task/12523841191802392441) started by @SjnExe*