### PR TITLE
docs: fix broken README.md badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 </div>
 <div align="center">
 
-[![Latest Release](https://img.shields.io/github/v/release/SjnExe/AddonExe?label=latest%20version&display_name=tag&style=for-the-badge)](https://github.com/SjnExe/AddonExe/releases/latest)
+[![Latest Release](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2FSjnExe%2FAddonExe%2Fmain%2Fpackage.json&query=%24.version&prefix=v&label=latest%20version&style=for-the-badge&color=blue)](https://github.com/SjnExe/AddonExe/releases/latest)
 [![GitHub All Releases](https://img.shields.io/github/downloads/SjnExe/AddonExe/total?style=for-the-badge)](https://github.com/SjnExe/AddonExe/releases/latest)
 ![Minecraft BE Version](https://img.shields.io/badge/Minecraft_BE-26.20.0%2B-brightgreen?style=for-the-badge&logo=minecraft)
-[![GitHub Issues](https://img.shields.io/github/issues/SjnExe/AddonExe?style=for-the-badge&logo=github)](https://github.com/SjnExe/AddonExe/issues)
+[![GitHub Issues](https://img.shields.io/github/issues-raw/SjnExe/AddonExe?style=for-the-badge&logo=github)](https://github.com/SjnExe/AddonExe/issues)
 [![Status: Stable Release](https://img.shields.io/badge/Status-Stable%20Release-green?style=for-the-badge)](https://github.com/SjnExe/AddonExe/releases/latest)
 [![Discord Server](https://img.shields.io/discord/633296555650318346?style=for-the-badge&logo=discord&logoColor=white&label=Discord&color=7289DA)](https://discord.gg/SMUHUnGyyz)
 


### PR DESCRIPTION
Replaces broken `img.shields.io/github/*` badges in `README.md` to resolve API rate-limiting errors from shields.io. The release badge has been replaced with a dynamic JSON badge reading directly from `package.json`, and the issues badge has been pointed to the `issues-raw` endpoint. This approach fixes the visual errors while maintaining the `for-the-badge` style consistency across the README.

---
*PR created automatically by Jules for task [6635655100655854106](https://jules.google.com/task/6635655100655854106) started by @SjnExe*