### PR TITLE
Refactor UI System to String Permissions (Session 5)

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -64,8 +64,8 @@ We are replacing the current single-rank, integer-based `permissionLevel` system
 
 ## Session 5: UI Refactoring
 
-- [ ] **Update UI Schema & Interfaces:** Refactor `PanelItem` in `src/core/ui/types.ts` to replace `permissionLevel?: number` with `permission?: string`.
-- [ ] **Refactor Panel Definitions:** Update `src/core/ui/panelRegistry.ts` (and any other panel definition files) to use permission strings instead of integer levels. Convert old level checks to explicit node names (e.g. `ui.panel.owner` instead of level `0`).
+- [x] **Update UI Schema & Interfaces:** Refactor `PanelItem` in `src/core/ui/types.ts` to replace `permissionLevel?: number` with `permission?: string`.
+- [x] **Refactor Panel Definitions:** Update `src/core/ui/panelRegistry.ts` (and any other panel definition files) to use permission strings instead of integer levels. Convert old level checks to explicit node names (e.g. `ui.panel.owner` instead of level `0`).
 
 ## Session 6: Command Refactoring
 
@@ -80,12 +80,12 @@ _(To be updated after each session)_
 
 **Completed in Previous Session:**
 
-- Session 1, 2, 3, and 4 completed: Updated Rank Schema, Player Data Model, stripped legacy migrations, built Permission Engine, implemented Per-Rank caching, added the universal `/scriptevent` listener and rank action handlers, and completely integrated targeting hierarchy logic (`canTarget`) to prevent lower-ranking staff from moderating higher-ranking staff across all moderation/essential commands.
+- Session 5 completed: Refactored the UI Schema and Panel Interfaces (`PanelItem`, `PanelDefinition`, `ShopListEntry`, `ShopItem`) to use `permission` string nodes instead of `permissionLevel` integers. Updated all usages in `uiUtils`, `panelBuilder`, `panelRegistry`, and all feature-specific UI Panel Handlers to evaluate permissions via the new `hasPermission` engine rather than checking raw integers.
 
 **Current State:**
 
-- Session 4 completed. CI errors related to unused `permissionLevel` variables resulting from the `canTarget` conversion have been resolved. The remaining errors and type inconsistencies trace back to interfaces currently undergoing refactor in Session 5 (and now Session 6).
+- UI Refactor is complete. All dynamic UI components now safely map interface elements using permission strings, allowing ranks to control UI visibility using specific nodes (e.g. `ui.panel.mod`).
 
 **Next Session Needs to Know:**
 
-- Execute Session 5 tasks to completely refactor UI schema to use the new string-based permission checks instead of `permissionLevel`. Following that, Session 6 will handle the refactoring of configurations and command definitions.
+- Begin Session 6: Execute Command refactoring tasks. Search the codebase to modify `commandSettings` (in config files) from using `permissionLevel: number` to `permissionNode: string`. Update slash command execution logic (`src/core/commands/` and all features) to utilize the string-based engine.

--- a/src/core/__tests__/CommandManager.test.ts
+++ b/src/core/__tests__/CommandManager.test.ts
@@ -46,7 +46,7 @@ describe('CommandManager', () => {
             commandPrefix: '!',
             commandSettings: {}
         });
-        mockGetPlayer.mockReturnValue({ permissionLevel: 1024 });
+        mockGetPlayer.mockReturnValue({ permission: 'ui.panel.member' });
         mockGetCooldown.mockReturnValue(0);
     });
 
@@ -90,7 +90,7 @@ describe('CommandManager', () => {
         const cmd = {
             name: 'testint',
             description: '',
-            permissionLevel: 1024,
+            permission: 'ui.panel.member',
             parameters: [{ name: 'val', type: 'int' }],
             execute
         };

--- a/src/core/__tests__/Economy.test.ts
+++ b/src/core/__tests__/Economy.test.ts
@@ -23,7 +23,7 @@ vi.mock('../configManager.js', () => ({
         },
         playerDefaults: {
             rankId: 'member',
-            permissionLevel: 1024,
+            permission: 'ui.panel.member',
             xrayNotificationsEnabled: false
         }
     })

--- a/src/core/__tests__/UI-DynamicPanels.test.ts
+++ b/src/core/__tests__/UI-DynamicPanels.test.ts
@@ -7,7 +7,7 @@ vi.mock('../configManager.js', () => ({
     getConfig: vi.fn().mockReturnValue({})
 }));
 vi.mock('../rankManager.js', () => ({
-    getPlayerRank: vi.fn().mockReturnValue({ permissionLevel: 0 })
+    getPlayerRank: vi.fn().mockReturnValue({ permission: 'ui.panel.owner' })
 }));
 vi.mock('../playerDataManager.js', () => ({
     getVisiblePlayers: vi.fn().mockReturnValue([]),

--- a/src/core/__tests__/UI-Handlers.test.ts
+++ b/src/core/__tests__/UI-Handlers.test.ts
@@ -7,7 +7,7 @@ vi.mock('../configManager.js', () => ({
     getConfig: vi.fn().mockReturnValue({})
 }));
 vi.mock('../rankManager.js', () => ({
-    getPlayerRank: vi.fn().mockReturnValue({ permissionLevel: 0 })
+    getPlayerRank: vi.fn().mockReturnValue({ permission: 'ui.panel.owner' })
 }));
 vi.mock('../playerDataManager.js', () => ({
     getVisiblePlayers: vi.fn().mockReturnValue([]),
@@ -29,8 +29,8 @@ describe('UI Handlers Response Logic', () => {
 
         // Mock getItems specifically for this test
         vi.spyOn(handler, 'getItems').mockResolvedValue([
-            { id: '1', actionType: 'openPanel', actionValue: 'somePanel', permissionLevel: 1024, text: 'Test' },
-            { id: '2', actionType: 'functionCall', actionValue: 'noop', permissionLevel: 1024, text: 'Test2' }
+            { id: '1', actionType: 'openPanel', actionValue: 'somePanel', permission: 'ui.panel.member', text: 'Test' },
+            { id: '2', actionType: 'functionCall', actionValue: 'noop', permission: 'ui.panel.member', text: 'Test2' }
         ]);
 
         // ActionFormData selection 0 -> openPanel

--- a/src/core/__tests__/UI-Permissions.test.ts
+++ b/src/core/__tests__/UI-Permissions.test.ts
@@ -11,10 +11,9 @@ describe('UI Permissions Integrity', () => {
             // Check the panel itself
             const isPanelSensitive = sensitiveKeywords.some((kw) => panelId.toLowerCase().includes(kw));
             if (isPanelSensitive) {
-                // If it's a sensitive panel, it should ideally have a permissionLevel <= 3
-                // (Assuming levels: 1 = Owner, 2 = Admin, 3 = Mod, 4 = Builder, 1024 = Default)
-                if (def.permissionLevel === undefined || def.permissionLevel > 3) {
-                    securityFlaws.push(`Panel ${panelId} is sensitive but has high/default permissionLevel (${def.permissionLevel})`);
+                // If it's a sensitive panel, it should ideally have a permission node other than member
+                if (def.permission === undefined || def.permission === 'ui.panel.member') {
+                    securityFlaws.push(`Panel ${panelId} is sensitive but has high/default permission (${def.permission})`);
                 }
             }
 
@@ -28,8 +27,8 @@ describe('UI Permissions Integrity', () => {
                     );
 
                     if (isItemSensitive) {
-                        if (item.permissionLevel === undefined || item.permissionLevel > 3) {
-                            securityFlaws.push(`Item '${item.text}' in panel ${panelId} is sensitive but has high/default permissionLevel (${item.permissionLevel})`);
+                        if (item.permission === undefined || item.permission === 'ui.panel.member') {
+                            securityFlaws.push(`Item '${item.text}' in panel ${panelId} is sensitive but has high/default permission (${item.permission})`);
                         }
                     }
                 }

--- a/src/core/ui/actionRegistry.ts
+++ b/src/core/ui/actionRegistry.ts
@@ -1,3 +1,4 @@
+import { hasPermission } from '@core/permissionEngine.js';
 import * as mc from '@minecraft/server';
 import { ActionFormData, ActionFormResponse, ModalFormData, ModalFormResponse } from '@minecraft/server-ui';
 
@@ -36,10 +37,9 @@ export const uiActionFunctions: Record<string, (player: mc.Player, context: UICo
 
     showRules: async (player: mc.Player) => {
         const rules = rulesManager.getRules();
-        const pData = getOrCreatePlayer(player);
 
         const rulesForm = new ActionFormData().title('§l§6Server Rules').body(rules.join('\n'));
-        const { hasPermission } = require('@core/permissionEngine.js');
+
         const isAdmin = hasPermission(player, 'ui.panel.admin');
 
         if (isAdmin) {
@@ -61,7 +61,6 @@ export const uiActionFunctions: Record<string, (player: mc.Player, context: UICo
 
     showHelpfulLinks: async (player: mc.Player) => {
         const links = helpfulLinksManager.getHelpfulLinks();
-        const pData = getOrCreatePlayer(player);
 
         const form = new ActionFormData().title('§l§9Helpful Links');
 
@@ -72,7 +71,6 @@ export const uiActionFunctions: Record<string, (player: mc.Player, context: UICo
             form.body(bodyText);
         }
 
-        const { hasPermission } = require('@core/permissionEngine.js');
         const isAdmin = hasPermission(player, 'ui.panel.admin');
 
         if (isAdmin) {

--- a/src/core/ui/actionRegistry.ts
+++ b/src/core/ui/actionRegistry.ts
@@ -39,8 +39,10 @@ export const uiActionFunctions: Record<string, (player: mc.Player, context: UICo
         const pData = getOrCreatePlayer(player);
 
         const rulesForm = new ActionFormData().title('§l§6Server Rules').body(rules.join('\n'));
+        const { hasPermission } = require('@core/permissionEngine.js');
+        const isAdmin = hasPermission(player, 'ui.panel.admin');
 
-        if (isDefined(pData) && pData.permissionLevel <= 1) {
+        if (isAdmin) {
             rulesForm.button('§l§4Edit Rules', 'textures/ui/icon_setting');
         }
 
@@ -52,7 +54,7 @@ export const uiActionFunctions: Record<string, (player: mc.Player, context: UICo
             return;
         }
 
-        if (isDefined(pData) && pData.permissionLevel <= 1 && (response as ActionFormResponse).selection === 0) {
+        if (isAdmin && (response as ActionFormResponse).selection === 0) {
             return showPanel(player, 'rulesManagementPanel');
         }
     },
@@ -70,7 +72,10 @@ export const uiActionFunctions: Record<string, (player: mc.Player, context: UICo
             form.body(bodyText);
         }
 
-        if (isDefined(pData) && pData.permissionLevel <= 1) {
+        const { hasPermission } = require('@core/permissionEngine.js');
+        const isAdmin = hasPermission(player, 'ui.panel.admin');
+
+        if (isAdmin) {
             form.button('§l§4Edit Links', 'textures/ui/icon_setting');
         }
 
@@ -82,7 +87,7 @@ export const uiActionFunctions: Record<string, (player: mc.Player, context: UICo
             return;
         }
 
-        if (isDefined(pData) && pData.permissionLevel <= 1 && (response as ActionFormResponse).selection === 0) {
+        if (isAdmin && (response as ActionFormResponse).selection === 0) {
             return showPanel(player, 'helpfulLinksManagementPanel');
         }
     },

--- a/src/core/ui/panelBuilder.ts
+++ b/src/core/ui/panelBuilder.ts
@@ -4,10 +4,10 @@ import { ActionFormData, ModalFormData } from '@minecraft/server-ui';
 import { getConfig } from '@core/configManager.js';
 import { errorLog } from '@core/logger.js';
 import { getValueFromPath } from '@core/objectUtils.js';
+import { hasPermission } from '@core/permissionEngine.js';
 import { getPlayerFromCache } from '@core/playerCache.js';
 import { getOrCreatePlayer, loadPlayerData } from '@core/playerDataManager.js';
-import { hasPermission } from '@core/permissionEngine.js';
-import { getPlayerRank } from '@core/rankManager.js';
+
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
 import { panelRouter } from '@ui/PanelRouter.js';
 import { panelDefinitions } from '@ui/panelRegistry.js';
@@ -48,7 +48,6 @@ export function getStaticMenuItems(player: mc.Player, panelDef: PanelDefinition,
 
 export async function buildPanelForm(player: mc.Player, panelId: string, context: UIContext): Promise<ActionFormData | ModalFormData | undefined> {
     try {
-        const config = getConfig();
         const panelDef = panelDefinitions[panelId];
         if (panelDef && isNonEmptyString(panelDef.permission) && !hasPermission(player, panelDef.permission)) {
             // Access Denied

--- a/src/core/ui/panelBuilder.ts
+++ b/src/core/ui/panelBuilder.ts
@@ -6,13 +6,14 @@ import { errorLog } from '@core/logger.js';
 import { getValueFromPath } from '@core/objectUtils.js';
 import { getPlayerFromCache } from '@core/playerCache.js';
 import { getOrCreatePlayer, loadPlayerData } from '@core/playerDataManager.js';
+import { hasPermission } from '@core/permissionEngine.js';
 import { getPlayerRank } from '@core/rankManager.js';
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
 import { panelRouter } from '@ui/PanelRouter.js';
 import { panelDefinitions } from '@ui/panelRegistry.js';
 import { MainConfig, PanelDefinition, PanelItem, UIContext } from '@ui/types.js';
 
-export function getStaticMenuItems(panelDef: PanelDefinition, permissionLevel: number, context?: UIContext): PanelItem[] {
+export function getStaticMenuItems(player: mc.Player, panelDef: PanelDefinition, context?: UIContext): PanelItem[] {
     const config = getConfig() as unknown as MainConfig;
     const items = (isDefined(panelDef.items) ? panelDef.items : [])
         .filter((item: PanelItem) => {
@@ -25,7 +26,7 @@ export function getStaticMenuItems(panelDef: PanelDefinition, permissionLevel: n
                 // Fallback for older hardcoded definition
                 return false;
             }
-            return permissionLevel <= item.permissionLevel;
+            return hasPermission(player, item.permission ?? 'ui.panel.member');
         })
         .toSorted((a: PanelItem, b: PanelItem) => (a.sortId ?? 0) - (b.sortId ?? 0));
 
@@ -37,7 +38,7 @@ export function getStaticMenuItems(panelDef: PanelDefinition, permissionLevel: n
             id: '__back__',
             text: '§l§8< Back',
             icon: 'textures/gui/controls/left.png',
-            permissionLevel: 1024,
+            permission: 'ui.panel.member',
             actionType: 'openPanel',
             actionValue: isDefined(context) && isNonEmptyString(context.returnPanel) ? context.returnPanel : (panelDef.parentPanelId as string)
         });
@@ -48,11 +49,8 @@ export function getStaticMenuItems(panelDef: PanelDefinition, permissionLevel: n
 export async function buildPanelForm(player: mc.Player, panelId: string, context: UIContext): Promise<ActionFormData | ModalFormData | undefined> {
     try {
         const config = getConfig();
-        const rank = getPlayerRank(player, config);
-        const permissionLevel = rank.permissionLevel;
-
         const panelDef = panelDefinitions[panelId];
-        if (panelDef && typeof panelDef.permissionLevel === 'number' && permissionLevel > panelDef.permissionLevel) {
+        if (panelDef && isNonEmptyString(panelDef.permission) && !hasPermission(player, panelDef.permission)) {
             // Access Denied
             return undefined;
         }
@@ -74,7 +72,7 @@ export async function buildPanelForm(player: mc.Player, panelId: string, context
 
         // 2. Fallback: Static Definition
         if (isDefined(panelDef)) {
-            const items = getStaticMenuItems(panelDef, permissionLevel, context);
+            const items = getStaticMenuItems(player, panelDef, context);
             if (items.length > 0 || isDefined(panelDef.parentPanelId) || isNonEmptyString(context.returnPanel)) {
                 return buildActionFormFromItems(player, panelId, context, items);
             }

--- a/src/core/ui/panelRegistry.ts
+++ b/src/core/ui/panelRegistry.ts
@@ -18,7 +18,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'economy',
                 text: '§l§6Economy',
                 icon: 'textures/items/emerald',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'openPanel',
                 actionValue: 'economyMainPanel',
                 sortId: 10
@@ -27,7 +27,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'social',
                 text: '§l§dSocial',
                 icon: 'textures/ui/icon_multiplayer',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'openPanel',
                 actionValue: 'socialMainPanel',
                 sortId: 15
@@ -36,7 +36,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'profile',
                 text: '§l§3Profile',
                 icon: 'textures/ui/profile_glyph_color',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'openPanel',
                 actionValue: 'profileMainPanel',
                 sortId: 20
@@ -45,7 +45,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'info',
                 text: '§l§bServer Info',
                 icon: 'textures/items/book_enchanted.png',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'openPanel',
                 actionValue: 'infoPanel',
                 sortId: 30
@@ -54,7 +54,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'staffDashboard',
                 text: '§l§4Staff Dashboard',
                 icon: 'textures/ui/op',
-                permissionLevel: 3, // Accessible to moderators (3) and up, items inside dictate further restrictions
+                permission: 'ui.panel.mod', // Accessible to moderators (3) and up, items inside dictate further restrictions
                 actionType: 'openPanel',
                 actionValue: 'staffDashboardPanel',
                 sortId: 99
@@ -69,7 +69,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'shop',
                 text: '§2Shop',
                 icon: 'textures/ui/trade_icon',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'openPanel',
                 actionValue: 'shopMainPanel',
                 requiresFeature: 'shop.enabled',
@@ -79,7 +79,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'auctionHouse',
                 text: '§6Auction House',
                 icon: 'textures/items/gold_ingot',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'functionCall',
                 actionValue: 'openAuctionHouse',
                 // Assuming auctionHouse config exists similarly. Leaving without requiresFeature for now if unknown.
@@ -89,7 +89,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'bountyList',
                 text: '§4Bounty List',
                 icon: 'textures/items/netherite_sword.png',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'openPanel',
                 actionValue: 'bountyListPanel',
                 sortId: 30
@@ -104,7 +104,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'playerList',
                 text: '§2Player List',
                 icon: 'textures/ui/icon_steve.png',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'openPanel',
                 actionValue: 'playerListPanel',
                 sortId: 10
@@ -113,7 +113,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'team',
                 text: '§1Team',
                 icon: 'textures/ui/icon_multiplayer.png',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'openPanel',
                 actionValue: 'teamMainPanel',
                 sortId: 20
@@ -122,7 +122,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'friend',
                 text: '§5Friends',
                 icon: 'textures/ui/icon_steve',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'openPanel',
                 actionValue: 'friendMainPanel',
                 sortId: 25
@@ -137,7 +137,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'myStats',
                 text: '§3My Stats',
                 icon: 'textures/ui/profile_glyph_color.png',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'openPanel',
                 actionValue: 'myStatsPanel',
                 sortId: 10
@@ -146,7 +146,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'tpaSettings',
                 text: '§5TPA Settings',
                 icon: 'textures/items/ender_pearl',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'openPanel',
                 actionValue: 'tpaSettingsPanel',
                 sortId: 20
@@ -196,7 +196,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'rules',
                 text: '§9Rules',
                 icon: 'textures/items/book_enchanted.png',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'functionCall',
                 actionValue: 'showRules',
                 sortId: 10
@@ -205,7 +205,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'helpfulLinks',
                 text: '§9Helpful Links',
                 icon: 'textures/items/chain',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'functionCall',
                 actionValue: 'showHelpfulLinks',
                 sortId: 20
@@ -215,13 +215,13 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
     staffDashboardPanel: {
         title: 'Staff Dashboard',
         parentPanelId: 'mainPanel',
-        permissionLevel: 3,
+        permission: 'ui.panel.mod',
         items: [
             {
                 id: 'reportManagement',
                 text: '§4Report Management',
                 icon: 'textures/ui/WarningGlyph',
-                permissionLevel: 3,
+                permission: 'ui.panel.mod',
                 actionType: 'openPanel',
                 actionValue: 'reportListPanel',
                 sortId: 10
@@ -230,7 +230,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'playerManagement',
                 text: '§3Player Management',
                 icon: 'textures/ui/icon_multiplayer.png',
-                permissionLevel: 3,
+                permission: 'ui.panel.mod',
                 actionType: 'openPanel',
                 actionValue: 'playerManagementPanel',
                 sortId: 20
@@ -239,7 +239,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'moderation',
                 text: '§4Moderation',
                 icon: 'textures/ui/hammer_l.png',
-                permissionLevel: 3,
+                permission: 'ui.panel.mod',
                 actionType: 'openPanel',
                 actionValue: 'moderationPanel',
                 sortId: 30
@@ -248,7 +248,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'floatingText',
                 text: '§5Floating Text',
                 icon: 'textures/ui/text_color_paintbrush',
-                permissionLevel: 1, // Restrict to admin
+                permission: 'ui.panel.admin', // Restrict to admin
                 actionType: 'openPanel',
                 actionValue: 'floatingTextListPanel',
                 sortId: 40
@@ -257,7 +257,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'config',
                 text: '§8Config',
                 icon: 'textures/ui/settings_glyph_color_2x',
-                permissionLevel: 1, // Restrict to admin
+                permission: 'ui.panel.admin', // Restrict to admin
                 actionType: 'openPanel',
                 actionValue: 'configCategoryPanel',
                 sortId: 50
@@ -282,7 +282,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'viewInvites',
                 text: 'View Invites',
                 icon: 'textures/ui/mail_icon',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'openPanel',
                 actionValue: 'teamInvitesPanel'
             },
@@ -290,7 +290,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'searchTeam',
                 text: 'Search Team ID',
                 icon: 'textures/ui/magnifyingGlass',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'openPanel',
                 actionValue: 'teamSearchPanel'
             },
@@ -298,7 +298,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'browseTeam',
                 text: 'Browse Team',
                 icon: 'textures/ui/world_glyph_color',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'openPanel',
                 actionValue: 'teamBrowserPanel'
             }
@@ -362,7 +362,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
     reportListPanel: {
         title: 'Active Reports',
         parentPanelId: 'staffDashboardPanel',
-        permissionLevel: 3,
+        permission: 'ui.panel.mod',
         items: [] // Dynamically populated
     },
     reportActionsPanel: {
@@ -373,7 +373,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'assignReport',
                 text: 'Assign to Me',
                 icon: 'textures/ui/profile_glyph_color.png',
-                permissionLevel: 3,
+                permission: 'ui.panel.mod',
                 actionType: 'functionCall',
                 actionValue: 'assignReport'
             },
@@ -381,7 +381,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'resolveReport',
                 text: 'Mark as Resolved',
                 icon: 'textures/ui/check.png',
-                permissionLevel: 3,
+                permission: 'ui.panel.mod',
                 actionType: 'functionCall',
                 actionValue: 'resolveReport'
             },
@@ -389,7 +389,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'clearReport',
                 text: 'Clear Report',
                 icon: 'textures/ui/trash.png',
-                permissionLevel: 3,
+                permission: 'ui.panel.mod',
                 actionType: 'functionCall',
                 actionValue: 'clearReport'
             }
@@ -408,13 +408,13 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
     moderationPanel: {
         title: 'Moderation Tools',
         parentPanelId: 'staffDashboardPanel',
-        permissionLevel: 3,
+        permission: 'ui.panel.mod',
         items: [
             {
                 id: 'unbanPlayer',
                 text: 'Unban Player',
                 icon: 'textures/ui/check.png',
-                permissionLevel: 3,
+                permission: 'ui.panel.mod',
                 actionType: 'functionCall',
                 actionValue: 'showUnbanForm'
             },
@@ -422,7 +422,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'unmutePlayer',
                 text: 'Unmute Player',
                 icon: 'textures/ui/mute_off.png',
-                permissionLevel: 3,
+                permission: 'ui.panel.mod',
                 actionType: 'functionCall',
                 actionValue: 'showUnmuteForm'
             }
@@ -431,13 +431,13 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
     configCategoryPanel: {
         title: 'Configuration',
         parentPanelId: 'staffDashboardPanel',
-        permissionLevel: 1,
+        permission: 'ui.panel.admin',
         items: [
             {
                 id: 'worldProtection',
                 text: 'World Protection',
                 icon: 'textures/ui/icon_recipe_nature',
-                permissionLevel: 1,
+                permission: 'ui.panel.admin',
                 actionType: 'openPanel',
                 actionValue: 'worldProtectionListPanel',
                 sortId: 90
@@ -446,7 +446,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'configTransfer',
                 text: 'Export/Import Configs',
                 icon: 'textures/ui/refresh',
-                permissionLevel: 0, // Only highest permission level
+                permission: 'ui.panel.owner', // Only highest permission level
                 actionType: 'openPanel',
                 actionValue: 'configTransferPanel',
                 sortId: 100
@@ -456,13 +456,13 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
     configTransferPanel: {
         title: 'Configuration Transfer',
         parentPanelId: 'configCategoryPanel',
-        permissionLevel: 0,
+        permission: 'ui.panel.owner',
         items: [
             {
                 id: 'exportConfig',
                 text: 'Export Configurations',
                 icon: 'textures/ui/arrow_right',
-                permissionLevel: 0,
+                permission: 'ui.panel.owner',
                 actionType: 'openPanel',
                 actionValue: 'configExportPanel'
             },
@@ -470,7 +470,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'importConfig',
                 text: 'Import Configurations',
                 icon: 'textures/ui/arrow_left',
-                permissionLevel: 0,
+                permission: 'ui.panel.owner',
                 actionType: 'openPanel',
                 actionValue: 'configImportPanel'
             }
@@ -479,13 +479,13 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
     configExportPanel: {
         title: 'Export Config',
         parentPanelId: 'configTransferPanel',
-        permissionLevel: 0,
+        permission: 'ui.panel.owner',
         items: [] // Modal
     },
     configImportPanel: {
         title: 'Import Config',
         parentPanelId: 'configTransferPanel',
-        permissionLevel: 0,
+        permission: 'ui.panel.owner',
         items: [] // Modal
     },
     worldProtectionListPanel: {
@@ -516,7 +516,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'addRank',
                 text: 'Create New Rank',
                 icon: 'textures/ui/color_plus',
-                permissionLevel: 1,
+                permission: 'ui.panel.admin',
                 actionType: 'openPanel',
                 actionValue: 'addRankPanel',
                 sortId: 0 // Show first
@@ -525,7 +525,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'rankSettings',
                 text: 'Settings',
                 icon: 'textures/ui/settings_glyph_color_2x',
-                permissionLevel: 1,
+                permission: 'ui.panel.admin',
                 actionType: 'openPanel',
                 actionValue: 'rankSettingsPanel',
                 sortId: 1
@@ -551,7 +551,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
     playerManagementPanel: {
         title: 'Player Management',
         parentPanelId: 'staffDashboardPanel',
-        permissionLevel: 3,
+        permission: 'ui.panel.mod',
         items: [] // Dynamically populated
     },
     playerListPanel: {
@@ -567,7 +567,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'setBounty',
                 text: 'Set Bounty',
                 icon: 'textures/ui/realms_green_check.png',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'functionCall',
                 actionValue: 'bountyPlayer',
                 sortId: 10
@@ -576,7 +576,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'removePlayerBounty',
                 text: 'Remove Bounty',
                 icon: 'textures/ui/cancel.png',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'functionCall',
                 actionValue: 'removePlayerBounty',
                 sortId: 20
@@ -592,7 +592,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'kick',
                 text: 'Kick',
                 icon: 'textures/ui/cancel.png',
-                permissionLevel: 3,
+                permission: 'ui.panel.mod',
                 actionType: 'functionCall',
                 actionValue: 'kickPlayer'
             },
@@ -600,7 +600,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'mute',
                 text: 'Mute',
                 icon: 'textures/ui/mute_on.png',
-                permissionLevel: 3,
+                permission: 'ui.panel.mod',
                 actionType: 'functionCall',
                 actionValue: 'mutePlayer'
             },
@@ -608,7 +608,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'unmute',
                 text: 'Unmute',
                 icon: 'textures/ui/mute_off.png',
-                permissionLevel: 3,
+                permission: 'ui.panel.mod',
                 actionType: 'functionCall',
                 actionValue: 'unmutePlayer'
             },
@@ -616,7 +616,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'ban',
                 text: 'Ban',
                 icon: 'textures/ui/hammer_l.png',
-                permissionLevel: 3,
+                permission: 'ui.panel.mod',
                 actionType: 'functionCall',
                 actionValue: 'banPlayer'
             },
@@ -624,7 +624,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'freeze',
                 text: 'Freeze',
                 icon: 'textures/ui/icon_lock.png',
-                permissionLevel: 3,
+                permission: 'ui.panel.mod',
                 actionType: 'functionCall',
                 actionValue: 'freezePlayer'
             },
@@ -632,7 +632,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'unfreeze',
                 text: 'Unfreeze',
                 icon: 'textures/ui/icon_unlocked.png',
-                permissionLevel: 3,
+                permission: 'ui.panel.mod',
                 actionType: 'functionCall',
                 actionValue: 'unfreezePlayer'
             },
@@ -641,7 +641,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'tpa',
                 text: 'TPA',
                 icon: 'textures/gui/controls/jump.png',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'functionCall',
                 actionValue: 'tpaPlayer',
                 sortId: 10
@@ -650,7 +650,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'tpahere',
                 text: 'TPAHere',
                 icon: 'textures/gui/controls/sneak.png',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'functionCall',
                 actionValue: 'tpaherePlayer',
                 sortId: 20
@@ -659,7 +659,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'bounty',
                 text: 'Bounty',
                 icon: 'textures/items/netherite_sword.png',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'openPanel',
                 actionValue: 'bountyActionsPanel',
                 sortId: 30
@@ -668,7 +668,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'report',
                 text: 'Report Player',
                 icon: 'textures/ui/WarningGlyph',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'functionCall',
                 actionValue: 'reportPlayer',
                 sortId: 40
@@ -743,7 +743,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'economyGeneralSettings',
                 text: 'General Settings',
                 icon: 'textures/ui/settings_glyph_color_2x',
-                permissionLevel: 1,
+                permission: 'ui.panel.admin',
                 actionType: 'openPanel',
                 actionValue: 'config_economyGeneralSettings'
             },
@@ -751,7 +751,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'mobDropsSystemPanel',
                 text: 'Mob Drops System',
                 icon: 'textures/items/bone',
-                permissionLevel: 1,
+                permission: 'ui.panel.admin',
                 actionType: 'openPanel',
                 actionValue: 'mobDropsSystemPanel'
             },
@@ -759,7 +759,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'stealSystem',
                 text: 'Steal System',
                 icon: 'textures/items/iron_sword',
-                permissionLevel: 1,
+                permission: 'ui.panel.admin',
                 actionType: 'openPanel',
                 actionValue: 'config_stealSystem'
             },
@@ -767,7 +767,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'pvpSystem',
                 text: 'PvP System',
                 icon: 'textures/items/diamond_sword',
-                permissionLevel: 1,
+                permission: 'ui.panel.admin',
                 actionType: 'openPanel',
                 actionValue: 'config_pvpSystem'
             }
@@ -781,7 +781,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'addMobDrop',
                 text: 'Add New Mob',
                 icon: 'textures/ui/realms_green_check.png',
-                permissionLevel: 1,
+                permission: 'ui.panel.admin',
                 actionType: 'openPanel',
                 actionValue: 'addMobDropPanel'
             }
@@ -805,7 +805,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'addXrayOre',
                 text: 'Add New Ore',
                 icon: 'textures/ui/color_plus',
-                permissionLevel: 1,
+                permission: 'ui.panel.admin',
                 actionType: 'openPanel',
                 actionValue: 'addXrayOrePanel'
             }
@@ -839,7 +839,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'generalSettings',
                 text: 'General Settings',
                 icon: 'textures/ui/settings_glyph_color_2x',
-                permissionLevel: 1,
+                permission: 'ui.panel.admin',
                 actionType: 'openPanel',
                 actionValue: 'config_sidebar'
             },
@@ -847,7 +847,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'sidebarLines',
                 text: 'Scoreboard (Global)',
                 icon: 'textures/ui/text_color_paintbrush',
-                permissionLevel: 1,
+                permission: 'ui.panel.admin',
                 actionType: 'openPanel',
                 actionValue: 'sidebarLinesPanel'
             },
@@ -855,7 +855,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'actionBarLines',
                 text: 'Action Bar (Personal)',
                 icon: 'textures/ui/text_color_paintbrush',
-                permissionLevel: 1,
+                permission: 'ui.panel.admin',
                 actionType: 'openPanel',
                 actionValue: 'actionBarLinesPanel'
             },
@@ -863,7 +863,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
                 id: 'placeholders',
                 text: 'Placeholder List',
                 icon: 'textures/ui/infobulb',
-                permissionLevel: 1,
+                permission: 'ui.panel.admin',
                 actionType: 'openPanel',
                 actionValue: 'placeholderListPanel'
             }

--- a/src/core/ui/panels/adminPanel.ts
+++ b/src/core/ui/panels/adminPanel.ts
@@ -15,13 +15,13 @@ export class AdminPanelHandler implements IPanelHandler {
         return panelId === 'staffDashboardPanel' || panelId.startsWith('floatingText');
     }
 
-    getItems(_player: mc.Player, panelId: string, _context: UIContext): Promise<PanelItem[]> {
+    getItems(player: mc.Player, panelId: string, _context: UIContext): Promise<PanelItem[]> {
         const items: PanelItem[] = [];
         // Admin Panel uses static items (delegates to sub-panels)
         if (panelId === 'staffDashboardPanel') {
             const def = panelDefinitions[panelId];
             if (isDefined(def)) {
-                const staticItems = getStaticMenuItems(def, 1); // Admin
+                const staticItems = getStaticMenuItems(player, def);
                 items.push(...staticItems);
             }
             return Promise.resolve(items);
@@ -34,7 +34,7 @@ export class AdminPanelHandler implements IPanelHandler {
                     id: 'placeholderList',
                     text: '§l§6View Placeholders',
                     icon: 'textures/ui/icon_sign',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'openPanel',
                     actionValue: 'placeholderListPanel'
                 },
@@ -42,7 +42,7 @@ export class AdminPanelHandler implements IPanelHandler {
                     id: 'create',
                     text: '§l§2+ Create New',
                     icon: 'textures/ui/color_plus',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'openPanel',
                     actionValue: 'floatingTextCreatePanel'
                 }
@@ -53,7 +53,7 @@ export class AdminPanelHandler implements IPanelHandler {
                 items.push({
                     id: text.id,
                     text: `§6${text.id}§r\n${formatLocation(text.location)}`,
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'openPanel',
                     actionValue: 'floatingTextActionPanel'
                 });
@@ -68,7 +68,7 @@ export class AdminPanelHandler implements IPanelHandler {
                     id: 'edit',
                     text: 'Edit Settings',
                     icon: 'textures/ui/icon_setting',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'openPanel',
                     actionValue: 'floatingTextEditPanel'
                 },
@@ -76,7 +76,7 @@ export class AdminPanelHandler implements IPanelHandler {
                     id: 'respawn',
                     text: 'Respawn Entity',
                     icon: 'textures/ui/refresh_light',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'functionCall',
                     actionValue: 'respawnText'
                 },
@@ -84,7 +84,7 @@ export class AdminPanelHandler implements IPanelHandler {
                     id: 'despawn',
                     text: 'Despawn Entity',
                     icon: 'textures/ui/cancel',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'functionCall',
                     actionValue: 'despawnText'
                 },
@@ -92,7 +92,7 @@ export class AdminPanelHandler implements IPanelHandler {
                     id: 'delete',
                     text: '§4Delete Text',
                     icon: 'textures/ui/trash',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'functionCall',
                     actionValue: 'deleteText'
                 }

--- a/src/core/ui/panels/commandPanel.ts
+++ b/src/core/ui/panels/commandPanel.ts
@@ -43,7 +43,7 @@ export class CommandPanelHandler implements IPanelHandler {
                     id: cmd.name,
                     text: `${color}/${cmd.name}§r\nPerm: ${perm}`,
                     icon: 'textures/ui/command_block_icon',
-                    permissionLevel: 0,
+                    permission: 'ui.panel.owner',
                     actionType: 'openPanel',
                     actionValue: `commandSettingsPanel_${cmd.name}`
                 });

--- a/src/core/ui/panels/configPanel.ts
+++ b/src/core/ui/panels/configPanel.ts
@@ -1,3 +1,4 @@
+import { hasPermission } from "@core/permissionEngine.js";
 import * as mc from '@minecraft/server';
 import { ActionFormResponse, ModalFormData, ModalFormResponse } from '@minecraft/server-ui';
 
@@ -40,41 +41,41 @@ export class ConfigPanelHandler implements IPanelHandler {
     }
 
     getItems(player: mc.Player, panelId: string, context: UIContext): Promise<PanelItem[]> {
-        const pData: PlayerData = getOrCreatePlayer(player);
+
 
         if (panelId === 'configCategoryPanel') {
-            return Promise.resolve(this.getCategoryPanelItems(pData, context));
+            return Promise.resolve(this.getCategoryPanelItems(player, context));
         }
 
         if (panelId.startsWith('configSubCategoryPanel_')) {
             const category = panelId.replace('configSubCategoryPanel_', '');
-            return Promise.resolve(this.getSubCategoryPanelItems(pData, category, context));
+            return Promise.resolve(this.getSubCategoryPanelItems(player, category, context));
         }
 
         if (panelId === 'configResetPanel') {
-            return Promise.resolve(this.getResetPanelItems(pData, context));
+            return Promise.resolve(this.getResetPanelItems(player, context));
         }
 
         if (panelId.startsWith('configResetCategoryPanel_')) {
             const category = panelId.replace('configResetCategoryPanel_', '');
-            return Promise.resolve(this.getResetCategoryPanelItems(pData, category, context));
+            return Promise.resolve(this.getResetCategoryPanelItems(player, category, context));
         }
 
         if (panelId === 'configTransferPanel') {
-            return Promise.resolve(this.getTransferPanelItems(pData, context));
+            return Promise.resolve(this.getTransferPanelItems(player, context));
         }
 
         return Promise.resolve([]);
     }
 
-    private getTransferPanelItems(_pData: PlayerData, _context: UIContext): PanelItem[] {
+    private getTransferPanelItems(player: mc.Player, _context: UIContext): PanelItem[] {
         const items: PanelItem[] = [];
         addBackButton(items, 'configCategoryPanel');
         items.push({
             id: 'exportConfig',
             text: 'Export Configurations',
             icon: 'textures/ui/arrow_right',
-            permissionLevel: 0,
+            permission: 'ui.panel.owner',
             actionType: 'openPanel',
             actionValue: 'configExportPanel'
         });
@@ -82,19 +83,19 @@ export class ConfigPanelHandler implements IPanelHandler {
             id: 'importConfig',
             text: 'Import Configurations',
             icon: 'textures/ui/arrow_left',
-            permissionLevel: 0,
+            permission: 'ui.panel.owner',
             actionType: 'openPanel',
             actionValue: 'configImportPanel'
         });
         return items;
     }
 
-    private getCategoryPanelItems(pData: PlayerData, context: UIContext): PanelItem[] {
+    private getCategoryPanelItems(player: mc.Player, context: UIContext): PanelItem[] {
         const items: PanelItem[] = [];
         addBackButton(items, 'staffDashboardPanel');
-        const categories = getVisibleCategories(pData);
+        const categories = getVisibleCategories(player);
 
-        if (pData.permissionLevel === 0) {
+        if (hasPermission(player, 'ui.panel.owner')) {
             categories.push({
                 id: 'resetSettings',
                 title: '§l§cReset Settings§r',
@@ -111,7 +112,7 @@ export class ConfigPanelHandler implements IPanelHandler {
                     id: 'resetSettings',
                     text: '§l§cReset Settings§r',
                     icon: 'textures/ui/wysiwyg_reset',
-                    permissionLevel: 0,
+                    permission: 'ui.panel.owner',
                     actionType: 'openPanel',
                     actionValue: 'configResetPanel'
                 });
@@ -120,7 +121,7 @@ export class ConfigPanelHandler implements IPanelHandler {
                     id: cat.id,
                     text: cat.title,
                     icon: cat.icon,
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'openPanel',
                     actionValue: `configSubCategoryPanel_${cat.id}`
                 });
@@ -131,10 +132,10 @@ export class ConfigPanelHandler implements IPanelHandler {
         return items;
     }
 
-    private getSubCategoryPanelItems(pData: PlayerData, category: string, context: UIContext): PanelItem[] {
+    private getSubCategoryPanelItems(player: mc.Player, category: string, context: UIContext): PanelItem[] {
         const items: PanelItem[] = [];
         addBackButton(items, 'configCategoryPanel');
-        const systems = getSystemsByCategory(pData, category);
+        const systems = getSystemsByCategory(player, category);
         const paginated = getPaginatedItems(systems, (context.page as number) || 1);
         for (const sys of paginated) {
             if (!isDefined(sys)) continue;
@@ -142,7 +143,7 @@ export class ConfigPanelHandler implements IPanelHandler {
                 id: sys.id,
                 text: sys.title,
                 icon: sys.icon,
-                permissionLevel: 1,
+                permission: 'ui.panel.admin',
                 actionType: 'openPanel',
                 actionValue: sys.id
             });
@@ -151,10 +152,10 @@ export class ConfigPanelHandler implements IPanelHandler {
         return items;
     }
 
-    private getResetPanelItems(pData: PlayerData, context: UIContext): PanelItem[] {
+    private getResetPanelItems(player: mc.Player, context: UIContext): PanelItem[] {
         const items: PanelItem[] = [];
         addBackButton(items, 'configCategoryPanel');
-        const categories = getVisibleCategories(pData);
+        const categories = getVisibleCategories(player);
 
         categories.push({
             id: 'resetAll',
@@ -171,7 +172,7 @@ export class ConfigPanelHandler implements IPanelHandler {
                     id: 'resetAll',
                     text: '§l§4Reset All Systems',
                     icon: 'textures/ui/trash',
-                    permissionLevel: 0,
+                    permission: 'ui.panel.owner',
                     actionType: 'functionCall',
                     actionValue: 'resetAllConfig'
                 });
@@ -180,7 +181,7 @@ export class ConfigPanelHandler implements IPanelHandler {
                     id: cat.id,
                     text: `Reset ${cat.title}`,
                     icon: cat.icon,
-                    permissionLevel: 0,
+                    permission: 'ui.panel.owner',
                     actionType: 'openPanel',
                     actionValue: `configResetCategoryPanel_${cat.id}`
                 });
@@ -191,17 +192,17 @@ export class ConfigPanelHandler implements IPanelHandler {
         return items;
     }
 
-    private getResetCategoryPanelItems(pData: PlayerData, category: string, context: UIContext): PanelItem[] {
+    private getResetCategoryPanelItems(player: mc.Player, category: string, context: UIContext): PanelItem[] {
         const items: PanelItem[] = [];
         addBackButton(items, 'configResetPanel');
-        const systems = getSystemsByCategory(pData, category);
+        const systems = getSystemsByCategory(player, category);
         const paginated = getPaginatedItems(systems, (context.page as number) || 1);
 
         items.push({
             id: 'resetCategory',
             text: `§l§4Reset All ${category}§r`,
             icon: 'textures/ui/trash',
-            permissionLevel: 0,
+            permission: 'ui.panel.owner',
             actionType: 'functionCall',
             actionValue: `resetCategory_${category}`
         });
@@ -212,7 +213,7 @@ export class ConfigPanelHandler implements IPanelHandler {
                 id: sys.id,
                 text: `§4Reset ${sys.title}`,
                 icon: sys.icon,
-                permissionLevel: 0,
+                permission: 'ui.panel.owner',
                 actionType: 'functionCall',
                 actionValue: `resetSystem_${sys.id}`
             });
@@ -416,9 +417,8 @@ export class ConfigPanelHandler implements IPanelHandler {
     }
 
     private async handleResetCategory(player: mc.Player, category: string, panelId: string, context: UIContext): Promise<void> {
-        const pData = getOrCreatePlayer(player);
         // Removed dynamic import of getSystemsByCategory as it caused shadowing
-        const systems = getSystemsByCategory(pData, category);
+        const systems = getSystemsByCategory(player, category);
 
         await showConfirmationDialog(player, {
             title: `Reset ${category}`,

--- a/src/core/ui/panels/configPanel.ts
+++ b/src/core/ui/panels/configPanel.ts
@@ -1,4 +1,4 @@
-import { hasPermission } from "@core/permissionEngine.js";
+import { hasPermission } from '@core/permissionEngine.js';
 import * as mc from '@minecraft/server';
 import { ActionFormResponse, ModalFormData, ModalFormResponse } from '@minecraft/server-ui';
 
@@ -7,7 +7,6 @@ import { refreshXrayCache } from '@features/anticheat/xrayDetection.js';
 import { resetConfigSection } from '@core/configManager.js';
 import { errorLog } from '@core/logger.js';
 import { getValueFromPath, setValueByPath } from '@core/objectUtils.js';
-import { getOrCreatePlayer, type PlayerData } from '@core/playerDataManager.js';
 import { showPanel } from '@core/uiManager.js';
 import * as utils from '@core/utils.js';
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
@@ -41,8 +40,6 @@ export class ConfigPanelHandler implements IPanelHandler {
     }
 
     getItems(player: mc.Player, panelId: string, context: UIContext): Promise<PanelItem[]> {
-
-
         if (panelId === 'configCategoryPanel') {
             return Promise.resolve(this.getCategoryPanelItems(player, context));
         }
@@ -68,7 +65,7 @@ export class ConfigPanelHandler implements IPanelHandler {
         return Promise.resolve([]);
     }
 
-    private getTransferPanelItems(player: mc.Player, _context: UIContext): PanelItem[] {
+    private getTransferPanelItems(_player: mc.Player, _context: UIContext): PanelItem[] {
         const items: PanelItem[] = [];
         addBackButton(items, 'configCategoryPanel');
         items.push({

--- a/src/core/ui/panels/generalPanel.ts
+++ b/src/core/ui/panels/generalPanel.ts
@@ -1,8 +1,6 @@
 import * as mc from '@minecraft/server';
 import { ActionFormResponse } from '@minecraft/server-ui';
 
-import { getConfig } from '@core/configManager.js';
-import { getPlayerRank } from '@core/rankManager.js';
 import { showPanel } from '@core/uiManager.js';
 import { isDefined } from '@lib/guards.js';
 import { getStaticMenuItems } from '@ui/panelBuilder.js';

--- a/src/core/ui/panels/generalPanel.ts
+++ b/src/core/ui/panels/generalPanel.ts
@@ -25,9 +25,7 @@ export class GeneralPanelHandler implements IPanelHandler {
         const items: PanelItem[] = [];
         const def = panelDefinitions[panelId];
         if (isDefined(def)) {
-            const config = getConfig();
-            const rank = getPlayerRank(player, config);
-            const staticItems = getStaticMenuItems(def, rank.permissionLevel);
+            const staticItems = getStaticMenuItems(player, def);
             items.push(...staticItems);
         }
         return Promise.resolve(items);

--- a/src/core/ui/panels/infoPanel.ts
+++ b/src/core/ui/panels/infoPanel.ts
@@ -1,3 +1,4 @@
+import { hasPermission } from '@core/permissionEngine.js';
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 import * as mc from '@minecraft/server';
 import { ActionFormResponse, ModalFormData, ModalFormResponse } from '@minecraft/server-ui';
@@ -61,7 +62,7 @@ export class InfoPanelHandler implements IPanelHandler {
         if (panelId === 'ruleActionPanel') {
             const items: PanelItem[] = [];
             addBackButton(items, 'rulesManagementPanel');
-            const { hasPermission } = require('@core/permissionEngine.js');
+
             if (hasPermission(player, 'ui.panel.admin')) {
                 items.push({
                     id: 'delete',
@@ -82,7 +83,7 @@ export class InfoPanelHandler implements IPanelHandler {
         if (panelId === 'helpfulLinkActionPanel') {
             const items: PanelItem[] = [];
             addBackButton(items, 'helpfulLinksManagementPanel');
-            const { hasPermission } = require('@core/permissionEngine.js');
+
             if (hasPermission(player, 'ui.panel.admin')) {
                 items.push({
                     id: 'delete',
@@ -124,7 +125,7 @@ export class InfoPanelHandler implements IPanelHandler {
     private getRulesManagementItems(player: mc.Player, page: number): PanelItem[] {
         const items: PanelItem[] = [];
         addBackButton(items, 'infoPanel');
-        const { hasPermission } = require('@core/permissionEngine.js');
+
         if (hasPermission(player, 'ui.panel.admin')) {
             items.push({
                 id: 'addRule',
@@ -155,7 +156,7 @@ export class InfoPanelHandler implements IPanelHandler {
     private getHelpfulLinksManagementItems(player: mc.Player, page: number): PanelItem[] {
         const items: PanelItem[] = [];
         addBackButton(items, 'infoPanel');
-        const { hasPermission } = require('@core/permissionEngine.js');
+
         if (hasPermission(player, 'ui.panel.admin')) {
             items.push({
                 id: 'addLink',

--- a/src/core/ui/panels/infoPanel.ts
+++ b/src/core/ui/panels/infoPanel.ts
@@ -3,7 +3,7 @@ import * as mc from '@minecraft/server';
 import { ActionFormResponse, ModalFormData, ModalFormResponse } from '@minecraft/server-ui';
 
 import { getConfig } from '@core/configManager.js';
-import { getOrCreatePlayer, type PlayerData } from '@core/playerDataManager.js';
+
 import { showPanel } from '@core/uiManager.js';
 import * as helpfulLinksManager from '@features/essentials/helpfulLinksManager.js';
 import * as rulesManager from '@features/essentials/rulesManager.js';
@@ -32,7 +32,6 @@ export class InfoPanelHandler implements IPanelHandler {
     }
 
     getItems(player: mc.Player, panelId: string, context: UIContext): Promise<PanelItem[]> {
-        const pData = getOrCreatePlayer(player);
         const page = (context.page as number) || 1;
 
         if (panelId === 'infoPanel') {

--- a/src/core/ui/panels/infoPanel.ts
+++ b/src/core/ui/panels/infoPanel.ts
@@ -33,14 +33,13 @@ export class InfoPanelHandler implements IPanelHandler {
 
     getItems(player: mc.Player, panelId: string, context: UIContext): Promise<PanelItem[]> {
         const pData = getOrCreatePlayer(player);
-        const permissionLevel = pData.permissionLevel;
         const page = (context.page as number) || 1;
 
         if (panelId === 'infoPanel') {
             const items: PanelItem[] = [];
             const def = panelDefinitions[panelId];
             if (isDefined(def)) {
-                const staticItems = getStaticMenuItems(def, permissionLevel);
+                const staticItems = getStaticMenuItems(player, def);
                 items.push(...staticItems);
             }
             return Promise.resolve(items);
@@ -57,18 +56,19 @@ export class InfoPanelHandler implements IPanelHandler {
         }
 
         if (panelId === 'rulesManagementPanel') {
-            return Promise.resolve(this.getRulesManagementItems(pData, page));
+            return Promise.resolve(this.getRulesManagementItems(player, page));
         }
 
         if (panelId === 'ruleActionPanel') {
             const items: PanelItem[] = [];
             addBackButton(items, 'rulesManagementPanel');
-            if (permissionLevel <= 1) {
+            const { hasPermission } = require('@core/permissionEngine.js');
+            if (hasPermission(player, 'ui.panel.admin')) {
                 items.push({
                     id: 'delete',
                     text: 'Delete Rule',
                     icon: 'textures/ui/trash',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'functionCall',
                     actionValue: 'deleteRule'
                 });
@@ -77,18 +77,19 @@ export class InfoPanelHandler implements IPanelHandler {
         }
 
         if (panelId === 'helpfulLinksManagementPanel') {
-            return Promise.resolve(this.getHelpfulLinksManagementItems(pData, page));
+            return Promise.resolve(this.getHelpfulLinksManagementItems(player, page));
         }
 
         if (panelId === 'helpfulLinkActionPanel') {
             const items: PanelItem[] = [];
             addBackButton(items, 'helpfulLinksManagementPanel');
-            if (permissionLevel <= 1) {
+            const { hasPermission } = require('@core/permissionEngine.js');
+            if (hasPermission(player, 'ui.panel.admin')) {
                 items.push({
                     id: 'delete',
                     text: 'Delete Link',
                     icon: 'textures/ui/trash',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'functionCall',
                     actionValue: 'deleteHelpfulLink'
                 });
@@ -112,7 +113,7 @@ export class InfoPanelHandler implements IPanelHandler {
                 id: `link_${idx}`,
                 text: link.title,
                 icon: 'textures/ui/world_glyph_color_2x_black_outline',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'functionCall',
                 actionValue: 'printLink',
                 sortId: idx
@@ -121,15 +122,16 @@ export class InfoPanelHandler implements IPanelHandler {
         return items;
     }
 
-    private getRulesManagementItems(pData: PlayerData, page: number): PanelItem[] {
+    private getRulesManagementItems(player: mc.Player, page: number): PanelItem[] {
         const items: PanelItem[] = [];
         addBackButton(items, 'infoPanel');
-        if (pData.permissionLevel <= 1) {
+        const { hasPermission } = require('@core/permissionEngine.js');
+        if (hasPermission(player, 'ui.panel.admin')) {
             items.push({
                 id: 'addRule',
                 text: '§l§2+ Add Rule',
                 icon: 'textures/ui/color_plus',
-                permissionLevel: 1,
+                permission: 'ui.panel.admin',
                 actionType: 'openPanel',
                 actionValue: 'addRulePanel'
             });
@@ -142,7 +144,7 @@ export class InfoPanelHandler implements IPanelHandler {
             items.push({
                 id: String(realIndex),
                 text: rule,
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'openPanel',
                 actionValue: 'ruleActionPanel'
             });
@@ -151,15 +153,16 @@ export class InfoPanelHandler implements IPanelHandler {
         return items;
     }
 
-    private getHelpfulLinksManagementItems(pData: PlayerData, page: number): PanelItem[] {
+    private getHelpfulLinksManagementItems(player: mc.Player, page: number): PanelItem[] {
         const items: PanelItem[] = [];
         addBackButton(items, 'infoPanel');
-        if (pData.permissionLevel <= 1) {
+        const { hasPermission } = require('@core/permissionEngine.js');
+        if (hasPermission(player, 'ui.panel.admin')) {
             items.push({
                 id: 'addLink',
                 text: '§l§2+ Add Link',
                 icon: 'textures/ui/color_plus',
-                permissionLevel: 1,
+                permission: 'ui.panel.admin',
                 actionType: 'openPanel',
                 actionValue: 'addHelpfulLinkPanel'
             });
@@ -173,7 +176,7 @@ export class InfoPanelHandler implements IPanelHandler {
                 id: String(realIndex),
                 text: `§l§6${link.title}§r\n§9${link.url}`,
                 icon: 'textures/items/chain',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'openPanel',
                 actionValue: 'helpfulLinkActionPanel'
             });

--- a/src/core/ui/panels/playerPanel.ts
+++ b/src/core/ui/panels/playerPanel.ts
@@ -19,9 +19,8 @@ export class PlayerPanelHandler implements IPanelHandler {
 
     getItems(player: mc.Player, panelId: string, _context: UIContext): Promise<PanelItem[] | undefined> {
         const config = getConfig();
-        const rank = getPlayerRank(player, config);
         const def = panelDefinitions[panelId];
-        const baseItems = isDefined(def) ? getStaticMenuItems(def, rank.permissionLevel, _context) : [];
+        const baseItems = isDefined(def) ? getStaticMenuItems(player, def, _context) : [];
 
         if (panelId === 'playerListPanel' || panelId === 'playerManagementPanel') {
             const players = getVisiblePlayers(player);
@@ -34,7 +33,7 @@ export class PlayerPanelHandler implements IPanelHandler {
                     icon: getPlayerIcon(p),
                     actionType: 'openPanel',
                     actionValue: 'playerActionsPanel',
-                    permissionLevel: 1024
+                    permission: 'ui.panel.member'
                 };
             });
             // Append player items to static items (which includes back button at start)
@@ -50,7 +49,7 @@ export class PlayerPanelHandler implements IPanelHandler {
                     id: 'stat_money',
                     text: `§2Balance: §r${formatCurrency(data.balance)}`,
                     icon: 'textures/items/emerald',
-                    permissionLevel: 1024,
+                    permission: 'ui.panel.member',
                     actionType: 'functionCall',
                     actionValue: 'noop'
                 },
@@ -58,7 +57,7 @@ export class PlayerPanelHandler implements IPanelHandler {
                     id: 'stat_rank',
                     text: `§6Rank: §r${data.rankId}`,
                     icon: 'textures/ui/icon_rank',
-                    permissionLevel: 1024,
+                    permission: 'ui.panel.member',
                     actionType: 'functionCall',
                     actionValue: 'noop'
                 },
@@ -66,7 +65,7 @@ export class PlayerPanelHandler implements IPanelHandler {
                     id: 'stat_playtime',
                     text: `§3Playtime: §r${formatDuration(data.totalPlayTime)}`,
                     icon: 'textures/items/clock_item',
-                    permissionLevel: 1024,
+                    permission: 'ui.panel.member',
                     actionType: 'functionCall',
                     actionValue: 'noop'
                 },
@@ -74,7 +73,7 @@ export class PlayerPanelHandler implements IPanelHandler {
                     id: 'stat_kills',
                     text: `§cKills: §r${data.kills}`,
                     icon: 'textures/items/iron_sword',
-                    permissionLevel: 1024,
+                    permission: 'ui.panel.member',
                     actionType: 'functionCall',
                     actionValue: 'noop'
                 },
@@ -82,7 +81,7 @@ export class PlayerPanelHandler implements IPanelHandler {
                     id: 'stat_deaths',
                     text: `§4Deaths: §r${data.deaths}`,
                     icon: 'textures/ui/skull_face',
-                    permissionLevel: 1024,
+                    permission: 'ui.panel.member',
                     actionType: 'functionCall',
                     actionValue: 'noop'
                 }
@@ -110,9 +109,7 @@ export class PlayerPanelHandler implements IPanelHandler {
         if (!isDefined(items)) {
             const def = panelDefinitions[panelId];
             if (isDefined(def)) {
-                const config = getConfig();
-                const rank = getPlayerRank(player, config);
-                items = getStaticMenuItems(def, rank.permissionLevel, context);
+                items = getStaticMenuItems(player, def, context);
             } else {
                 return;
             }

--- a/src/core/ui/panels/rankPanel.ts
+++ b/src/core/ui/panels/rankPanel.ts
@@ -27,7 +27,7 @@ export class RankPanelHandler implements IPanelHandler {
                     id: 'addRank',
                     text: 'Create New Rank',
                     icon: 'textures/ui/color_plus',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'openPanel',
                     actionValue: 'addRankPanel',
                     sortId: 0
@@ -36,7 +36,7 @@ export class RankPanelHandler implements IPanelHandler {
                     id: 'rankSettings',
                     text: 'Settings',
                     icon: 'textures/ui/settings_glyph_color_2x',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'openPanel',
                     actionValue: 'rankSettingsPanel',
                     sortId: 1
@@ -52,7 +52,7 @@ export class RankPanelHandler implements IPanelHandler {
                     id: rank.id,
                     text: `§l${rank.name}§r\nPriority: ${rank.priority}`,
                     icon: 'textures/ui/permissions_op_crown', // Generic icon
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'openPanel',
                     actionValue: 'editRankPanel'
                 });

--- a/src/core/ui/panels/sidebarPanel.ts
+++ b/src/core/ui/panels/sidebarPanel.ts
@@ -15,11 +15,11 @@ export class SidebarPanelHandler implements IPanelHandler {
         return panelId === 'sidebarMainPanel' || panelId.startsWith('sidebarLine') || panelId.startsWith('actionBarLine') || panelId === 'actionBarLinesPanel' || panelId === 'placeholderListPanel';
     }
 
-    getBody(_player: mc.Player, panelId: string, _context: UIContext): Promise<string | undefined | void> {
+    getBody(player: mc.Player, panelId: string, _context: UIContext): Promise<string | undefined | void> {
         if (panelId === 'placeholderListPanel') {
             return Promise.resolve(
                 `§l§6Global Placeholders§r (Scoreboard, Floating Text)\n` +
-                    `{server_name}, {tps}, {online}, {max_players}, {time}, {date}\n\n` +
+                    `{server_name}, {tps}, {online}, {maxplayers}, {time}, {date}\n\n` +
                     `§l§dPersonal Placeholders§r (Action Bar Only)\n` +
                     `{name}, {money}, {rank}, {kills}, {deaths}, {streak}, {kdr}, {playtime}, {team}, {ping}, {x}, {y}, {z}, {dimension}`
             );
@@ -27,13 +27,13 @@ export class SidebarPanelHandler implements IPanelHandler {
         return Promise.resolve();
     }
 
-    getItems(_player: mc.Player, panelId: string, _context: UIContext): Promise<PanelItem[]> {
+    getItems(player: mc.Player, panelId: string, _context: UIContext): Promise<PanelItem[]> {
         const items: PanelItem[] = [];
 
         if (panelId === 'sidebarMainPanel') {
             const def = panelDefinitions[panelId];
             if (isDefined(def)) {
-                const staticItems = getStaticMenuItems(def, 1); // Admin
+                const staticItems = getStaticMenuItems(player, def);
                 items.push(...staticItems);
             }
             return Promise.resolve(items);
@@ -58,7 +58,7 @@ export class SidebarPanelHandler implements IPanelHandler {
             id: 'addLine',
             text: '§l§2+ Add Line',
             icon: 'textures/ui/color_plus',
-            permissionLevel: 1,
+            permission: 'ui.panel.admin',
             actionType: 'openPanel',
             actionValue: isSidebar ? 'sidebarLineAddPanel' : 'actionBarLineAddPanel'
         });
@@ -71,7 +71,7 @@ export class SidebarPanelHandler implements IPanelHandler {
             items.push({
                 id: String(idx),
                 text: `${idx + 1}. ${line}`,
-                permissionLevel: 1,
+                permission: 'ui.panel.admin',
                 actionType: 'openPanel',
                 actionValue: isSidebar ? 'sidebarLineActionPanel' : 'actionBarLineActionPanel'
             });
@@ -88,7 +88,7 @@ export class SidebarPanelHandler implements IPanelHandler {
                 id: 'edit',
                 text: 'Edit',
                 icon: 'textures/ui/icon_setting',
-                permissionLevel: 1,
+                permission: 'ui.panel.admin',
                 actionType: 'functionCall',
                 actionValue: 'editLine'
             },
@@ -96,7 +96,7 @@ export class SidebarPanelHandler implements IPanelHandler {
                 id: 'moveUp',
                 text: 'Move Up',
                 icon: 'textures/gui/controls/up',
-                permissionLevel: 1,
+                permission: 'ui.panel.admin',
                 actionType: 'functionCall',
                 actionValue: 'moveUp'
             },
@@ -104,7 +104,7 @@ export class SidebarPanelHandler implements IPanelHandler {
                 id: 'moveDown',
                 text: 'Move Down',
                 icon: 'textures/gui/controls/down',
-                permissionLevel: 1,
+                permission: 'ui.panel.admin',
                 actionType: 'functionCall',
                 actionValue: 'moveDown'
             },
@@ -112,7 +112,7 @@ export class SidebarPanelHandler implements IPanelHandler {
                 id: 'delete',
                 text: 'Delete',
                 icon: 'textures/ui/trash',
-                permissionLevel: 1,
+                permission: 'ui.panel.admin',
                 actionType: 'functionCall',
                 actionValue: 'deleteLine'
             }
@@ -120,7 +120,7 @@ export class SidebarPanelHandler implements IPanelHandler {
         return items;
     }
 
-    buildModal(_player: mc.Player, panelId: string, context: UIContext): Promise<ModalFormData | undefined | void> {
+    buildModal(player: mc.Player, panelId: string, context: UIContext): Promise<ModalFormData | undefined | void> {
         if (panelId === 'sidebarLineEditPanel') {
             const config = getSidebarConfig();
             const lines = config.sidebarLines;

--- a/src/core/ui/panels/sidebarPanel.ts
+++ b/src/core/ui/panels/sidebarPanel.ts
@@ -15,7 +15,7 @@ export class SidebarPanelHandler implements IPanelHandler {
         return panelId === 'sidebarMainPanel' || panelId.startsWith('sidebarLine') || panelId.startsWith('actionBarLine') || panelId === 'actionBarLinesPanel' || panelId === 'placeholderListPanel';
     }
 
-    getBody(player: mc.Player, panelId: string, _context: UIContext): Promise<string | undefined | void> {
+    getBody(_player: mc.Player, panelId: string, _context: UIContext): Promise<string | undefined | void> {
         if (panelId === 'placeholderListPanel') {
             return Promise.resolve(
                 `§l§6Global Placeholders§r (Scoreboard, Floating Text)\n` +
@@ -120,7 +120,7 @@ export class SidebarPanelHandler implements IPanelHandler {
         return items;
     }
 
-    buildModal(player: mc.Player, panelId: string, context: UIContext): Promise<ModalFormData | undefined | void> {
+    buildModal(_player: mc.Player, panelId: string, context: UIContext): Promise<ModalFormData | undefined | void> {
         if (panelId === 'sidebarLineEditPanel') {
             const config = getSidebarConfig();
             const lines = config.sidebarLines;

--- a/src/core/ui/types.ts
+++ b/src/core/ui/types.ts
@@ -40,8 +40,8 @@ export interface PanelItem {
     text: string;
     /** An optional icon texture path. */
     icon?: string;
-    /** The minimum permission level required to see this button. */
-    permissionLevel: number;
+    /** The permission node required to see this button. Defaults to 'ui.panel.member' if not specified. */
+    permission?: string;
     /** The action to perform when clicked. */
     actionType: 'openPanel' | 'functionCall';
     /** The ID of the panel to open or the function to call. */
@@ -59,8 +59,8 @@ export interface PanelDefinition {
     parentPanelId: string | undefined;
     /** The buttons to display on this panel. */
     items: PanelItem[];
-    /** Optional: Minimum permission level to view this panel. */
-    permissionLevel?: number;
+    /** Optional: Permission node required to view this panel. */
+    permission?: string;
     /** Optional: Static body text for the panel. */
     body?: string;
 }
@@ -96,14 +96,14 @@ export interface ShopListEntry {
     icon?: string;
     buyPrice?: number;
     sellPrice?: number;
-    permissionLevel?: number;
+    permission?: string;
     items?: Record<string, ShopItem>;
 }
 
 export interface ShopItem {
     buyPrice: number;
     sellPrice: number;
-    permissionLevel: number;
+    permission?: string;
     icon?: string;
     displayName?: string;
     itemId?: string; // Minecraft ID

--- a/src/core/ui/uiUtils.ts
+++ b/src/core/ui/uiUtils.ts
@@ -27,6 +27,7 @@ import { spawnConfig } from '@features/essentials/spawnConfig.default.js';
 import { kitsConfig } from '@features/kit/kitsConfig.default.js';
 import { shopConfig } from '@features/shop/shopConfig.js';
 import { teamConfig } from '@features/team/teamConfig.js';
+import { hasPermission } from '@core/permissionEngine.js';
 import * as mc from '@minecraft/server';
 import { PanelItem, UIContext } from '@ui/types.js';
 
@@ -108,14 +109,14 @@ export function addPaginationButtons(form: ActionFormData, page: number, totalIt
 /**
  * Helper to add pagination items to a PanelItem array.
  */
-export function addPaginationItems(items: PanelItem[], page: number, totalItems: number, permissionLevel: number = 1024): void {
+export function addPaginationItems(items: PanelItem[], page: number, totalItems: number, permission: string = 'ui.panel.member'): void {
     const totalPages = Math.ceil(totalItems / itemsPerPage);
     if (page > 1) {
         items.push({
             id: '__prev__',
             text: '§6< Previous Page',
             icon: 'textures/ui/arrow_left.png',
-            permissionLevel,
+            permission,
             actionType: 'functionCall',
             actionValue: 'prevPage'
         });
@@ -125,7 +126,7 @@ export function addPaginationItems(items: PanelItem[], page: number, totalItems:
             id: '__next__',
             text: '§6Next Page >',
             icon: 'textures/ui/arrow_right.png',
-            permissionLevel,
+            permission,
             actionType: 'functionCall',
             actionValue: 'nextPage'
         });
@@ -135,12 +136,12 @@ export function addPaginationItems(items: PanelItem[], page: number, totalItems:
 /**
  * Helper to add a standardized back button to a PanelItem array.
  */
-export function addBackButton(items: PanelItem[], targetPanelId: string, permissionLevel: number = 1024): void {
+export function addBackButton(items: PanelItem[], targetPanelId: string, permission: string = 'ui.panel.member'): void {
     items.push({
         id: '__back__',
         text: '§l§8< Back',
         icon: 'textures/gui/controls/left.png',
-        permissionLevel,
+        permission,
         actionType: 'openPanel',
         actionValue: targetPanelId
     });
@@ -175,18 +176,18 @@ export function getAllSystems(): SystemDefinition[] {
 /**
  * Returns all visible systems for a player (permission filtered).
  */
-export function getVisibleSystems(pData: PlayerData): SystemDefinition[] {
+export function getVisibleSystems(player: mc.Player): SystemDefinition[] {
     return getSystemRegistry().filter((sys) => {
         if (sys.hidden === true) return false;
-        return pData.permissionLevel <= 1;
+        return hasPermission(player, 'ui.panel.admin');
     });
 }
 
 /**
  * Returns unique categories available to the player.
  */
-export function getVisibleCategories(pData: PlayerData): SystemItem[] {
-    const systems = getVisibleSystems(pData);
+export function getVisibleCategories(player: mc.Player): SystemItem[] {
+    const systems = getVisibleSystems(player);
     const categories = new Set<string>();
     for (const sys of systems) {
         if (sys.category !== undefined && sys.category.length > 0) categories.add(sys.category);
@@ -195,7 +196,7 @@ export function getVisibleCategories(pData: PlayerData): SystemItem[] {
     const sortedCategories = [...categories].toSorted((a, b) => a.localeCompare(b));
 
     // Add "Reset" category if Owner
-    if (pData.permissionLevel === 0) {
+    if (hasPermission(player, 'ui.panel.owner')) {
         // Reset isn't a category in systemRegistry, it's a panel.
         // We handle Reset separately in panelBuilder.
     }
@@ -210,8 +211,8 @@ export function getVisibleCategories(pData: PlayerData): SystemItem[] {
 /**
  * Returns systems belonging to a specific category.
  */
-export function getSystemsByCategory(pData: PlayerData, category: string): SystemItem[] {
-    const systems = getVisibleSystems(pData).filter((sys) => sys.category === category);
+export function getSystemsByCategory(player: mc.Player, category: string): SystemItem[] {
+    const systems = getVisibleSystems(player).filter((sys) => sys.category === category);
     return systems
         .map((sys) => ({
             id: sys.configPanelId,

--- a/src/core/ui/uiUtils.ts
+++ b/src/core/ui/uiUtils.ts
@@ -16,7 +16,8 @@ import {
     saveXrayConfig,
     SidebarConfig
 } from '@core/configurations.js';
-import type { PlayerData } from '@core/playerDataManager.js';
+
+import { hasPermission } from '@core/permissionEngine.js';
 import ranksConfig from '@core/ranksConfig.default.js';
 import { showPanel } from '@core/uiManager.js';
 import { AnticheatConfig, getAnticheatConfig, saveAnticheatConfig } from '@features/anticheat/configLoader.js';
@@ -27,7 +28,6 @@ import { spawnConfig } from '@features/essentials/spawnConfig.default.js';
 import { kitsConfig } from '@features/kit/kitsConfig.default.js';
 import { shopConfig } from '@features/shop/shopConfig.js';
 import { teamConfig } from '@features/team/teamConfig.js';
-import { hasPermission } from '@core/permissionEngine.js';
 import * as mc from '@minecraft/server';
 import { PanelItem, UIContext } from '@ui/types.js';
 

--- a/src/features/economy/ui/bountyPanel.ts
+++ b/src/features/economy/ui/bountyPanel.ts
@@ -22,7 +22,7 @@ export class BountyPanelHandler implements IPanelHandler {
                 id: '__back__',
                 text: '§l§8< Back',
                 icon: 'textures/gui/controls/left.png',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'openPanel',
                 actionValue: 'economyMainPanel'
             }
@@ -38,7 +38,7 @@ export class BountyPanelHandler implements IPanelHandler {
                 id: 'no_bounties',
                 text: '§7No active bounties',
                 icon: 'textures/ui/info_icon',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'functionCall',
                 actionValue: 'noop' // Does nothing
             });
@@ -52,7 +52,7 @@ export class BountyPanelHandler implements IPanelHandler {
                 id: b.playerId,
                 text: `${b.name}\n${formatCurrency(b.amount)}`,
                 icon: 'textures/items/netherite_sword',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'openPanel',
                 actionValue: 'playerActionsPanel'
             });
@@ -67,7 +67,7 @@ export class BountyPanelHandler implements IPanelHandler {
                 id: '__prev__',
                 text: '§6< Previous Page',
                 icon: 'textures/ui/arrow_left.png',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'functionCall',
                 actionValue: 'prevPage'
             });
@@ -77,7 +77,7 @@ export class BountyPanelHandler implements IPanelHandler {
                 id: '__next__',
                 text: '§6Next Page >',
                 icon: 'textures/ui/arrow_right.png',
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'functionCall',
                 actionValue: 'nextPage'
             });

--- a/src/features/economy/ui/panel.ts
+++ b/src/features/economy/ui/panel.ts
@@ -2,7 +2,7 @@ import * as mc from '@minecraft/server';
 import { ActionFormResponse, ModalFormData, ModalFormResponse } from '@minecraft/server-ui';
 
 import { getEconomyConfig, saveEconomyConfig } from '@core/configurations.js';
-import { getOrCreatePlayer } from '@core/playerDataManager.js';
+
 import { showPanel } from '@core/uiManager.js';
 import { formatCurrency } from '@core/utils.js';
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
@@ -20,7 +20,6 @@ export class EconomyPanelHandler implements IPanelHandler {
     async getItems(player: mc.Player, panelId: string, context: UIContext): Promise<PanelItem[]> {
         await Promise.resolve();
         const items: PanelItem[] = [];
-        const pData = getOrCreatePlayer(player);
 
         if (panelId === 'economyPanel') {
             const def = panelDefinitions[panelId];

--- a/src/features/economy/ui/panel.ts
+++ b/src/features/economy/ui/panel.ts
@@ -25,7 +25,7 @@ export class EconomyPanelHandler implements IPanelHandler {
         if (panelId === 'economyPanel') {
             const def = panelDefinitions[panelId];
             if (isDefined(def)) {
-                const staticItems = getStaticMenuItems(def, pData.permissionLevel);
+                const staticItems = getStaticMenuItems(player, def);
                 items.push(...staticItems);
             }
             return items;
@@ -35,7 +35,7 @@ export class EconomyPanelHandler implements IPanelHandler {
             addBackButton(items, 'economyPanel');
             const def = panelDefinitions[panelId];
             if (isDefined(def)) {
-                const staticItems = getStaticMenuItems(def, pData.permissionLevel);
+                const staticItems = getStaticMenuItems(player, def);
                 items.push(...staticItems);
             }
 
@@ -52,7 +52,7 @@ export class EconomyPanelHandler implements IPanelHandler {
                     id: mobId,
                     text: `${mobId}\n${color}${formatCurrency(amount)}`,
                     icon: 'textures/ui/egg_icon',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'openPanel',
                     actionValue: 'editMobDropPanel'
                 });
@@ -71,7 +71,7 @@ export class EconomyPanelHandler implements IPanelHandler {
                     id: 'edit',
                     text: 'Edit Value',
                     icon: 'textures/ui/icon_setting',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'functionCall',
                     actionValue: 'editMobValue'
                 },
@@ -79,7 +79,7 @@ export class EconomyPanelHandler implements IPanelHandler {
                     id: 'delete',
                     text: '§4Delete',
                     icon: 'textures/ui/trash',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'functionCall',
                     actionValue: 'deleteMobDrop'
                 }

--- a/src/features/essentials/ui/worldProtectionPanel.ts
+++ b/src/features/essentials/ui/worldProtectionPanel.ts
@@ -19,7 +19,7 @@ export class WorldProtectionPanelHandler implements IPanelHandler {
                     id: 'addZone',
                     text: 'Add New Zone',
                     icon: 'textures/ui/color_plus',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'openPanel',
                     actionValue: 'addWorldProtectionPanel',
                     sortId: 0
@@ -31,7 +31,7 @@ export class WorldProtectionPanelHandler implements IPanelHandler {
                     id: `zone_${zone.id}`,
                     text: zone.name,
                     icon: 'textures/ui/icon_recipe_nature',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'openPanel',
                     actionValue: 'editWorldProtectionPanel',
                     sortId: index + 1

--- a/src/features/kit/adminManager.ts
+++ b/src/features/kit/adminManager.ts
@@ -6,7 +6,7 @@ export interface Kit {
     enabled: boolean;
     description: string;
     cooldownSeconds: number;
-    permissionLevel: number;
+    permission: string;
     price: number;
     icon: string;
     items: ItemInfo[];
@@ -14,7 +14,7 @@ export interface Kit {
 
 interface KitOptions {
     cooldown?: number;
-    permissionLevel?: number;
+    permission?: string;
     price?: number;
     icon?: string;
     description?: string;
@@ -24,7 +24,7 @@ interface KitSettings {
     enabled?: boolean;
     description?: string;
     cooldownSeconds?: number;
-    permissionLevel?: number;
+    permission?: string;
     price?: number;
     icon?: string;
 }
@@ -46,7 +46,7 @@ export function createKit(kitName: string, options: KitOptions = {}): ActionResu
 
     const {
         cooldown = 3600,
-        permissionLevel = 1024, // Default to Member
+        permission = 'ui.panel.member', // Default to Member
         price = 0,
         icon = 'textures/ui/inventory_icon',
         description = 'A new custom kit.'
@@ -62,7 +62,7 @@ export function createKit(kitName: string, options: KitOptions = {}): ActionResu
         enabled: false, // Disabled by default
         description: description,
         cooldownSeconds: cooldown,
-        permissionLevel: permissionLevel,
+        permission: permission,
         price: price,
         icon: icon,
         items: []

--- a/src/features/kit/kitsConfig.default.ts
+++ b/src/features/kit/kitsConfig.default.ts
@@ -9,7 +9,7 @@ export interface KitDefinition {
     cooldownSeconds: number;
     icon: string;
     price: number;
-    permissionLevel: number;
+    permission: string;
     items: KitItem[];
 }
 
@@ -33,7 +33,7 @@ export const kitsConfig: KitsConfig = {
             cooldownSeconds: 3600, // 1 hour
             icon: 'textures/items/stone_sword',
             price: 0,
-            permissionLevel: 1024,
+            permission: 'ui.panel.member',
             items: [
                 { typeId: 'minecraft:stone_sword', amount: 1 },
                 { typeId: 'minecraft:stone_pickaxe', amount: 1 },
@@ -48,7 +48,7 @@ export const kitsConfig: KitsConfig = {
             cooldownSeconds: 900, // 15 minutes
             icon: 'textures/items/beef_cooked',
             price: 10,
-            permissionLevel: 1024,
+            permission: 'ui.panel.member',
             items: [{ typeId: 'minecraft:cooked_beef', amount: 8 }]
         },
         warrior: {
@@ -57,7 +57,7 @@ export const kitsConfig: KitsConfig = {
             cooldownSeconds: 86_400, // 24 hours
             icon: 'textures/items/iron_sword',
             price: 100,
-            permissionLevel: 1024,
+            permission: 'ui.panel.member',
             items: [
                 { typeId: 'minecraft:iron_sword', amount: 1 },
                 { typeId: 'minecraft:iron_helmet', amount: 1 },
@@ -74,7 +74,7 @@ export const kitsConfig: KitsConfig = {
             cooldownSeconds: 86_400, // 24 hours
             icon: 'textures/items/bow_standby',
             price: 100,
-            permissionLevel: 1024,
+            permission: 'ui.panel.member',
             items: [
                 { typeId: 'minecraft:bow', amount: 1 },
                 { typeId: 'minecraft:arrow', amount: 64 },
@@ -91,7 +91,7 @@ export const kitsConfig: KitsConfig = {
             cooldownSeconds: 43_200, // 12 hours
             icon: 'textures/items/iron_pickaxe',
             price: 50,
-            permissionLevel: 1024,
+            permission: 'ui.panel.member',
             items: [
                 { typeId: 'minecraft:iron_pickaxe', amount: 1 },
                 { typeId: 'minecraft:iron_shovel', amount: 1 },
@@ -106,7 +106,7 @@ export const kitsConfig: KitsConfig = {
             cooldownSeconds: 86_400, // 24 hours
             icon: 'textures/blocks/planks_oak',
             price: 200,
-            permissionLevel: 1024,
+            permission: 'ui.panel.member',
             items: [
                 { typeId: 'minecraft:oak_log', amount: 64 },
                 { typeId: 'minecraft:oak_log', amount: 64 },

--- a/src/features/kit/manager.ts
+++ b/src/features/kit/manager.ts
@@ -59,8 +59,8 @@ export function listKits(player: mc.Player): KitInfo[] {
             if (!isDefined(kit) || kit.enabled !== true) {
                 return false;
             }
-            const requiredPermission = (isDefined(kit) ? kit.permissionLevel : undefined) ?? 1024;
-            return pData.permissionLevel <= requiredPermission;
+            const { hasPermission } = require('@core/permissionEngine.js');
+            return hasPermission(player, kit?.permission ?? 'ui.panel.member');
         })
         .map((kitName) => {
             const kit = kitDefs[kitName];
@@ -131,8 +131,8 @@ export function giveKit(player: mc.Player, kitName: string): KitResult {
     }
 
     // Check permissions
-    const requiredPermission = (isDefined(kit) ? kit.permissionLevel : undefined) ?? 1024;
-    if (pData.permissionLevel > requiredPermission) {
+    const { hasPermission } = require('@core/permissionEngine.js');
+    if (!hasPermission(player, kit?.permission ?? 'ui.panel.member')) {
         return { success: false, message: 'You do not have permission to claim this kit.' };
     }
 

--- a/src/features/kit/manager.ts
+++ b/src/features/kit/manager.ts
@@ -1,3 +1,4 @@
+import { hasPermission } from '@core/permissionEngine.js';
 import * as mc from '@minecraft/server';
 
 import { getConfig } from '@core/configManager.js';
@@ -59,8 +60,8 @@ export function listKits(player: mc.Player): KitInfo[] {
             if (!isDefined(kit) || kit.enabled !== true) {
                 return false;
             }
-            const { hasPermission } = require('@core/permissionEngine.js');
-            return hasPermission(player, kit?.permission ?? 'ui.panel.member');
+
+            return hasPermission(player, kit.permission);
         })
         .map((kitName) => {
             const kit = kitDefs[kitName];
@@ -131,8 +132,8 @@ export function giveKit(player: mc.Player, kitName: string): KitResult {
     }
 
     // Check permissions
-    const { hasPermission } = require('@core/permissionEngine.js');
-    if (!hasPermission(player, kit?.permission ?? 'ui.panel.member')) {
+
+    if (!hasPermission(player, kit.permission)) {
         return { success: false, message: 'You do not have permission to claim this kit.' };
     }
 

--- a/src/features/kit/ui/panel.ts
+++ b/src/features/kit/ui/panel.ts
@@ -26,7 +26,7 @@ export class KitPanelHandler implements IPanelHandler {
                     id: 'toggleKits',
                     text: isEnabled ? '§2Kit System: ENABLED' : '§4Kit System: DISABLED',
                     icon: isEnabled ? 'textures/ui/realms_green_check' : 'textures/ui/cancel',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'functionCall',
                     actionValue: 'toggleKits'
                 },
@@ -34,7 +34,7 @@ export class KitPanelHandler implements IPanelHandler {
                     id: 'createKit',
                     text: '§l§2+ Create New Kit',
                     icon: 'textures/ui/color_plus',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'functionCall',
                     actionValue: 'createKit'
                 }
@@ -50,7 +50,7 @@ export class KitPanelHandler implements IPanelHandler {
                     id: name,
                     text: `${name}\n${kit.enabled ? '§2[Enabled]' : '§4[Disabled]'}`,
                     icon: 'textures/ui/inventory_icon',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'openPanel',
                     actionValue: `kitActionMenu_${name}`
                 });
@@ -67,7 +67,7 @@ export class KitPanelHandler implements IPanelHandler {
                     id: 'editSettings',
                     text: 'Edit Settings',
                     icon: 'textures/ui/icon_setting',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'openPanel',
                     actionValue: `kitSettingsPanel_${kitName}`
                 },
@@ -75,7 +75,7 @@ export class KitPanelHandler implements IPanelHandler {
                     id: 'editItems',
                     text: 'Edit Items',
                     icon: 'textures/ui/inventory_icon',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'openPanel',
                     actionValue: `kitItemsPanel_${kitName}`
                 },
@@ -83,7 +83,7 @@ export class KitPanelHandler implements IPanelHandler {
                     id: 'deleteKit',
                     text: '§4Delete Kit',
                     icon: 'textures/ui/cancel',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'functionCall',
                     actionValue: 'deleteKit'
                 }
@@ -99,7 +99,7 @@ export class KitPanelHandler implements IPanelHandler {
                     id: 'addItem',
                     text: '§l§2+ Add New Item (Manual)',
                     icon: 'textures/ui/color_plus',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'functionCall',
                     actionValue: 'addKitItem'
                 },
@@ -107,7 +107,7 @@ export class KitPanelHandler implements IPanelHandler {
                     id: 'addItemHand',
                     text: '§l§6+ Add Item From Hand',
                     icon: 'textures/ui/inventory_icon',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'functionCall',
                     actionValue: 'addKitItemHand'
                 }
@@ -123,7 +123,7 @@ export class KitPanelHandler implements IPanelHandler {
                         id: String(realIdx),
                         text: `${realIdx + 1}. ${item.typeId.replace('minecraft:', '')} x${item.amount}`,
                         icon: 'textures/items/item_frame',
-                        permissionLevel: 1,
+                        permission: 'ui.panel.admin',
                         actionType: 'functionCall',
                         actionValue: 'manageKitItem'
                     });
@@ -150,7 +150,7 @@ export class KitPanelHandler implements IPanelHandler {
                 .textField('Description', 'Description', { defaultValue: kit.description || '' })
                 .textField('Icon', 'Icon', { defaultValue: kit.icon || '' })
                 .textField('Cooldown', 'Cooldown', { defaultValue: String(kit.cooldownSeconds) })
-                .textField('Permission', 'Level', { defaultValue: String(kit.permissionLevel) })
+                .textField('Permission Node', 'ui.panel.member', { defaultValue: kit.permission })
                 .textField('Price', 'Price', { defaultValue: String(kit.price || 0) });
         }
         return undefined;
@@ -280,7 +280,7 @@ export class KitPanelHandler implements IPanelHandler {
         if (response.formValues) {
             const [enabled, name, desc, icon, cooldownStr, permStr, priceStr] = response.formValues as [boolean, string, string, string, string, string, string];
             const cooldown = Number.parseInt(cooldownStr) || 0;
-            const perm = Number.parseInt(permStr) || 1024;
+            const perm = permStr || 'ui.panel.member';
             const price = Number.parseInt(priceStr) || 0;
 
             kitAdminManager.updateKitSettings(kitName, {
@@ -288,7 +288,7 @@ export class KitPanelHandler implements IPanelHandler {
                 description: desc,
                 icon,
                 cooldownSeconds: cooldown,
-                permissionLevel: perm,
+                permission: perm,
                 price
             });
 

--- a/src/features/moderation/ui/panel.ts
+++ b/src/features/moderation/ui/panel.ts
@@ -16,14 +16,14 @@ export class ModerationPanelHandler implements IPanelHandler {
         return panelId === 'moderationPanel' || panelId === 'reportListPanel' || panelId === 'reportActionsPanel';
     }
 
-    async getItems(_player: mc.Player, panelId: string, context: UIContext): Promise<PanelItem[]> {
+    async getItems(player: mc.Player, panelId: string, context: UIContext): Promise<PanelItem[]> {
         await Promise.resolve();
         const items: PanelItem[] = [];
 
         if (panelId === 'moderationPanel') {
             const def = panelDefinitions[panelId];
             if (isDefined(def)) {
-                const staticItems = getStaticMenuItems(def, 1); // Admin only
+                const staticItems = getStaticMenuItems(player, def);
                 items.push(...staticItems);
             }
             return items;
@@ -41,7 +41,7 @@ export class ModerationPanelHandler implements IPanelHandler {
                 items.push({
                     id: report.id,
                     text: `[${statusColor}${report.status.toUpperCase()}§r] ${report.reportedPlayerName}\n§8Reported by: ${report.reporterName}`,
-                    permissionLevel: 2,
+                    permission: 'ui.panel.mod',
                     actionType: 'openPanel',
                     actionValue: 'reportActionsPanel'
                 });
@@ -55,7 +55,7 @@ export class ModerationPanelHandler implements IPanelHandler {
             // Static items from registry
             const def = panelDefinitions[panelId];
             if (isDefined(def)) {
-                const staticItems = getStaticMenuItems(def, 2);
+                const staticItems = getStaticMenuItems(player, def);
                 items.push(...staticItems.filter((i) => i.id !== '__back__')); // AddBack handled manually
             }
             return items;

--- a/src/features/moderation/ui/xrayPanel.ts
+++ b/src/features/moderation/ui/xrayPanel.ts
@@ -17,12 +17,12 @@ export class XrayPanelHandler implements IPanelHandler {
         const items: PanelItem[] = [];
 
         if (panelId === 'xrayOresPanel') {
-            addBackButton(items, 'configCategoryPanel', 1);
+            addBackButton(items, 'configCategoryPanel', 'ui.panel.admin');
             items.push({
                 id: 'addOre',
                 text: '§l§2+ Add Ore',
                 icon: 'textures/ui/color_plus',
-                permissionLevel: 1,
+                permission: 'ui.panel.admin',
                 actionType: 'openPanel',
                 actionValue: 'addXrayOrePanel'
             });
@@ -38,12 +38,12 @@ export class XrayPanelHandler implements IPanelHandler {
                     id: key,
                     text: `${ore.oreName}\n${ore.enabled ? '§2[Enabled]' : '§4[Disabled]'}`,
                     icon: 'textures/blocks/diamond_ore',
-                    permissionLevel: 1,
+                    permission: 'ui.panel.admin',
                     actionType: 'openPanel',
                     actionValue: `editXrayOrePanel_${key}`
                 });
             }
-            addPaginationItems(items, (context.page as number) || 1, oreKeys.length, 1);
+            addPaginationItems(items, (context.page as number) || 1, oreKeys.length, 'ui.panel.admin');
             return items;
         }
 

--- a/src/features/shop/adminManager.ts
+++ b/src/features/shop/adminManager.ts
@@ -20,7 +20,7 @@ interface ItemData {
     displayName: string;
     buyPrice: number;
     sellPrice: number;
-    permissionLevel?: number;
+    permission?: string;
     category?: string;
 }
 
@@ -30,7 +30,7 @@ interface UpdateItemData {
     icon: string;
     buyPrice: number;
     sellPrice: number;
-    permissionLevel: number;
+    permission: string;
 }
 
 /**
@@ -350,7 +350,7 @@ export function addShopItemFromHand(itemStack: mc.ItemStack, categoryName: strin
     const shopItemData = {
         buyPrice,
         sellPrice,
-        permissionLevel: 1024, // Default to everyone
+        permission: 'ui.panel.member', // Default to everyone
         icon: icon,
         displayName: displayName,
         itemId: newId
@@ -372,7 +372,7 @@ export function addShopItemFromHand(itemStack: mc.ItemStack, categoryName: strin
  * @param categoryName - The name of the category.
  * @param subCategoryName - The name of the subcategory, or undefined for the main category.
  * @param itemId - The ID of the item to add/update.
- * @param itemData - The data for the item (buyPrice, sellPrice, permissionLevel).
+ * @param itemData - The data for the item (buyPrice, sellPrice, permission).
  * @returns The result of the operation.
  */
 export function setItem(categoryName: string, subCategoryName: string | undefined, itemId: string, itemData: ItemData): ActionResult {
@@ -395,7 +395,7 @@ export function setItem(categoryName: string, subCategoryName: string | undefine
     targetContainer.items[itemId] = {
         buyPrice: itemData.buyPrice,
         sellPrice: itemData.sellPrice,
-        permissionLevel: itemData.permissionLevel ?? 1024,
+        permission: itemData.permission ?? 'ui.panel.member',
         icon: itemData.icon,
         displayName: itemData.displayName
     };
@@ -513,7 +513,7 @@ export function updateShopItem(categoryName: string, subCategoryName: string | u
     // Update shop-specific properties
     targetContainer.items[itemId].buyPrice = newData.buyPrice;
     targetContainer.items[itemId].sellPrice = newData.sellPrice;
-    targetContainer.items[itemId].permissionLevel = newData.permissionLevel;
+    targetContainer.items[itemId].permission = newData.permission;
     // Also update denormalized data like icon and displayName for consistency
     targetContainer.items[itemId].icon = newData.icon;
     targetContainer.items[itemId].displayName = newData.displayName;

--- a/src/features/shop/shopConfig.ts
+++ b/src/features/shop/shopConfig.ts
@@ -1,7 +1,7 @@
 export interface ShopItem {
     buyPrice: number;
     sellPrice: number;
-    permissionLevel: number;
+    permission: string;
     icon?: string;
     displayName?: string;
     itemId?: string;
@@ -27,27 +27,27 @@ export const shopConfig: ShopConfig = {
         'Ores & Minerals': {
             icon: 'textures/ui/icon_iron_pickaxe',
             items: {
-                diamond: { buyPrice: 1000, sellPrice: 500, permissionLevel: 1024 },
-                emerald: { buyPrice: 800, sellPrice: 400, permissionLevel: 1024 },
-                goldIngot: { buyPrice: 100, sellPrice: 50, permissionLevel: 1024 },
-                ironIngot: { buyPrice: 50, sellPrice: 25, permissionLevel: 1024 },
-                netheriteIngot: { buyPrice: 10_000, sellPrice: 5000, permissionLevel: 1024 },
-                netheriteScrap: { buyPrice: 2000, sellPrice: 1000, permissionLevel: 1024 },
-                ancientDebris: { buyPrice: 1800, sellPrice: 900, permissionLevel: 1024 },
-                lapisLazuli: { buyPrice: 20, sellPrice: 10, permissionLevel: 1024 },
-                quartz: { buyPrice: 30, sellPrice: 15, permissionLevel: 1024 }
+                diamond: { buyPrice: 1000, sellPrice: 500, permission: 'ui.panel.member' },
+                emerald: { buyPrice: 800, sellPrice: 400, permission: 'ui.panel.member' },
+                goldIngot: { buyPrice: 100, sellPrice: 50, permission: 'ui.panel.member' },
+                ironIngot: { buyPrice: 50, sellPrice: 25, permission: 'ui.panel.member' },
+                netheriteIngot: { buyPrice: 10_000, sellPrice: 5000, permission: 'ui.panel.member' },
+                netheriteScrap: { buyPrice: 2000, sellPrice: 1000, permission: 'ui.panel.member' },
+                ancientDebris: { buyPrice: 1800, sellPrice: 900, permission: 'ui.panel.member' },
+                lapisLazuli: { buyPrice: 20, sellPrice: 10, permission: 'ui.panel.member' },
+                quartz: { buyPrice: 30, sellPrice: 15, permission: 'ui.panel.member' }
             },
             subCategories: {}
         },
         'Special Items': {
             icon: 'textures/ui/filledStar',
             items: {
-                totemOfUndying: { buyPrice: 5000, sellPrice: 2500, permissionLevel: 1024 },
-                netherStar: { buyPrice: 20_000, sellPrice: -1, permissionLevel: 1024 },
-                shulkerShell: { buyPrice: 750, sellPrice: 300, permissionLevel: 1024 },
-                elytra: { buyPrice: 15_000, sellPrice: -1, permissionLevel: 1024 },
-                witherSkeletonSkull: { buyPrice: 8000, sellPrice: 2000, permissionLevel: 1024 },
-                enchantedGoldenApple: { buyPrice: 25_000, sellPrice: -1, permissionLevel: 1024 }
+                totemOfUndying: { buyPrice: 5000, sellPrice: 2500, permission: 'ui.panel.member' },
+                netherStar: { buyPrice: 20_000, sellPrice: -1, permission: 'ui.panel.member' },
+                shulkerShell: { buyPrice: 750, sellPrice: 300, permission: 'ui.panel.member' },
+                elytra: { buyPrice: 15_000, sellPrice: -1, permission: 'ui.panel.member' },
+                witherSkeletonSkull: { buyPrice: 8000, sellPrice: 2000, permission: 'ui.panel.member' },
+                enchantedGoldenApple: { buyPrice: 25_000, sellPrice: -1, permission: 'ui.panel.member' }
             },
             subCategories: {}
         },
@@ -58,18 +58,18 @@ export const shopConfig: ShopConfig = {
                 Diamond: {
                     icon: 'textures/items/diamond',
                     items: {
-                        diamondSword: { buyPrice: 2500, sellPrice: 1000, permissionLevel: 1024 },
-                        diamondPickaxe: { buyPrice: 3500, sellPrice: 1200, permissionLevel: 1024 },
-                        diamondAxe: { buyPrice: 3500, sellPrice: 1200, permissionLevel: 1024 },
-                        diamondShovel: { buyPrice: 1500, sellPrice: 600, permissionLevel: 1024 },
-                        diamondHoe: { buyPrice: 2500, sellPrice: 1000, permissionLevel: 1024 }
+                        diamondSword: { buyPrice: 2500, sellPrice: 1000, permission: 'ui.panel.member' },
+                        diamondPickaxe: { buyPrice: 3500, sellPrice: 1200, permission: 'ui.panel.member' },
+                        diamondAxe: { buyPrice: 3500, sellPrice: 1200, permission: 'ui.panel.member' },
+                        diamondShovel: { buyPrice: 1500, sellPrice: 600, permission: 'ui.panel.member' },
+                        diamondHoe: { buyPrice: 2500, sellPrice: 1000, permission: 'ui.panel.member' }
                     }
                 },
                 Netherite: {
                     icon: 'textures/items/netherite_ingot',
                     items: {
-                        netheriteSword: { buyPrice: 15_000, sellPrice: 7500, permissionLevel: 1024 },
-                        netheritePickaxe: { buyPrice: 18_000, sellPrice: 8000, permissionLevel: 1024 }
+                        netheriteSword: { buyPrice: 15_000, sellPrice: 7500, permission: 'ui.panel.member' },
+                        netheritePickaxe: { buyPrice: 18_000, sellPrice: 8000, permission: 'ui.panel.member' }
                     }
                 }
             }
@@ -81,19 +81,19 @@ export const shopConfig: ShopConfig = {
                 Diamond: {
                     icon: 'textures/items/diamond',
                     items: {
-                        diamondHelmet: { buyPrice: 5000, sellPrice: 2000, permissionLevel: 1024 },
-                        diamondChestplate: { buyPrice: 8000, sellPrice: 3500, permissionLevel: 1024 },
-                        diamondLeggings: { buyPrice: 7000, sellPrice: 3000, permissionLevel: 1024 },
-                        diamondBoots: { buyPrice: 4000, sellPrice: 1800, permissionLevel: 1024 }
+                        diamondHelmet: { buyPrice: 5000, sellPrice: 2000, permission: 'ui.panel.member' },
+                        diamondChestplate: { buyPrice: 8000, sellPrice: 3500, permission: 'ui.panel.member' },
+                        diamondLeggings: { buyPrice: 7000, sellPrice: 3000, permission: 'ui.panel.member' },
+                        diamondBoots: { buyPrice: 4000, sellPrice: 1800, permission: 'ui.panel.member' }
                     }
                 },
                 Netherite: {
                     icon: 'textures/items/netherite_ingot',
                     items: {
-                        netheriteHelmet: { buyPrice: 20_000, sellPrice: 10_000, permissionLevel: 1024 },
-                        netheriteChestplate: { buyPrice: 30_000, sellPrice: 15_000, permissionLevel: 1024 },
-                        netheriteLeggings: { buyPrice: 25_000, sellPrice: 12_000, permissionLevel: 1024 },
-                        netheriteBoots: { buyPrice: 18_000, sellPrice: 9000, permissionLevel: 1024 }
+                        netheriteHelmet: { buyPrice: 20_000, sellPrice: 10_000, permission: 'ui.panel.member' },
+                        netheriteChestplate: { buyPrice: 30_000, sellPrice: 15_000, permission: 'ui.panel.member' },
+                        netheriteLeggings: { buyPrice: 25_000, sellPrice: 12_000, permission: 'ui.panel.member' },
+                        netheriteBoots: { buyPrice: 18_000, sellPrice: 9000, permission: 'ui.panel.member' }
                     }
                 }
             }
@@ -101,67 +101,67 @@ export const shopConfig: ShopConfig = {
         Logs: {
             icon: 'textures/blocks/sapling_oak',
             items: {
-                oakLog: { buyPrice: 20, sellPrice: 10, permissionLevel: 1024 },
-                spruceLog: { buyPrice: 20, sellPrice: 10, permissionLevel: 1024 },
-                birchLog: { buyPrice: 20, sellPrice: 10, permissionLevel: 1024 },
-                jungleLog: { buyPrice: 20, sellPrice: 10, permissionLevel: 1024 },
-                acaciaLog: { buyPrice: 20, sellPrice: 10, permissionLevel: 1024 },
-                darkOakLog: { buyPrice: 20, sellPrice: 10, permissionLevel: 1024 },
-                mangroveLog: { buyPrice: 20, sellPrice: 10, permissionLevel: 1024 },
-                cherryLog: { buyPrice: 20, sellPrice: 10, permissionLevel: 1024 },
-                crimsonStem: { buyPrice: 25, sellPrice: 12, permissionLevel: 1024 },
-                warpedStem: { buyPrice: 25, sellPrice: 12, permissionLevel: 1024 }
+                oakLog: { buyPrice: 20, sellPrice: 10, permission: 'ui.panel.member' },
+                spruceLog: { buyPrice: 20, sellPrice: 10, permission: 'ui.panel.member' },
+                birchLog: { buyPrice: 20, sellPrice: 10, permission: 'ui.panel.member' },
+                jungleLog: { buyPrice: 20, sellPrice: 10, permission: 'ui.panel.member' },
+                acaciaLog: { buyPrice: 20, sellPrice: 10, permission: 'ui.panel.member' },
+                darkOakLog: { buyPrice: 20, sellPrice: 10, permission: 'ui.panel.member' },
+                mangroveLog: { buyPrice: 20, sellPrice: 10, permission: 'ui.panel.member' },
+                cherryLog: { buyPrice: 20, sellPrice: 10, permission: 'ui.panel.member' },
+                crimsonStem: { buyPrice: 25, sellPrice: 12, permission: 'ui.panel.member' },
+                warpedStem: { buyPrice: 25, sellPrice: 12, permission: 'ui.panel.member' }
             },
             subCategories: {}
         },
         'Building Blocks': {
             icon: 'textures/blocks/stonebrick',
             items: {
-                stone: { buyPrice: 10, sellPrice: 5, permissionLevel: 1024 },
-                cobblestone: { buyPrice: 5, sellPrice: 1, permissionLevel: 1024 },
-                dirt: { buyPrice: 2, sellPrice: 1, permissionLevel: 1024 },
-                sand: { buyPrice: 5, sellPrice: 2, permissionLevel: 1024 },
-                gravel: { buyPrice: 5, sellPrice: 2, permissionLevel: 1024 },
-                glass: { buyPrice: 15, sellPrice: 5, permissionLevel: 1024 },
-                terracotta: { buyPrice: 10, sellPrice: 5, permissionLevel: 1024 },
-                whiteConcrete: { buyPrice: 20, sellPrice: 10, permissionLevel: 1024 },
-                stoneBricks: { buyPrice: 12, sellPrice: 6, permissionLevel: 1024 },
-                obsidian: { buyPrice: 100, sellPrice: 50, permissionLevel: 1024 },
-                glowstone: { buyPrice: 80, sellPrice: 40, permissionLevel: 1024 },
-                netherrack: { buyPrice: 5, sellPrice: 1, permissionLevel: 1024 },
-                endStone: { buyPrice: 10, sellPrice: 2, permissionLevel: 1024 },
-                purpurBlock: { buyPrice: 15, sellPrice: 5, permissionLevel: 1024 }
+                stone: { buyPrice: 10, sellPrice: 5, permission: 'ui.panel.member' },
+                cobblestone: { buyPrice: 5, sellPrice: 1, permission: 'ui.panel.member' },
+                dirt: { buyPrice: 2, sellPrice: 1, permission: 'ui.panel.member' },
+                sand: { buyPrice: 5, sellPrice: 2, permission: 'ui.panel.member' },
+                gravel: { buyPrice: 5, sellPrice: 2, permission: 'ui.panel.member' },
+                glass: { buyPrice: 15, sellPrice: 5, permission: 'ui.panel.member' },
+                terracotta: { buyPrice: 10, sellPrice: 5, permission: 'ui.panel.member' },
+                whiteConcrete: { buyPrice: 20, sellPrice: 10, permission: 'ui.panel.member' },
+                stoneBricks: { buyPrice: 12, sellPrice: 6, permission: 'ui.panel.member' },
+                obsidian: { buyPrice: 100, sellPrice: 50, permission: 'ui.panel.member' },
+                glowstone: { buyPrice: 80, sellPrice: 40, permission: 'ui.panel.member' },
+                netherrack: { buyPrice: 5, sellPrice: 1, permission: 'ui.panel.member' },
+                endStone: { buyPrice: 10, sellPrice: 2, permission: 'ui.panel.member' },
+                purpurBlock: { buyPrice: 15, sellPrice: 5, permission: 'ui.panel.member' }
             },
             subCategories: {}
         },
         Food: {
             icon: 'textures/items/bread',
             items: {
-                steak: { buyPrice: 20, sellPrice: 10, permissionLevel: 1024 },
-                cookedPorkchop: { buyPrice: 20, sellPrice: 10, permissionLevel: 1024 },
-                bread: { buyPrice: 15, sellPrice: 5, permissionLevel: 1024 },
-                goldenCarrot: { buyPrice: 100, sellPrice: 40, permissionLevel: 1024 },
-                cookedSalmon: { buyPrice: 20, sellPrice: 10, permissionLevel: 1024 },
-                cookedCod: { buyPrice: 20, sellPrice: 10, permissionLevel: 1024 },
-                chorusFruit: { buyPrice: 50, sellPrice: 25, permissionLevel: 1024 }
+                steak: { buyPrice: 20, sellPrice: 10, permission: 'ui.panel.member' },
+                cookedPorkchop: { buyPrice: 20, sellPrice: 10, permission: 'ui.panel.member' },
+                bread: { buyPrice: 15, sellPrice: 5, permission: 'ui.panel.member' },
+                goldenCarrot: { buyPrice: 100, sellPrice: 40, permission: 'ui.panel.member' },
+                cookedSalmon: { buyPrice: 20, sellPrice: 10, permission: 'ui.panel.member' },
+                cookedCod: { buyPrice: 20, sellPrice: 10, permission: 'ui.panel.member' },
+                chorusFruit: { buyPrice: 50, sellPrice: 25, permission: 'ui.panel.member' }
             },
             subCategories: {}
         },
         Farming: {
             icon: 'textures/items/diamond_hoe',
             items: {
-                wheat: { buyPrice: 5, sellPrice: 2, permissionLevel: 1024 },
-                carrot: { buyPrice: 5, sellPrice: 2, permissionLevel: 1024 },
-                potato: { buyPrice: 5, sellPrice: 2, permissionLevel: 1024 },
-                melonSlice: { buyPrice: 3, sellPrice: 1, permissionLevel: 1024 },
-                pumpkin: { buyPrice: 10, sellPrice: 5, permissionLevel: 1024 },
-                sugarCane: { buyPrice: 8, sellPrice: 4, permissionLevel: 1024 }
+                wheat: { buyPrice: 5, sellPrice: 2, permission: 'ui.panel.member' },
+                carrot: { buyPrice: 5, sellPrice: 2, permission: 'ui.panel.member' },
+                potato: { buyPrice: 5, sellPrice: 2, permission: 'ui.panel.member' },
+                melonSlice: { buyPrice: 3, sellPrice: 1, permission: 'ui.panel.member' },
+                pumpkin: { buyPrice: 10, sellPrice: 5, permission: 'ui.panel.member' },
+                sugarCane: { buyPrice: 8, sellPrice: 4, permission: 'ui.panel.member' }
             },
             subCategories: {
                 Potions: {
                     icon: 'textures/items/potion_bottle_empty',
                     items: {
-                        netherWart: { buyPrice: 25, sellPrice: 10, permissionLevel: 1024 }
+                        netherWart: { buyPrice: 25, sellPrice: 10, permission: 'ui.panel.member' }
                     }
                 }
             }
@@ -173,64 +173,64 @@ export const shopConfig: ShopConfig = {
                 General: {
                     icon: 'textures/items/book_normal',
                     items: {
-                        enchantMending: { buyPrice: 8000, sellPrice: -1, permissionLevel: 1024 },
-                        enchantUnbreaking3: { buyPrice: 4000, sellPrice: -1, permissionLevel: 1024 }
+                        enchantMending: { buyPrice: 8000, sellPrice: -1, permission: 'ui.panel.member' },
+                        enchantUnbreaking3: { buyPrice: 4000, sellPrice: -1, permission: 'ui.panel.member' }
                     }
                 },
                 Sword: {
                     icon: 'textures/items/diamond_sword',
                     items: {
-                        enchantSharpness5: { buyPrice: 5000, sellPrice: -1, permissionLevel: 1024 },
-                        enchantLooting3: { buyPrice: 3000, sellPrice: -1, permissionLevel: 1024 },
-                        enchantFireAspect2: { buyPrice: 2000, sellPrice: -1, permissionLevel: 1024 }
+                        enchantSharpness5: { buyPrice: 5000, sellPrice: -1, permission: 'ui.panel.member' },
+                        enchantLooting3: { buyPrice: 3000, sellPrice: -1, permission: 'ui.panel.member' },
+                        enchantFireAspect2: { buyPrice: 2000, sellPrice: -1, permission: 'ui.panel.member' }
                     }
                 },
                 Armour: {
                     icon: 'textures/items/diamond_chestplate',
                     items: {
-                        enchantProtection4: { buyPrice: 4500, sellPrice: -1, permissionLevel: 1024 },
-                        enchantFeatherFalling4: { buyPrice: 3500, sellPrice: -1, permissionLevel: 1024 }
+                        enchantProtection4: { buyPrice: 4500, sellPrice: -1, permission: 'ui.panel.member' },
+                        enchantFeatherFalling4: { buyPrice: 3500, sellPrice: -1, permission: 'ui.panel.member' }
                     }
                 },
                 Tools: {
                     icon: 'textures/items/diamond_pickaxe',
                     items: {
-                        enchantEfficiency5: { buyPrice: 5000, sellPrice: -1, permissionLevel: 1024 },
-                        enchantFortune3: { buyPrice: 4000, sellPrice: -1, permissionLevel: 1024 },
-                        enchantSilkTouch: { buyPrice: 6000, sellPrice: -1, permissionLevel: 1024 }
+                        enchantEfficiency5: { buyPrice: 5000, sellPrice: -1, permission: 'ui.panel.member' },
+                        enchantFortune3: { buyPrice: 4000, sellPrice: -1, permission: 'ui.panel.member' },
+                        enchantSilkTouch: { buyPrice: 6000, sellPrice: -1, permission: 'ui.panel.member' }
                     }
                 },
                 Bow: {
                     icon: 'textures/items/bow_standby',
                     items: {
-                        enchantPower5: { buyPrice: 5000, sellPrice: -1, permissionLevel: 1024 },
-                        enchantInfinity: { buyPrice: 7000, sellPrice: -1, permissionLevel: 1024 },
-                        enchantFlame: { buyPrice: 2000, sellPrice: -1, permissionLevel: 1024 }
+                        enchantPower5: { buyPrice: 5000, sellPrice: -1, permission: 'ui.panel.member' },
+                        enchantInfinity: { buyPrice: 7000, sellPrice: -1, permission: 'ui.panel.member' },
+                        enchantFlame: { buyPrice: 2000, sellPrice: -1, permission: 'ui.panel.member' }
                     }
                 },
                 Trident: {
                     icon: 'textures/items/trident',
                     items: {
-                        enchantImpaling5: { buyPrice: 3000, sellPrice: -1, permissionLevel: 1024 },
-                        enchantLoyalty3: { buyPrice: 2500, sellPrice: -1, permissionLevel: 1024 },
-                        enchantChanneling: { buyPrice: 4000, sellPrice: -1, permissionLevel: 1024 },
-                        enchantRiptide3: { buyPrice: 3500, sellPrice: -1, permissionLevel: 1024 }
+                        enchantImpaling5: { buyPrice: 3000, sellPrice: -1, permission: 'ui.panel.member' },
+                        enchantLoyalty3: { buyPrice: 2500, sellPrice: -1, permission: 'ui.panel.member' },
+                        enchantChanneling: { buyPrice: 4000, sellPrice: -1, permission: 'ui.panel.member' },
+                        enchantRiptide3: { buyPrice: 3500, sellPrice: -1, permission: 'ui.panel.member' }
                     }
                 },
                 Mace: {
                     icon: 'textures/items/mace',
                     items: {
-                        enchantDensity5: { buyPrice: 5000, sellPrice: -1, permissionLevel: 1024 },
-                        enchantBreach4: { buyPrice: 4000, sellPrice: -1, permissionLevel: 1024 },
-                        enchantWindBurst3: { buyPrice: 6000, sellPrice: -1, permissionLevel: 1024 }
+                        enchantDensity5: { buyPrice: 5000, sellPrice: -1, permission: 'ui.panel.member' },
+                        enchantBreach4: { buyPrice: 4000, sellPrice: -1, permission: 'ui.panel.member' },
+                        enchantWindBurst3: { buyPrice: 6000, sellPrice: -1, permission: 'ui.panel.member' }
                     }
                 },
                 Crossbow: {
                     icon: 'textures/items/crossbow_standby',
                     items: {
-                        enchantMultishot1: { buyPrice: 4000, sellPrice: -1, permissionLevel: 1024 },
-                        enchantPiercing4: { buyPrice: 4500, sellPrice: -1, permissionLevel: 1024 },
-                        enchantQuickCharge3: { buyPrice: 3500, sellPrice: -1, permissionLevel: 1024 }
+                        enchantMultishot1: { buyPrice: 4000, sellPrice: -1, permission: 'ui.panel.member' },
+                        enchantPiercing4: { buyPrice: 4500, sellPrice: -1, permission: 'ui.panel.member' },
+                        enchantQuickCharge3: { buyPrice: 3500, sellPrice: -1, permission: 'ui.panel.member' }
                     }
                 }
             }

--- a/src/features/shop/ui/adminPanel.ts
+++ b/src/features/shop/ui/adminPanel.ts
@@ -26,7 +26,7 @@ interface ShopItemEntry {
     displayName?: string;
     buyPrice: number;
     sellPrice: number;
-    permissionLevel: number;
+    permission?: string;
 }
 
 type ShopEntry = ShopCategoryEntry | ShopItemEntry;
@@ -114,7 +114,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
                 id: 'toggleShop',
                 text: toggleText,
                 icon: isEnabled ? 'textures/ui/realms_green_check' : 'textures/ui/cancel',
-                permissionLevel: 0,
+                permission: 'ui.panel.owner',
                 actionType: 'functionCall',
                 actionValue: 'toggleShop'
             },
@@ -122,7 +122,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
                 id: 'addCategory',
                 text: '§l§2+ Add Category',
                 icon: 'textures/ui/color_plus',
-                permissionLevel: 0,
+                permission: 'ui.panel.owner',
                 actionType: 'openPanel',
                 actionValue: 'addCategoryPanel'
             }
@@ -139,7 +139,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
                 id: catName,
                 text: catName,
                 icon: cat.icon,
-                permissionLevel: 0,
+                permission: 'ui.panel.owner',
                 actionType: 'openPanel',
                 actionValue: `shopAdminCategoryPanel_${catName}`
             });
@@ -171,7 +171,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
                     ...(isNonEmptyString(item?.displayName) ? { displayName: item.displayName } : {}),
                     buyPrice: item?.buyPrice ?? -1,
                     sellPrice: item?.sellPrice ?? -1,
-                    permissionLevel: item?.permissionLevel ?? 1024
+                    permission: item?.permission ?? 'ui.panel.member'
                 };
             })
         ];
@@ -186,7 +186,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
                 id: 'addItem',
                 text: '§l§2+ Add Item',
                 icon: 'textures/ui/color_plus',
-                permissionLevel: 0,
+                permission: 'ui.panel.owner',
                 actionType: 'openPanel',
                 actionValue: `shopAddItemPanel_${categoryName}`
             },
@@ -194,7 +194,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
                 id: 'addSubCategory',
                 text: '§l§2+ Add Subcategory',
                 icon: 'textures/ui/color_plus',
-                permissionLevel: 0,
+                permission: 'ui.panel.owner',
                 actionType: 'openPanel',
                 actionValue: 'addSubCategoryPanel'
             },
@@ -202,7 +202,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
                 id: 'editCategory',
                 text: '§l§9* Edit Category',
                 icon: 'textures/ui/icon_setting',
-                permissionLevel: 0,
+                permission: 'ui.panel.owner',
                 actionType: 'openPanel',
                 actionValue: `shopAdminCategoryActionPanel_${categoryName}`
             }
@@ -224,7 +224,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
                         id: entry.id,
                         text: `§6${entry.id}`,
                         icon: sub.icon,
-                        permissionLevel: 0,
+                        permission: 'ui.panel.owner',
                         actionType: 'openPanel',
                         actionValue: `shopAdminSubCategoryItemPanel_${categoryName}_${entry.id}`
                     });
@@ -237,7 +237,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
                         id: entry.id,
                         text: item.displayName ?? masterItem.displayName ?? entry.id,
                         ...(isNonEmptyString(icon) ? { icon } : {}),
-                        permissionLevel: 0,
+                        permission: 'ui.panel.owner',
                         actionType: 'functionCall',
                         actionValue: 'editItem'
                     });
@@ -258,7 +258,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
                 id: 'addItem',
                 text: '§l§2+ Add Item',
                 icon: 'textures/ui/color_plus',
-                permissionLevel: 0,
+                permission: 'ui.panel.owner',
                 actionType: 'openPanel',
                 actionValue: `shopAddItemPanel_${categoryName}`
             },
@@ -266,7 +266,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
                 id: 'editSubCategory',
                 text: '§l§9* Edit Subcategory',
                 icon: 'textures/ui/icon_setting',
-                permissionLevel: 0,
+                permission: 'ui.panel.owner',
                 actionType: 'openPanel',
                 actionValue: `shopAdminSubCategoryActionPanel_${subCategoryName}`
             }
@@ -288,7 +288,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
                     id: id,
                     text: item.displayName ?? masterItem.displayName ?? id,
                     ...(isNonEmptyString(icon) ? { icon } : {}),
-                    permissionLevel: 0,
+                    permission: 'ui.panel.owner',
                     actionType: 'functionCall',
                     actionValue: 'editItem'
                 });
@@ -306,7 +306,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
             id: 'addCustomItem',
             text: '§l§2+ Add Custom Item',
             icon: 'textures/ui/color_plus',
-            permissionLevel: 0,
+            permission: 'ui.panel.owner',
             actionType: 'openPanel',
             actionValue: 'addCustomItemPanel'
         });
@@ -322,7 +322,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
                 id: itemId,
                 text: masterItem.displayName ?? itemId,
                 ...(isNonEmptyString(masterItem.icon) ? { icon: masterItem.icon } : {}),
-                permissionLevel: 0,
+                permission: 'ui.panel.owner',
                 actionType: 'openPanel',
                 actionValue: 'addItemFromListPanel'
             });
@@ -340,7 +340,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
                 id: 'edit',
                 text: 'Edit',
                 icon: 'textures/ui/icon_setting',
-                permissionLevel: 0,
+                permission: 'ui.panel.owner',
                 actionType: 'openPanel',
                 actionValue: 'editCategoryPanel'
             },
@@ -348,7 +348,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
                 id: 'delete',
                 text: '§4Delete',
                 icon: 'textures/ui/trash',
-                permissionLevel: 0,
+                permission: 'ui.panel.owner',
                 actionType: 'functionCall',
                 actionValue: 'deleteCategory'
             }
@@ -365,7 +365,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
                 id: 'edit',
                 text: 'Edit',
                 icon: 'textures/ui/icon_setting',
-                permissionLevel: 0,
+                permission: 'ui.panel.owner',
                 actionType: 'openPanel',
                 actionValue: 'editSubCategoryPanel'
             },
@@ -373,7 +373,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
                 id: 'delete',
                 text: '§4Delete',
                 icon: 'textures/ui/trash',
-                permissionLevel: 0,
+                permission: 'ui.panel.owner',
                 actionType: 'functionCall',
                 actionValue: 'deleteSubCategory'
             }
@@ -485,7 +485,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
             .textField('Icon', 'Icon', { defaultValue: isNonEmptyString(shopItem.icon) ? shopItem.icon : '' })
             .textField('Buy Price', 'Price', { defaultValue: String(shopItem.buyPrice) })
             .textField('Sell Price', 'Price', { defaultValue: String(shopItem.sellPrice) })
-            .textField('Permission', 'Level', { defaultValue: String(shopItem.permissionLevel) });
+            .textField('Permission Node', 'ui.panel.member', { defaultValue: shopItem.permission });
     }
 
     async handleResponse(player: mc.Player, panelId: string, response: ActionFormResponse | ModalFormResponse, context: UIContext): Promise<void> {
@@ -604,7 +604,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
         const icon = iconStr;
         const buyPrice = Number.parseInt(isNonEmptyString(buyPriceStr) ? buyPriceStr : '-1', 10);
         const sellPrice = Number.parseInt(isNonEmptyString(sellPriceStr) ? sellPriceStr : '-1', 10);
-        const permissionLevel = Number.parseInt(isNonEmptyString(permLevelStr) ? permLevelStr : '1024', 10);
+        const permission = isNonEmptyString(permLevelStr) ? permLevelStr : 'ui.panel.member';
 
         if (isNonEmptyString(customId) && isNonEmptyString(displayName) && isNonEmptyString(mcId) && !Number.isNaN(buyPrice)) {
             shopAdminManager.addCustomItemToConfig(customId, {
@@ -617,7 +617,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
             shopAdminManager.setItem(context.categoryName as string, (context.subCategoryName as string) || undefined, customId, {
                 buyPrice,
                 sellPrice,
-                permissionLevel,
+                permission,
                 icon: icon ?? '',
                 displayName,
                 itemId: customId
@@ -647,13 +647,13 @@ export class ShopAdminPanelHandler implements IPanelHandler {
         const icon = iconStr;
         const buyPrice = Number.parseInt(isNonEmptyString(buyPriceStr) ? buyPriceStr : '-1', 10);
         const sellPrice = Number.parseInt(isNonEmptyString(sellPriceStr) ? sellPriceStr : '-1', 10);
-        const permissionLevel = Number.parseInt(isNonEmptyString(permLevelStr) ? permLevelStr : '1024', 10);
+        const permission = isNonEmptyString(permLevelStr) ? permLevelStr : 'ui.panel.member';
 
         if (!Number.isNaN(buyPrice) && isDefined(masterItem)) {
             shopAdminManager.setItem(context.categoryName as string, (context.subCategoryName as string) || undefined, itemId, {
                 buyPrice,
                 sellPrice,
-                permissionLevel,
+                permission,
                 icon: icon ?? '',
                 displayName: masterItem.displayName ?? '',
                 itemId: itemId
@@ -682,12 +682,12 @@ export class ShopAdminPanelHandler implements IPanelHandler {
         const icon = vals[2] ?? undefined;
         const bPrice = vals[3] ?? undefined;
         const sPrice = vals[4] ?? undefined;
-        const pLevel = vals[5] ?? undefined;
+        const pLevel = vals[5] as string | undefined;
 
         shopAdminManager.updateShopItem(categoryName, subCategoryName ?? undefined, itemId, {
             buyPrice: isDefined(bPrice) ? Number(bPrice) : -1,
             sellPrice: isDefined(sPrice) ? Number(sPrice) : -1,
-            permissionLevel: isDefined(pLevel) ? Number(pLevel) : 1024,
+            permission: pLevel ?? 'ui.panel.member',
             icon: icon ?? '',
             minecraftId: mId ?? itemId,
             displayName: dName ?? itemId

--- a/src/features/shop/ui/userPanel.ts
+++ b/src/features/shop/ui/userPanel.ts
@@ -25,7 +25,7 @@ interface ShopItemEntry {
     displayName?: string;
     buyPrice: number;
     sellPrice: number;
-    permissionLevel: number;
+    permission?: string;
 }
 
 type ShopEntry = ShopCategoryEntry | ShopItemEntry;
@@ -78,7 +78,7 @@ export class ShopUserPanelHandler implements IPanelHandler {
             id: 'search',
             text: '§l§6Search Item',
             icon: 'textures/ui/magnifyingGlass',
-            permissionLevel: 1024,
+            permission: 'ui.panel.member',
             actionType: 'openPanel',
             actionValue: 'shopSearchPanel'
         });
@@ -99,7 +99,7 @@ export class ShopUserPanelHandler implements IPanelHandler {
                 id: catName,
                 text: catName,
                 icon: cat.icon,
-                permissionLevel: 1024,
+                permission: 'ui.panel.member',
                 actionType: 'openPanel',
                 actionValue: `shopCategoryPanel_${catName}`
             });
@@ -160,7 +160,7 @@ export class ShopUserPanelHandler implements IPanelHandler {
                 displayName,
                 buyPrice: item.buyPrice,
                 sellPrice: item.sellPrice,
-                permissionLevel: item.permissionLevel
+                permission: item.permission
             });
         }
     }
@@ -191,7 +191,7 @@ export class ShopUserPanelHandler implements IPanelHandler {
                     id,
                     buyPrice: item.buyPrice,
                     sellPrice: item.sellPrice,
-                    permissionLevel: item.permissionLevel,
+                    permission: item.permission,
                     type: 'item'
                 };
                 if (isDefined(item.icon)) entry.icon = item.icon;
@@ -220,7 +220,7 @@ export class ShopUserPanelHandler implements IPanelHandler {
                         id: entry.name,
                         text: `§6${entry.name}`,
                         icon: entry.icon,
-                        permissionLevel: 1024,
+                        permission: 'ui.panel.member',
                         actionType: 'openPanel',
                         actionValue: `shopItemListPanel_${categoryName}_${entry.name}`
                     });
@@ -253,7 +253,7 @@ export class ShopUserPanelHandler implements IPanelHandler {
                         id,
                         buyPrice: item.buyPrice,
                         sellPrice: item.sellPrice,
-                        permissionLevel: item.permissionLevel,
+                        permission: item.permission,
                         type: 'item'
                     };
                     if (isDefined(item.icon)) entry.icon = item.icon;
@@ -280,7 +280,7 @@ export class ShopUserPanelHandler implements IPanelHandler {
             id: entry.id,
             text: `${entry.displayName}\n${priceString}`,
             icon: entry.icon ?? '',
-            permissionLevel: 1024,
+            permission: 'ui.panel.member',
             actionType: 'functionCall',
             actionValue: 'buyOrSell'
         });

--- a/src/features/social/ui/friendPanel.ts
+++ b/src/features/social/ui/friendPanel.ts
@@ -24,7 +24,7 @@ export class FriendPanelHandler implements IPanelHandler {
                     icon: 'textures/ui/multiplayer',
                     actionType: 'openPanel',
                     actionValue: 'friendListPanel',
-                    permissionLevel: 1024
+                    permission: 'ui.panel.member'
                 },
                 {
                     id: 'friendAddBtn',
@@ -32,7 +32,7 @@ export class FriendPanelHandler implements IPanelHandler {
                     icon: 'textures/ui/plus',
                     actionType: 'openPanel',
                     actionValue: 'friendAddPanel',
-                    permissionLevel: 1024
+                    permission: 'ui.panel.member'
                 },
                 {
                     id: 'friendReqBtn',
@@ -40,7 +40,7 @@ export class FriendPanelHandler implements IPanelHandler {
                     icon: 'textures/ui/invite_base',
                     actionType: 'openPanel',
                     actionValue: 'friendRequestsPanel',
-                    permissionLevel: 1024
+                    permission: 'ui.panel.member'
                 }
             ];
         }
@@ -68,7 +68,7 @@ export class FriendPanelHandler implements IPanelHandler {
                     icon: icon,
                     actionType: 'functionCall',
                     actionValue: `manageFriend:${fid}`,
-                    permissionLevel: 1024
+                    permission: 'ui.panel.member'
                 };
             });
         }

--- a/src/features/team/ui/panel.ts
+++ b/src/features/team/ui/panel.ts
@@ -24,7 +24,7 @@ export class TeamPanelHandler implements IPanelHandler {
 
         // Base items (Back button)
         const def = panelDefinitions[panelId];
-        const baseItems = isDefined(def) ? getStaticMenuItems(def, 1024) : [];
+        const baseItems = isDefined(def) ? getStaticMenuItems(player, def) : [];
 
         if (panelId === 'teamMainPanel') {
             return this.getTeamMainPanelItems(player, team, baseItems);
@@ -48,7 +48,7 @@ export class TeamPanelHandler implements IPanelHandler {
                     icon: 'textures/ui/settings_glyph_color_2x',
                     actionType: 'openPanel',
                     actionValue: 'teamSettingPanel',
-                    permissionLevel: 1024
+                    permission: 'ui.panel.member'
                 },
                 {
                     id: 'teamRequestsBtn',
@@ -56,7 +56,7 @@ export class TeamPanelHandler implements IPanelHandler {
                     icon: 'textures/ui/user_icon',
                     actionType: 'openPanel',
                     actionValue: 'teamRequestsPanel',
-                    permissionLevel: 1024
+                    permission: 'ui.panel.member'
                 },
                 {
                     id: 'teamHomeManageBtn',
@@ -64,7 +64,7 @@ export class TeamPanelHandler implements IPanelHandler {
                     icon: 'textures/ui/portal',
                     actionType: 'openPanel',
                     actionValue: 'teamHomePanel',
-                    permissionLevel: 1024
+                    permission: 'ui.panel.member'
                 }
             ];
         }
@@ -88,7 +88,7 @@ export class TeamPanelHandler implements IPanelHandler {
                     icon: icon,
                     actionType: 'openPanel',
                     actionValue: 'teamRequestActionPanel',
-                    permissionLevel: 1024
+                    permission: 'ui.panel.member'
                 };
                 return item;
             });
@@ -102,7 +102,7 @@ export class TeamPanelHandler implements IPanelHandler {
                 icon: 'textures/ui/check',
                 actionType: 'functionCall',
                 actionValue: 'acceptTeamRequest',
-                permissionLevel: 1024
+                permission: 'ui.panel.member'
             };
             const deny: PanelItem = {
                 id: 'deny',
@@ -110,7 +110,7 @@ export class TeamPanelHandler implements IPanelHandler {
                 icon: 'textures/ui/cancel',
                 actionType: 'functionCall',
                 actionValue: 'denyTeamRequest',
-                permissionLevel: 1024
+                permission: 'ui.panel.member'
             };
             return [...baseItems, accept, deny];
         }
@@ -123,7 +123,7 @@ export class TeamPanelHandler implements IPanelHandler {
                 icon: 'textures/ui/op',
                 actionType: 'functionCall',
                 actionValue: 'setTeamHome',
-                permissionLevel: 1024
+                permission: 'ui.panel.member'
             };
             const delHome: PanelItem = {
                 id: 'delHome',
@@ -131,7 +131,7 @@ export class TeamPanelHandler implements IPanelHandler {
                 icon: 'textures/ui/trash',
                 actionType: 'functionCall',
                 actionValue: 'deleteTeamHome',
-                permissionLevel: 1024
+                permission: 'ui.panel.member'
             };
             const tpHome: PanelItem = {
                 id: 'tpHome',
@@ -139,7 +139,7 @@ export class TeamPanelHandler implements IPanelHandler {
                 icon: 'textures/ui/portal',
                 actionType: 'functionCall',
                 actionValue: 'teamTpHome',
-                permissionLevel: 1024
+                permission: 'ui.panel.member'
             };
             return [...baseItems, setHome, delHome, tpHome];
         }
@@ -155,7 +155,7 @@ export class TeamPanelHandler implements IPanelHandler {
                     icon: 'textures/ui/mail_icon',
                     actionType: 'openPanel',
                     actionValue: 'teamInviteActionPanel',
-                    permissionLevel: 1024
+                    permission: 'ui.panel.member'
                 };
                 return item;
             });
@@ -169,7 +169,7 @@ export class TeamPanelHandler implements IPanelHandler {
                 icon: 'textures/ui/check',
                 actionType: 'functionCall',
                 actionValue: 'acceptTeamInvite',
-                permissionLevel: 1024
+                permission: 'ui.panel.member'
             };
             const deny: PanelItem = {
                 id: 'deny',
@@ -177,7 +177,7 @@ export class TeamPanelHandler implements IPanelHandler {
                 icon: 'textures/ui/cancel',
                 actionType: 'functionCall',
                 actionValue: 'denyTeamInvite',
-                permissionLevel: 1024
+                permission: 'ui.panel.member'
             };
             return [...baseItems, accept, deny];
         }
@@ -191,7 +191,7 @@ export class TeamPanelHandler implements IPanelHandler {
                     icon: 'textures/ui/world_glyph_color',
                     actionType: 'functionCall',
                     actionValue: 'applyToTeam',
-                    permissionLevel: 1024
+                    permission: 'ui.panel.member'
                 };
                 return item;
             });
@@ -211,7 +211,7 @@ export class TeamPanelHandler implements IPanelHandler {
                     icon: 'textures/ui/color_plus',
                     actionType: 'openPanel',
                     actionValue: 'teamCreatePanel',
-                    permissionLevel: 1024
+                    permission: 'ui.panel.member'
                 },
                 {
                     id: 'teamJoinBtn',
@@ -219,7 +219,7 @@ export class TeamPanelHandler implements IPanelHandler {
                     icon: 'textures/ui/magnifyingGlass',
                     actionType: 'openPanel',
                     actionValue: 'teamJoinPanel',
-                    permissionLevel: 1024
+                    permission: 'ui.panel.member'
                 }
             ];
         }
@@ -235,7 +235,7 @@ export class TeamPanelHandler implements IPanelHandler {
                 icon: 'textures/ui/multiplayer',
                 actionType: 'openPanel',
                 actionValue: 'teamMembersPanel',
-                permissionLevel: 1024
+                permission: 'ui.panel.member'
             },
             {
                 id: 'teamInfoBtn',
@@ -243,7 +243,7 @@ export class TeamPanelHandler implements IPanelHandler {
                 icon: 'textures/ui/infobulb',
                 actionType: 'functionCall',
                 actionValue: 'noop',
-                permissionLevel: 1024
+                permission: 'ui.panel.member'
             },
             {
                 id: 'teamDepositBtn',
@@ -251,7 +251,7 @@ export class TeamPanelHandler implements IPanelHandler {
                 icon: 'textures/ui/gold_ingot',
                 actionType: 'functionCall',
                 actionValue: 'teamDeposit',
-                permissionLevel: 1024
+                permission: 'ui.panel.member'
             }
         ];
 
@@ -262,7 +262,7 @@ export class TeamPanelHandler implements IPanelHandler {
                 icon: 'textures/ui/portal',
                 actionType: 'functionCall',
                 actionValue: 'teamTpHome',
-                permissionLevel: 1024
+                permission: 'ui.panel.member'
             });
         }
 
@@ -273,7 +273,7 @@ export class TeamPanelHandler implements IPanelHandler {
                 icon: 'textures/ui/gear',
                 actionType: 'openPanel',
                 actionValue: 'teamManagePanel',
-                permissionLevel: 1024
+                permission: 'ui.panel.member'
             });
         }
 
@@ -283,7 +283,7 @@ export class TeamPanelHandler implements IPanelHandler {
             icon: 'textures/ui/door',
             actionType: 'functionCall',
             actionValue: 'teamLeave',
-            permissionLevel: 1024
+            permission: 'ui.panel.member'
         });
 
         return items;
@@ -318,7 +318,7 @@ export class TeamPanelHandler implements IPanelHandler {
                 icon: icon,
                 actionType: 'openPanel',
                 actionValue: 'teamMemberActionPanel',
-                permissionLevel: 1024
+                permission: 'ui.panel.member'
             };
             return item;
         });
@@ -344,7 +344,7 @@ export class TeamPanelHandler implements IPanelHandler {
                 icon: 'textures/ui/cancel',
                 actionType: 'functionCall',
                 actionValue: 'kickTeamMember',
-                permissionLevel: 1024
+                permission: 'ui.panel.member'
             });
         }
 
@@ -356,7 +356,7 @@ export class TeamPanelHandler implements IPanelHandler {
                     icon: 'textures/ui/down_arrow',
                     actionType: 'functionCall',
                     actionValue: 'demoteTeamMember',
-                    permissionLevel: 1024
+                    permission: 'ui.panel.member'
                 });
             } else {
                 items.push({
@@ -365,7 +365,7 @@ export class TeamPanelHandler implements IPanelHandler {
                     icon: 'textures/ui/up_arrow',
                     actionType: 'functionCall',
                     actionValue: 'promoteTeamMember',
-                    permissionLevel: 1024
+                    permission: 'ui.panel.member'
                 });
             }
             items.push({
@@ -374,7 +374,7 @@ export class TeamPanelHandler implements IPanelHandler {
                 icon: 'textures/ui/crown',
                 actionType: 'functionCall',
                 actionValue: 'transferTeamOwnership',
-                permissionLevel: 1024
+                permission: 'ui.panel.member'
             });
         }
 
@@ -388,7 +388,7 @@ export class TeamPanelHandler implements IPanelHandler {
         if (!isDefined(items)) {
             const def = panelDefinitions[panelId];
             if (isDefined(def)) {
-                items = getStaticMenuItems(def, 1024);
+                items = getStaticMenuItems(player, def);
             } else {
                 return;
             }

--- a/src/features/teleport/ui/panel.ts
+++ b/src/features/teleport/ui/panel.ts
@@ -27,7 +27,7 @@ export class TeleportPanelHandler implements IPanelHandler {
                     id: 'tpaDisabled',
                     text: '§cSystem Globally Disabled',
                     icon: 'textures/ui/warning_alert',
-                    permissionLevel: 1024,
+                    permission: 'ui.panel.member',
                     actionType: 'functionCall',
                     actionValue: 'noop'
                 });
@@ -39,7 +39,7 @@ export class TeleportPanelHandler implements IPanelHandler {
                     id: 'toggleTpa',
                     text: isEnabled ? '§2Incoming Requests: Allowed' : '§4Incoming Requests: Blocked',
                     icon: isEnabled ? 'textures/ui/realms_green_check' : 'textures/ui/cancel',
-                    permissionLevel: 1024,
+                    permission: 'ui.panel.member',
                     actionType: 'functionCall',
                     actionValue: 'toggleTpa'
                 },
@@ -47,7 +47,7 @@ export class TeleportPanelHandler implements IPanelHandler {
                     id: 'blockList',
                     text: 'Blocked Players',
                     icon: 'textures/ui/icon_multiplayer',
-                    permissionLevel: 1024,
+                    permission: 'ui.panel.member',
                     actionType: 'openPanel',
                     actionValue: 'tpaBlockListPanel'
                 }
@@ -63,7 +63,7 @@ export class TeleportPanelHandler implements IPanelHandler {
                 items.push({
                     id: id,
                     text: name,
-                    permissionLevel: 1024,
+                    permission: 'ui.panel.member',
                     actionType: 'functionCall',
                     actionValue: 'unblockPlayer'
                 });

--- a/src/features/vote/ui/panel.ts
+++ b/src/features/vote/ui/panel.ts
@@ -9,9 +9,8 @@ import { isDefined, isNonEmptyString } from '@lib/guards.js';
 
 export async function showVoteMenu(player: mc.Player) {
     const activeVote = getActiveVote();
-    const config = getConfig();
-    const rank = getPlayerRank(player, config);
-    const isAdmin = rank.permissionLevel <= 1;
+    const { hasPermission } = require('@core/permissionEngine.js');
+    const isAdmin = hasPermission(player, 'ui.panel.admin');
 
     await (isDefined(activeVote) ? handleActiveVote(player, activeVote, isAdmin) : handleNoActiveVote(player, isAdmin));
 }

--- a/src/features/vote/ui/panel.ts
+++ b/src/features/vote/ui/panel.ts
@@ -1,8 +1,6 @@
 import * as mc from '@minecraft/server';
 import { ActionFormData, ActionFormResponse, ModalFormData, ModalFormResponse } from '@minecraft/server-ui';
 
-import { getConfig } from '@core/configManager.js';
-import { getPlayerRank } from '@core/rankManager.js';
 import { uiWait } from '@core/utils.js';
 import { castVote, createVote, endVote, getActiveVote, getLastVote } from '@features/vote/manager.js';
 import { isDefined, isNonEmptyString } from '@lib/guards.js';

--- a/src/features/vote/ui/panel.ts
+++ b/src/features/vote/ui/panel.ts
@@ -1,3 +1,4 @@
+import { hasPermission } from '@core/permissionEngine.js';
 import * as mc from '@minecraft/server';
 import { ActionFormData, ActionFormResponse, ModalFormData, ModalFormResponse } from '@minecraft/server-ui';
 
@@ -7,7 +8,7 @@ import { isDefined, isNonEmptyString } from '@lib/guards.js';
 
 export async function showVoteMenu(player: mc.Player) {
     const activeVote = getActiveVote();
-    const { hasPermission } = require('@core/permissionEngine.js');
+
     const isAdmin = hasPermission(player, 'ui.panel.admin');
 
     await (isDefined(activeVote) ? handleActiveVote(player, activeVote, isAdmin) : handleNoActiveVote(player, isAdmin));


### PR DESCRIPTION
Refactored the entirety of the UI Schema (`src/core/ui/`) and all Feature Panel Handlers to complete Session 5 of the plan.

This PR shifts the UI definitions from using an integer-based `permissionLevel` check to the new string-based node system powered by `permissionEngine`. All integer checks have been fully stripped from the UI component library.

---
*PR created automatically by Jules for task [3013803989430129999](https://jules.google.com/task/3013803989430129999) started by @SjnExe*