### PR TITLE
Refactor command system to use string-based permission nodes

### DIFF
--- a/src/core/__tests__/CommandManager.test.ts
+++ b/src/core/__tests__/CommandManager.test.ts
@@ -28,6 +28,10 @@ vi.mock('../logger.js', () => ({
     infoLog: vi.fn()
 }));
 
+vi.mock('../permissionEngine.js', () => ({
+    hasPermission: vi.fn().mockReturnValue(true)
+}));
+
 const { commandManager } = await import('@commands/commandManager.js');
 
 describe('CommandManager', () => {

--- a/src/core/commands/commandManager.ts
+++ b/src/core/commands/commandManager.ts
@@ -389,7 +389,7 @@ class CommandManager {
                         'id' in executor // Only filter if executor is a player
                     ) {
                         // Use permission node to see vanished players
-                        if (!hasPermission(executor as mc.Player, 'cmd.vanish.see')) {
+                        if (!hasPermission(executor, 'cmd.vanish.see')) {
                             value = (value as mc.Player[]).filter((target) => {
                                 const targetData = getPlayer(target.id);
                                 return !(isDefined(targetData) && targetData.isVanished);

--- a/src/core/commands/commandManager.ts
+++ b/src/core/commands/commandManager.ts
@@ -3,6 +3,7 @@ import * as mc from '@minecraft/server';
 import { getConfig } from '@core/configManager.js';
 import { getCooldown, setCooldownCustom } from '@core/cooldownManager.js';
 import { debugLog, errorLog, infoLog } from '@core/logger.js';
+import { hasPermission } from '@core/permissionEngine.js';
 import { findVisiblePlayerByName, getPlayer } from '@core/playerDataManager.js';
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
 
@@ -46,8 +47,8 @@ export interface CustomCommand {
     description: string;
     /** The UI category for the command. */
     category?: string;
-    /** The required permission level to execute the command. Defaults to 0 (Owner). */
-    permissionLevel?: number;
+    /** The required permission node to execute the command. Defaults to `cmd.${name}`. */
+    permissionNode?: string;
     /** An array of alternative names for the command. */
     aliases?: string[];
     /** An array of parameters the command accepts. */
@@ -75,7 +76,7 @@ export interface CustomCommand {
 interface CommandSettings {
     [key: string]: {
         enabled?: boolean;
-        permissionLevel?: number;
+        permissionNode?: string;
         cooldownSeconds?: number;
     };
 }
@@ -161,7 +162,7 @@ class CommandManager {
      * @param {CustomCommand} commandOptions
      */
     register(commandOptions: CustomCommand) {
-        const command: CustomCommand = { permissionLevel: 0, ...commandOptions };
+        const command: CustomCommand = { permissionNode: `cmd.${commandOptions.name.toLowerCase()}`, ...commandOptions };
         this.commands.set(command.name.toLowerCase(), command);
 
         if (isDefined(command.aliases)) {
@@ -180,18 +181,18 @@ class CommandManager {
     }
 
     /**
-     * Gets the effective permission level for a command, considering config overrides.
+     * Gets the effective permission node for a command, considering config overrides.
      * @param {CustomCommand} command The command to check.
-     * @returns {number} The effective permission level.
+     * @returns {string} The effective permission node.
      */
-    getEffectivePermissionLevel(command: CustomCommand): number {
+    getEffectivePermissionNode(command: CustomCommand): string {
         const config = getConfig() as Config;
-        if (!isDefined(config)) return command.permissionLevel ?? 0;
+        if (!isDefined(config)) return command.permissionNode ?? `cmd.${command.name.toLowerCase()}`;
         const commandSettings = isDefined(config.commandSettings) ? config.commandSettings[command.name] : undefined;
-        if (isDefined(commandSettings) && isDefined(commandSettings.permissionLevel)) {
-            return commandSettings.permissionLevel;
+        if (isDefined(commandSettings) && isDefined(commandSettings.permissionNode)) {
+            return commandSettings.permissionNode;
         }
-        return command.permissionLevel ?? 0;
+        return command.permissionNode ?? `cmd.${command.name.toLowerCase()}`;
     }
 
     /**
@@ -277,10 +278,9 @@ class CommandManager {
         }
 
         // Permission Check
-        const pData = getPlayer(player.id);
-        const requiredPermissionLevel = this.getEffectivePermissionLevel(command);
+        const requiredPermissionNode = this.getEffectivePermissionNode(command);
 
-        if (!isDefined(pData) || pData.permissionLevel > requiredPermissionLevel) {
+        if (!hasPermission(player, requiredPermissionNode)) {
             player.sendMessage('§cYou do not have permission to use this command.');
             return;
         }
@@ -388,9 +388,8 @@ class CommandManager {
                         Array.isArray(value) &&
                         'id' in executor // Only filter if executor is a player
                     ) {
-                        const executorData = getPlayer(executor.id);
-                        // Level 2 (Mod) and below can see vanished players
-                        if (isDefined(executorData) && executorData.permissionLevel > 2) {
+                        // Use permission node to see vanished players
+                        if (!hasPermission(executor as mc.Player, 'cmd.vanish.see')) {
                             value = (value as mc.Player[]).filter((target) => {
                                 const targetData = getPlayer(target.id);
                                 return !(isDefined(targetData) && targetData.isVanished);
@@ -439,7 +438,7 @@ class CommandManager {
         return {
             name: `${this.prefix}:${slashCommandName}`,
             description: command.description,
-            permissionLevel: this.translatePermissionLevel(command.permissionLevel),
+            permissionLevel: this.translatePermissionLevel(command.permissionNode),
             mandatoryParameters,
             optionalParameters
         };
@@ -513,12 +512,12 @@ class CommandManager {
     }
 
     /**
-     * Translates the numeric permission level to the API's enum.
-     * @param {number | undefined} level The numeric permission level.
+     * Translates the custom permission node to the API's enum.
+     * @param {string | undefined} node The custom permission node.
      * @returns {mc.CommandPermissionLevel} The corresponding enum value.
      * @private
      */
-    private translatePermissionLevel(_level?: number): mc.CommandPermissionLevel {
+    private translatePermissionLevel(_node?: string): mc.CommandPermissionLevel {
         // We will handle all permission checks with our custom rank system.
         // Registering all commands with 'Any' allows our more granular check to be the single source of truth.
         return mc.CommandPermissionLevel.Any;

--- a/src/core/ui/panels/commandPanel.ts
+++ b/src/core/ui/panels/commandPanel.ts
@@ -10,7 +10,7 @@ import { addBackButton, addPaginationItems, getPaginatedItems } from '@ui/uiUtil
 
 interface CmdSettings {
     enabled?: boolean;
-    permissionLevel?: number;
+    permissionNode?: string;
     cooldownSeconds?: number;
 }
 
@@ -37,11 +37,10 @@ export class CommandPanelHandler implements IPanelHandler {
                 const cmdSettings = settings[cmd.name] ?? {};
                 const isEnabled = cmdSettings.enabled !== false;
                 const color = isEnabled ? '§2' : '§4';
-                const perm = cmdSettings.permissionLevel ?? cmd.permissionLevel ?? 0;
 
                 items.push({
                     id: cmd.name,
-                    text: `${color}/${cmd.name}§r\nPerm: ${perm}`,
+                    text: `${color}/${cmd.name}§r`,
                     icon: 'textures/ui/command_block_icon',
                     permission: 'ui.panel.owner',
                     actionType: 'openPanel',
@@ -63,14 +62,12 @@ export class CommandPanelHandler implements IPanelHandler {
             const command = commandManager.commands.get(cmdName);
 
             const isEnabled = cmdSettings.enabled !== false;
-            const perm = cmdSettings.permissionLevel ?? command?.permissionLevel ?? 0;
             const cooldown = cmdSettings.cooldownSeconds ?? command?.defaultCooldown ?? 0;
 
             return Promise.resolve(
                 new ModalFormData()
                     .title(`Edit /${cmdName}`)
                     .toggle('Enabled', { defaultValue: isEnabled })
-                    .textField('Permission Level', '0=Owner, 1=Admin...', { defaultValue: String(perm) })
                     .textField('Cooldown (seconds)', '0 to disable', { defaultValue: String(cooldown) })
             );
         }
@@ -115,13 +112,11 @@ export class CommandPanelHandler implements IPanelHandler {
             if ((response as ModalFormResponse).canceled) return showPanel(player, 'commandSystemPanel', context);
 
             if (values) {
-                const [enabled, permStr, cooldownStr] = values as [boolean, string, string];
-                const perm = Number.parseInt(permStr) || 0;
+                const [enabled, cooldownStr] = values as [boolean, string];
                 const cooldown = Number.parseInt(cooldownStr) || 0;
 
                 const updates: Record<string, unknown> = {
                     [`commandSettings.${cmdName}.enabled`]: enabled,
-                    [`commandSettings.${cmdName}.permissionLevel`]: perm,
                     [`commandSettings.${cmdName}.cooldownSeconds`]: cooldown
                 };
 

--- a/src/core/ui/types.ts
+++ b/src/core/ui/types.ts
@@ -118,7 +118,7 @@ export interface MainConfig {
             announce?: boolean;
         };
     };
-    commandSettings?: Record<string, { enabled?: boolean; permissionLevel?: number; cooldownSeconds?: number }>;
+    commandSettings?: Record<string, { enabled?: boolean; permissionNode?: string; cooldownSeconds?: number }>;
     [key: string]: unknown;
 }
 

--- a/src/features/anticheat/commands/logs.ts
+++ b/src/features/anticheat/commands/logs.ts
@@ -13,7 +13,7 @@ const logsCommand: CustomCommand = {
     name: 'logs',
     description: 'View punishment, anticheat, and chat logs.',
     category: 'Moderation',
-    permissionLevel: 1, // Admin only
+
     execute: async (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) return;
         await showLogsMenu(executor);

--- a/src/features/anticheat/commands/notify.ts
+++ b/src/features/anticheat/commands/notify.ts
@@ -9,7 +9,7 @@ const notifyCommand: CustomCommand = {
     name: 'notify',
     description: 'Toggle anti-cheat notifications.',
     category: 'Moderation',
-    permissionLevel: 2, // Mod
+
     execute: (executor: CommandExecutor) => {
         if (executor instanceof mc.Player) {
             const pData = getPlayer(executor.id);

--- a/src/features/anticheat/commands/xraynotify.ts
+++ b/src/features/anticheat/commands/xraynotify.ts
@@ -14,7 +14,7 @@ const command: CustomCommand = {
     aliases: ['xray'],
     description: 'Toggles X-ray notifications for yourself or the console.',
     category: 'Administration',
-    permissionLevel: 2, // Moderator
+
     allowConsole: true,
     parameters: [],
     execute: (executor) => {

--- a/src/features/auction/commands/ah.ts
+++ b/src/features/auction/commands/ah.ts
@@ -15,7 +15,7 @@ const mainCommand: CustomCommand = {
     aliases: ['auction'],
     description: 'Auction House commands.',
     category: 'Economy',
-    permissionLevel: 1024,
+
     parameters: [
         { name: 'subcommand', type: 'string', optional: true, enumOptions: ['sell', 'help', 'search'] },
         { name: 'price', type: 'string', optional: true },

--- a/src/features/daily/commands/daily.ts
+++ b/src/features/daily/commands/daily.ts
@@ -11,7 +11,7 @@ const dailyCommand: CustomCommand = {
     aliases: ['reward'],
     description: 'Claim your daily reward.',
     category: 'Economy',
-    permissionLevel: 1024,
+
     execute: (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) return;
 

--- a/src/features/economy/commands/balance.ts
+++ b/src/features/economy/commands/balance.ts
@@ -13,7 +13,7 @@ const balanceCommand: CustomCommand = {
     aliases: ['bal', 'money', 'cash'],
     description: "Checks your or another player's balance.",
     category: 'Economy',
-    permissionLevel: 1024,
+
     parameters: [{ name: 'targets', type: 'string', optional: true }],
     execute: (executor: CommandExecutor, args: Record<string, unknown>) => {
         const config = getConfig();
@@ -57,7 +57,7 @@ const oBalanceCommand: CustomCommand = {
     aliases: ['obal', 'offlinebalance'],
     description: "Checks an offline player's balance.",
     category: 'Economy',
-    permissionLevel: 1024,
+
     allowConsole: true,
     hidden: true,
     parameters: [{ name: 'target', type: 'string' }],
@@ -89,7 +89,7 @@ const baltopCommand: CustomCommand = {
     aliases: ['topbal', 'leaderboard', 'richlist'],
     description: 'Shows the players with the highest balances on the server.',
     category: 'Economy',
-    permissionLevel: 1024,
+
     allowConsole: true,
     execute: (executor: CommandExecutor) => {
         const config = getConfig();

--- a/src/features/economy/commands/bounty.ts
+++ b/src/features/economy/commands/bounty.ts
@@ -67,7 +67,7 @@ const bountyCommand: CustomCommand = {
     description: 'Place a bounty on a player.',
     category: 'Economy',
     aliases: ['setbounty', 'addbounty', '+bounty', 'abounty'],
-    permissionLevel: 1024,
+
     parameters: [
         { name: 'target', type: 'string' },
         { name: 'amount', type: 'string' }
@@ -97,7 +97,7 @@ const removeBountyCommand: CustomCommand = {
     aliases: ['rbounty', 'delbounty', '-bounty'],
     description: 'Removes a bounty from a player using your money.',
     category: 'Economy',
-    permissionLevel: 1024,
+
     parameters: [
         { name: 'target', type: 'string' },
         { name: 'amount', type: 'string' }
@@ -143,7 +143,7 @@ const oBountyCommand: CustomCommand = {
     aliases: ['offlinebounty'],
     description: 'Place a bounty on an offline player.',
     category: 'Economy',
-    permissionLevel: 1024,
+
     hidden: true,
     parameters: [
         { name: 'target', type: 'string' },
@@ -173,7 +173,7 @@ const oRemoveBountyCommand: CustomCommand = {
     aliases: ['offlineremovebounty'],
     description: 'Removes a bounty from an offline player.',
     category: 'Economy',
-    permissionLevel: 1024,
+
     hidden: true,
     parameters: [
         { name: 'target', type: 'string' },
@@ -266,7 +266,7 @@ const listBountyCommand: CustomCommand = {
     aliases: ['lbounty', 'bounties', 'bountylist', 'showbounties', 'hitlist'],
     description: "Lists all active bounties or a specific player's bounty.",
     category: 'Economy',
-    permissionLevel: 1024,
+
     allowConsole: true,
     parameters: [{ name: 'target', type: 'string', optional: true }],
     execute: (executor: CommandExecutor, args: Record<string, unknown>) => {
@@ -287,7 +287,7 @@ const oListBountyCommand: CustomCommand = {
     aliases: ['offlinelistbounty'],
     description: "Checks an offline player's bounty.",
     category: 'Economy',
-    permissionLevel: 1024,
+
     allowConsole: true,
     hidden: true,
     parameters: [{ name: 'target', type: 'string' }],

--- a/src/features/economy/commands/pay.ts
+++ b/src/features/economy/commands/pay.ts
@@ -15,7 +15,7 @@ const payCommand: CustomCommand = {
     aliases: ['givemoney', 'transfer'],
     description: 'Pays another player from your balance.',
     category: 'Economy',
-    permissionLevel: 1024,
+
     hasCooldown: true,
     defaultCooldown: 5,
     parameters: [
@@ -71,7 +71,7 @@ const oPayCommand: CustomCommand = {
     aliases: ['offlinepay'],
     description: 'Pays an offline player.',
     category: 'Economy',
-    permissionLevel: 1024,
+
     hasCooldown: true,
     hidden: true,
     parameters: [
@@ -122,7 +122,7 @@ const payConfirmCommand: CustomCommand = {
     aliases: ['confirmpay'],
     description: 'Confirms a pending payment.',
     category: 'Economy',
-    permissionLevel: 1024,
+
     execute: (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) return;
 

--- a/src/features/economy/commands/setbalance.ts
+++ b/src/features/economy/commands/setbalance.ts
@@ -69,7 +69,7 @@ const setBalanceCommand: CustomCommand = {
     aliases: ['setbal', 'setmoney'],
     description: "Sets a player's (or players') balance to a specific amount.",
     category: 'Economy',
-    permissionLevel: 1,
+
     allowConsole: true,
     hidden: true,
     parameters: [
@@ -86,7 +86,7 @@ const addBalanceCommand: CustomCommand = {
     aliases: ['addbal', '+bal'],
     description: "Adds a specific amount to a player's (or players') balance.",
     category: 'Economy',
-    permissionLevel: 1,
+
     allowConsole: true,
     hidden: true,
     parameters: [
@@ -103,7 +103,7 @@ const removeBalanceCommand: CustomCommand = {
     aliases: ['removebal', '-bal', 'rembal'],
     description: "Removes a specific amount from a player's (or players') balance.",
     category: 'Economy',
-    permissionLevel: 1,
+
     allowConsole: true,
     hidden: true,
     parameters: [
@@ -167,7 +167,7 @@ const oSetBalanceCommand: CustomCommand = {
     aliases: ['osetbal', 'offlinesetbalance'],
     description: "Sets an offline player's balance.",
     category: 'Economy',
-    permissionLevel: 1,
+
     allowConsole: true,
     parameters: [
         { name: 'target', type: 'string', description: "The player's name." },
@@ -183,7 +183,7 @@ const oAddBalanceCommand: CustomCommand = {
     aliases: ['oaddbal', 'offlineaddbalance'],
     description: "Adds amount to an offline player's balance.",
     category: 'Economy',
-    permissionLevel: 1,
+
     allowConsole: true,
     parameters: [
         { name: 'target', type: 'string' },
@@ -199,7 +199,7 @@ const oRemoveBalanceCommand: CustomCommand = {
     aliases: ['oremovebal', 'offlineremovebalance'],
     description: "Removes amount from an offline player's balance.",
     category: 'Economy',
-    permissionLevel: 1,
+
     allowConsole: true,
     parameters: [
         { name: 'target', type: 'string' },

--- a/src/features/essentials/commands/announcement.ts
+++ b/src/features/essentials/commands/announcement.ts
@@ -11,7 +11,7 @@ const announcementCommand: CustomCommand = {
     name: 'announce',
     description: 'Broadcasts an announcement to all players.',
     category: 'Essentials',
-    permissionLevel: 2,
+
     parameters: [{ name: 'message', type: 'text' }],
     execute: (_executor: CommandExecutor, args: Record<string, unknown>) => {
         const message = args.message as string;

--- a/src/features/essentials/commands/chattoconsole.ts
+++ b/src/features/essentials/commands/chattoconsole.ts
@@ -8,7 +8,7 @@ const command: CustomCommand = {
     aliases: ['ctc', 'chat'],
     description: 'Toggles or sets whether player chat is logged to the server console.',
     category: 'Administration',
-    permissionLevel: 1, // Admins only
+
     allowConsole: true,
     parameters: [
         {

--- a/src/features/essentials/commands/clear.ts
+++ b/src/features/essentials/commands/clear.ts
@@ -18,7 +18,7 @@ const clearCommand: CustomCommand = {
     slashName: 'xclear',
     description: 'Clears the inventory of a player or yourself.',
     aliases: ['ci', 'clearinv'],
-    permissionLevel: 2,
+
     allowConsole: true,
     parameters: [{ name: 'target', type: 'player', optional: true }],
 

--- a/src/features/essentials/commands/debug.ts
+++ b/src/features/essentials/commands/debug.ts
@@ -9,7 +9,7 @@ const debugCommand: CustomCommand = {
     name: 'debug',
     description: 'Displays debug information.',
     category: 'Essentials',
-    permissionLevel: 1, // Admin only
+
     execute: (executor: CommandExecutor) => {
         const memory = mc.system.currentTick;
         // Optimization: Use cached player count

--- a/src/features/essentials/commands/fixplayer.ts
+++ b/src/features/essentials/commands/fixplayer.ts
@@ -7,7 +7,7 @@ const fixPlayerCommand: CustomCommand = {
     name: 'fixplayer',
     description: 'Fixes a player state (e.g. stuck in spawn protection, invulnerable).',
     category: 'Administration',
-    permissionLevel: 1024, // Anyone can use it on themselves
+
     execute: (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) return;
 

--- a/src/features/essentials/commands/floatingtext.ts
+++ b/src/features/essentials/commands/floatingtext.ts
@@ -8,7 +8,7 @@ const command: CustomCommand = {
     name: 'floatingtext',
     description: 'Manages floating text entities.',
     category: 'Essentials',
-    permissionLevel: 1, // Admin
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     execute: (executor: CommandExecutor, args: any) => {
         if (!(executor instanceof mc.Player)) {

--- a/src/features/essentials/commands/gamemode.ts
+++ b/src/features/essentials/commands/gamemode.ts
@@ -82,7 +82,7 @@ const mainGamemodeCommand: CustomCommand = {
     aliases: ['gm'],
     description: "Sets your or another player's gamemode.",
     category: 'Administration',
-    permissionLevel: 1,
+
     allowConsole: true,
     parameters: [
         {
@@ -128,7 +128,7 @@ const legacyCommands: CustomCommand[] = legacyCommandDefs.map((cmd) => ({
     aliases: cmd.aliases,
     description: cmd.description,
     category: 'Administration',
-    permissionLevel: 1,
+
     allowConsole: true,
     parameters: [{ name: 'targets', type: 'player', description: 'The player(s) to set the gamemode for', optional: true }],
     execute: (executor, args) => {

--- a/src/features/essentials/commands/help.ts
+++ b/src/features/essentials/commands/help.ts
@@ -4,9 +4,9 @@ import { ActionFormData, ActionFormResponse } from '@minecraft/server-ui';
 import { getConfig } from '@core/configManager.js';
 import { noPermission } from '@core/constants.js';
 import { sendMessage } from '@core/messaging.js';
-import { getPlayer } from '@core/playerDataManager.js';
 import { uiWait } from '@core/utils.js';
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
+import { hasPermission } from '@core/permissionEngine.js';
 
 import { CommandExecutor, commandManager, CustomCommand } from '@commands/commandManager.js';
 
@@ -76,11 +76,9 @@ function resolveCommandForHelp(executor: CommandExecutor, commandName: string): 
         return { cmd: undefined, error: `§cCommand '${commandName}' cannot be run from console.` };
     }
 
-    const pData = isConsole ? undefined : getPlayer(executor.id);
-    const userPermissionLevel = isDefined(pData) ? pData.permissionLevel : 1024;
-    const effectivePermissionLevel = isConsole ? 0 : userPermissionLevel;
+    const requiredPermissionNode = commandManager.getEffectivePermissionNode(cmd);
 
-    if (effectivePermissionLevel > (cmd.permissionLevel ?? 1024)) {
+    if (!isConsole && !hasPermission(executor as mc.Player, requiredPermissionNode)) {
         return { cmd: undefined, error: `§cYou do not have permission to view command: '${commandName}'.` };
     }
 
@@ -139,13 +137,19 @@ function showSpecificHelp(executor: CommandExecutor, commandName: string) {
 /**
  * Displays the chat-based categorized help.
  */
-function showChatHelp(executor: CommandExecutor, userPermissionLevel: number) {
+function showChatHelp(executor: CommandExecutor) {
     const allCategories = getCategorizedCommands();
     const visibleCategories: string[] = [];
+    const isConsole = !('id' in executor);
 
     // Filter categories: Only show if category contains at least one visible command
     for (const [cat, cmds] of allCategories) {
-        if (cmds.some((c) => userPermissionLevel <= (c.permissionLevel ?? 1024) && c.hidden !== true)) {
+        if (
+            cmds.some((c) => {
+                const reqNode = commandManager.getEffectivePermissionNode(c);
+                return (isConsole || hasPermission(executor as mc.Player, reqNode)) && c.hidden !== true;
+            })
+        ) {
             visibleCategories.push(cat);
         }
     }
@@ -164,7 +168,12 @@ function showChatHelp(executor: CommandExecutor, userPermissionLevel: number) {
 
     for (const categoryName of sortedCats) {
         const commands = allCategories.get(categoryName) ?? [];
-        const visibleCmds = commands.filter((c) => userPermissionLevel <= (c.permissionLevel ?? 1024) && c.hidden !== true).toSorted((a, b) => a.name.localeCompare(b.name));
+        const visibleCmds = commands
+            .filter((c) => {
+                const reqNode = commandManager.getEffectivePermissionNode(c);
+                return (isConsole || hasPermission(executor as mc.Player, reqNode)) && c.hidden !== true;
+            })
+            .toSorted((a, b) => a.name.localeCompare(b.name));
 
         if (visibleCmds.length > 0) {
             helpMessage += `\n§l§e--- ${categoryName} ---§r`;
@@ -185,12 +194,17 @@ function showChatHelp(executor: CommandExecutor, userPermissionLevel: number) {
 /**
  * Displays the UI-based categorized help.
  */
-async function showUIHelp(player: mc.Player, userPermissionLevel: number) {
+async function showUIHelp(player: mc.Player) {
     const allCategories = getCategorizedCommands();
     const visibleCategories: string[] = [];
 
     for (const [cat, cmds] of allCategories) {
-        if (cmds.some((c) => userPermissionLevel <= (c.permissionLevel ?? 1024) && c.hidden !== true)) {
+        if (
+            cmds.some((c) => {
+                const reqNode = commandManager.getEffectivePermissionNode(c);
+                return hasPermission(player, reqNode) && c.hidden !== true;
+            })
+        ) {
             visibleCategories.push(cat);
         }
     }
@@ -212,16 +226,21 @@ async function showUIHelp(player: mc.Player, userPermissionLevel: number) {
 
         const selectedCat = sortedCats[response.selection];
         if (selectedCat !== undefined) {
-            await showUICategory(player, selectedCat, userPermissionLevel);
+            await showUICategory(player, selectedCat);
         }
     } catch {
         // Ignore UI errors
     }
 }
 
-async function showUICategory(player: mc.Player, category: string, userPermissionLevel: number) {
+async function showUICategory(player: mc.Player, category: string) {
     const cmds = getCategorizedCommands().get(category) ?? [];
-    const visibleCmds = cmds.filter((c) => userPermissionLevel <= (c.permissionLevel ?? 1024) && c.hidden !== true).toSorted((a, b) => a.name.localeCompare(b.name));
+    const visibleCmds = cmds
+        .filter((c) => {
+            const reqNode = commandManager.getEffectivePermissionNode(c);
+            return hasPermission(player, reqNode) && c.hidden !== true;
+        })
+        .toSorted((a, b) => a.name.localeCompare(b.name));
 
     const form = new ActionFormData().title(`§l${category}`).body(`Commands in ${category}:`);
 
@@ -233,7 +252,7 @@ async function showUICategory(player: mc.Player, category: string, userPermissio
         if (response.canceled || response.selection === undefined) return;
 
         if (response.selection === 0) {
-            return showUIHelp(player, userPermissionLevel);
+            return showUIHelp(player);
         }
 
         const selectedCmd = visibleCmds[response.selection - 1];
@@ -255,29 +274,19 @@ const helpCommand: CustomCommand = {
     aliases: ['?', 'h', 'cmds', 'commands'],
     description: 'Displays a list of available commands or help for a specific command.',
     category: 'General',
-    permissionLevel: 1024,
+
     allowConsole: true,
     parameters: [{ name: 'command', type: 'string', optional: true }],
     execute: (executor: CommandExecutor, args: HelpCommandArgs) => {
-        let userPermissionLevel = 1024;
-        if (executor instanceof mc.Player) {
-            const pData = getPlayer(executor.id);
-            if (isDefined(pData)) {
-                userPermissionLevel = pData.permissionLevel;
-            }
-        } else {
-            userPermissionLevel = 0;
-        }
-
         const topic = isNonEmptyString(args.command) ? String(args.command).toLowerCase() : undefined;
 
         // Handle Mode Switching Override
         if (topic === 'ui' && executor instanceof mc.Player) {
-            showUIHelp(executor, userPermissionLevel).catch(() => {});
+            showUIHelp(executor).catch(() => {});
             return;
         }
         if (topic === 'chat') {
-            showChatHelp(executor, userPermissionLevel);
+            showChatHelp(executor);
             return;
         }
 
@@ -291,9 +300,9 @@ const helpCommand: CustomCommand = {
         const defaultMode = (isDefined(config.helpSystem) ? config.helpSystem.defaultMode : undefined) ?? 'chat';
 
         if (defaultMode === 'ui' && executor instanceof mc.Player) {
-            showUIHelp(executor, userPermissionLevel).catch(() => {});
+            showUIHelp(executor).catch(() => {});
         } else {
-            showChatHelp(executor, userPermissionLevel);
+            showChatHelp(executor);
         }
     }
 };

--- a/src/features/essentials/commands/help.ts
+++ b/src/features/essentials/commands/help.ts
@@ -4,9 +4,9 @@ import { ActionFormData, ActionFormResponse } from '@minecraft/server-ui';
 import { getConfig } from '@core/configManager.js';
 import { noPermission } from '@core/constants.js';
 import { sendMessage } from '@core/messaging.js';
+import { hasPermission } from '@core/permissionEngine.js';
 import { uiWait } from '@core/utils.js';
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
-import { hasPermission } from '@core/permissionEngine.js';
 
 import { CommandExecutor, commandManager, CustomCommand } from '@commands/commandManager.js';
 
@@ -78,7 +78,7 @@ function resolveCommandForHelp(executor: CommandExecutor, commandName: string): 
 
     const requiredPermissionNode = commandManager.getEffectivePermissionNode(cmd);
 
-    if (!isConsole && !hasPermission(executor as mc.Player, requiredPermissionNode)) {
+    if (!isConsole && !hasPermission(executor, requiredPermissionNode)) {
         return { cmd: undefined, error: `§cYou do not have permission to view command: '${commandName}'.` };
     }
 
@@ -147,7 +147,7 @@ function showChatHelp(executor: CommandExecutor) {
         if (
             cmds.some((c) => {
                 const reqNode = commandManager.getEffectivePermissionNode(c);
-                return (isConsole || hasPermission(executor as mc.Player, reqNode)) && c.hidden !== true;
+                return (isConsole || hasPermission(executor, reqNode)) && c.hidden !== true;
             })
         ) {
             visibleCategories.push(cat);
@@ -171,7 +171,7 @@ function showChatHelp(executor: CommandExecutor) {
         const visibleCmds = commands
             .filter((c) => {
                 const reqNode = commandManager.getEffectivePermissionNode(c);
-                return (isConsole || hasPermission(executor as mc.Player, reqNode)) && c.hidden !== true;
+                return (isConsole || hasPermission(executor, reqNode)) && c.hidden !== true;
             })
             .toSorted((a, b) => a.name.localeCompare(b.name));
 

--- a/src/features/essentials/commands/links.ts
+++ b/src/features/essentials/commands/links.ts
@@ -10,7 +10,7 @@ const linksCommand: CustomCommand = {
     aliases: ['link', 'websites'],
     description: 'Displays helpful server links.',
     category: 'General',
-    permissionLevel: 1024,
+
     allowConsole: true,
     execute: (executor: CommandExecutor) => {
         const config = getConfig();

--- a/src/features/essentials/commands/panel.ts
+++ b/src/features/essentials/commands/panel.ts
@@ -9,7 +9,7 @@ const panelCommand: CustomCommand = {
     aliases: ['ui', 'menu'],
     description: 'Opens the main UI panel.',
     category: 'Administration',
-    permissionLevel: 1024,
+
     execute: async (executor: CommandExecutor) => {
         if (executor instanceof mc.Player) {
             await showPanel(executor, 'mainPanel');

--- a/src/features/essentials/commands/pvp.ts
+++ b/src/features/essentials/commands/pvp.ts
@@ -10,7 +10,7 @@ const command: CustomCommand = {
     name: 'pvp',
     description: 'Challenge a player to a PvP duel with an optional wager.',
     category: 'PvP',
-    permissionLevel: 1024, // Everyone
+
     allowConsole: false,
     parameters: [
         { name: 'target', type: 'string', description: 'The player to challenge, or "accept"/"deny".' },

--- a/src/features/essentials/commands/rank.ts
+++ b/src/features/essentials/commands/rank.ts
@@ -7,7 +7,7 @@ const rankCommand: CustomCommand = {
     name: 'rank',
     description: 'Manage player ranks.',
     category: 'Essentials',
-    permissionLevel: 1, // Admin
+
     parameters: [
         { name: 'action', type: 'string', enumOptions: ['set', 'get', 'list'] },
         { name: 'target', type: 'string', optional: true },

--- a/src/features/essentials/commands/reload.ts
+++ b/src/features/essentials/commands/reload.ts
@@ -10,7 +10,7 @@ const command: CustomCommand = {
     aliases: ['xreload'],
     description: 'Reloads the addon configuration from the config file.',
     category: 'Administration',
-    permissionLevel: 1, // Admins only
+
     allowConsole: true,
     parameters: [],
     execute: (_executor) => {

--- a/src/features/essentials/commands/restart.ts
+++ b/src/features/essentials/commands/restart.ts
@@ -6,7 +6,7 @@ const command: CustomCommand = {
     name: 'restart',
     description: 'Initiates the server restart sequence.',
     category: 'Administration',
-    permissionLevel: 1, // Admin only
+
     allowConsole: true,
     parameters: [],
     execute: (executor, _args) => {

--- a/src/features/essentials/commands/rules.ts
+++ b/src/features/essentials/commands/rules.ts
@@ -14,7 +14,7 @@ const rulesCommand: CustomCommand = {
     aliases: ['rule'],
     description: 'Displays the server rules.',
     category: 'General',
-    permissionLevel: 1024,
+
     allowConsole: true,
     parameters: [{ name: 'ruleNumber', type: 'int', optional: true }],
 

--- a/src/features/essentials/commands/save.ts
+++ b/src/features/essentials/commands/save.ts
@@ -12,7 +12,7 @@ const command: CustomCommand = {
     aliases: ['xsave'],
     description: 'Manually saves all server data to disk.',
     category: 'Administration',
-    permissionLevel: 1, // Admins only
+
     allowConsole: true,
     parameters: [],
     execute: (executor) => {

--- a/src/features/essentials/commands/sidebar.ts
+++ b/src/features/essentials/commands/sidebar.ts
@@ -8,7 +8,7 @@ const command: CustomCommand = {
     name: 'sidebar',
     description: 'Toggles the sidebar/HUD.',
     aliases: ['sb'],
-    permissionLevel: 1024, // Member
+
     category: 'General',
     execute: (executor) => {
         if (!(executor instanceof mc.Player)) {

--- a/src/features/essentials/commands/spawn.ts
+++ b/src/features/essentials/commands/spawn.ts
@@ -27,7 +27,7 @@ const spawnCommand: CustomCommand = {
     aliases: ['lobby', 'hub'],
     description: 'Teleports you to the server spawn point.',
     category: 'Transportation',
-    permissionLevel: 1024,
+
     hasCooldown: true,
     execute: (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) {
@@ -143,7 +143,7 @@ const setSpawnCommand: CustomCommand = {
     aliases: ['setworldspawn', 'spawnset'],
     description: "Sets the server's spawn location to your current position or specified coordinates.",
     category: 'Transportation',
-    permissionLevel: 1, // Admins only
+
     allowConsole: true,
     parameters: [
         { name: 'x', type: 'float', optional: true },

--- a/src/features/essentials/commands/status.ts
+++ b/src/features/essentials/commands/status.ts
@@ -8,7 +8,7 @@ const statusCommand: CustomCommand = {
     name: 'status',
     description: 'Shows server status.',
     category: 'Essentials',
-    permissionLevel: 1024,
+
     execute: (executor: CommandExecutor) => {
         const playerCount = getPlayerCount();
         const tick = mc.system.currentTick;

--- a/src/features/essentials/commands/version.ts
+++ b/src/features/essentials/commands/version.ts
@@ -10,7 +10,7 @@ const command: CustomCommand = {
     aliases: ['ver'],
     description: 'Displays the current version of the addon.',
     category: 'General',
-    permissionLevel: 1024, // Everyone
+
     parameters: [],
     execute: (executor: CommandExecutor) => {
         const config = getConfig();

--- a/src/features/kit/commands/kit.ts
+++ b/src/features/kit/commands/kit.ts
@@ -94,7 +94,7 @@ const kitCommand: CustomCommand = {
     name: 'kit',
     description: 'Claims a specific kit. Leave blank to see a list of available kits.',
     category: 'Economy',
-    permissionLevel: 1024,
+
     parameters: [
         {
             name: 'kitName',
@@ -141,7 +141,7 @@ const addKitCommand: CustomCommand = {
     name: 'addkit',
     description: 'Create a new kit from your inventory and open the editor.',
     category: 'Economy',
-    permissionLevel: 1, // Admins only
+
     allowConsole: false,
     parameters: [{ name: 'kitName', type: 'string', optional: true }],
     execute: async (executor: CommandExecutor, args: KitCommandArgs) => {

--- a/src/features/moderation/commands/ban.ts
+++ b/src/features/moderation/commands/ban.ts
@@ -71,7 +71,7 @@ const banCommand: CustomCommand = {
     name: 'ban',
     description: 'Bans a player for a specified duration with a reason.',
     category: 'Moderation',
-    permissionLevel: 2,
+
     allowConsole: true,
     hidden: true,
     parameters: [
@@ -150,7 +150,7 @@ const unbanCommand: CustomCommand = {
     aliases: ['pardon'],
     description: 'Unbans a player.',
     category: 'Moderation',
-    permissionLevel: 2,
+
     allowConsole: true,
     parameters: [{ name: 'target', type: 'string' }],
     execute: (executor: CommandExecutor, args: Record<string, unknown>) => {
@@ -216,7 +216,7 @@ const offlineBanCommand: CustomCommand = {
     aliases: ['oban'],
     description: 'Bans a player who is currently offline.',
     category: 'Moderation',
-    permissionLevel: 2,
+
     allowConsole: true,
     parameters: [
         { name: 'target', type: 'string' },

--- a/src/features/moderation/commands/chatlog.ts
+++ b/src/features/moderation/commands/chatlog.ts
@@ -6,7 +6,7 @@ const chatlogCommand: CustomCommand = {
     name: 'chatlog',
     description: 'View chat logs directly.',
     category: 'Moderation',
-    permissionLevel: 2,
+
     allowConsole: false,
     execute: async (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) return;

--- a/src/features/moderation/commands/clearchat.ts
+++ b/src/features/moderation/commands/clearchat.ts
@@ -10,7 +10,7 @@ const clearchatCommand: CustomCommand = {
     aliases: ['cc'],
     description: 'Clears the chat for all players.',
     category: 'Moderation',
-    permissionLevel: 2,
+
     allowConsole: true,
     execute: (executor: CommandExecutor) => {
         try {

--- a/src/features/moderation/commands/dimensionLock.ts
+++ b/src/features/moderation/commands/dimensionLock.ts
@@ -41,7 +41,7 @@ const netherLockCommand: CustomCommand = {
     name: 'netherlock',
     description: 'Toggles or sets the lock for the Nether dimension.',
     category: 'Administration',
-    permissionLevel: 1,
+
     allowConsole: true,
     parameters: [
         {
@@ -58,7 +58,7 @@ const endLockCommand: CustomCommand = {
     name: 'endlock',
     description: 'Toggles or sets the lock for the End dimension.',
     category: 'Administration',
-    permissionLevel: 1,
+
     allowConsole: true,
     parameters: [
         {

--- a/src/features/moderation/commands/freeze.ts
+++ b/src/features/moderation/commands/freeze.ts
@@ -114,7 +114,7 @@ const freezeCommand: CustomCommand = {
     name: 'freeze',
     description: 'Freezes a player, preventing them from moving or looking around.',
     category: 'Moderation',
-    permissionLevel: 2,
+
     allowConsole: true,
     parameters: [{ name: 'target', type: 'player' }],
     execute: (executor: CommandExecutor, args: FreezeCommandArgs) => {
@@ -145,7 +145,7 @@ const unfreezeCommand: CustomCommand = {
     name: 'unfreeze',
     description: 'Unfreezes a player, allowing them to move and look around again.',
     category: 'Moderation',
-    permissionLevel: 2,
+
     allowConsole: true,
     parameters: [{ name: 'target', type: 'player' }],
     execute: (executor: CommandExecutor, args: FreezeCommandArgs) => {

--- a/src/features/moderation/commands/inventory.ts
+++ b/src/features/moderation/commands/inventory.ts
@@ -45,7 +45,7 @@ const invseeCommand: CustomCommand = {
     name: 'invsee',
     description: 'View the inventory of another player.',
     category: 'Moderation',
-    permissionLevel: 3,
+
     parameters: [{ name: 'player', type: 'string', optional: false }],
     execute: (executor: CommandExecutor, params: Record<string, unknown>) => {
         if (!(executor instanceof mc.Player)) {
@@ -95,7 +95,7 @@ const ecseeCommand: CustomCommand = {
     name: 'ecsee',
     description: 'View the ender chest of another player.',
     category: 'Moderation',
-    permissionLevel: 3,
+
     parameters: [{ name: 'player', type: 'string', optional: false }],
     execute: (executor: CommandExecutor, _params: Record<string, unknown>) => {
         executor.sendMessage('§cEnder Chest inspection is not yet fully supported in this API version.');
@@ -106,7 +106,7 @@ const ecwipeCommand: CustomCommand = {
     name: 'ecwipe',
     description: "Clears a player's Ender Chest.",
     category: 'Moderation',
-    permissionLevel: 3,
+
     parameters: [{ name: 'player', type: 'string', optional: false }],
     execute: (executor: CommandExecutor, params: Record<string, unknown>) => {
         const targetName = params.player;
@@ -154,7 +154,7 @@ const copyinvCommand: CustomCommand = {
     name: 'copyinv',
     description: "Copies another player's inventory to yours.",
     category: 'Moderation',
-    permissionLevel: 3,
+
     parameters: [{ name: 'player', type: 'string', optional: false }],
     execute: (executor: CommandExecutor, params: Record<string, unknown>) => {
         if (!(executor instanceof mc.Player)) {

--- a/src/features/moderation/commands/kick.ts
+++ b/src/features/moderation/commands/kick.ts
@@ -71,7 +71,7 @@ const kickCommand: CustomCommand = {
     description: 'Kicks a player from the server.',
     category: 'Moderation',
     aliases: ['boot'],
-    permissionLevel: 2,
+
     allowConsole: true,
     parameters: [
         { name: 'target', type: 'string' },

--- a/src/features/moderation/commands/mute.ts
+++ b/src/features/moderation/commands/mute.ts
@@ -65,7 +65,7 @@ const muteCommand: CustomCommand = {
     description: 'Mutes a player for a specified duration with a reason.',
     category: 'Moderation',
     aliases: ['silence'],
-    permissionLevel: 2,
+
     allowConsole: true,
     parameters: [
         { name: 'target', type: 'player' },
@@ -145,7 +145,7 @@ const unmuteCommand: CustomCommand = {
     description: 'Unmutes a player.',
     category: 'Moderation',
     aliases: ['um'],
-    permissionLevel: 2,
+
     allowConsole: true,
     parameters: [{ name: 'target', type: 'string' }],
     execute: (executor: CommandExecutor, args: Record<string, unknown>) => {

--- a/src/features/moderation/commands/report.ts
+++ b/src/features/moderation/commands/report.ts
@@ -13,7 +13,7 @@ const reportCommand: CustomCommand = {
     name: 'report',
     description: 'Reports a player. Usage: /report [target] [reason]',
     category: 'Moderation',
-    permissionLevel: 1024,
+
     hasCooldown: true,
     defaultCooldown: 60,
     parameters: [
@@ -74,7 +74,7 @@ const reportsCommand: CustomCommand = {
     name: 'reports',
     description: 'Views the list of active reports.',
     category: 'Moderation',
-    permissionLevel: 2,
+
     execute: async (executor: CommandExecutor) => {
         if (executor instanceof mc.Player) {
             await showPanel(executor, 'reportListPanel');
@@ -86,7 +86,7 @@ const clearReportsCommand: CustomCommand = {
     name: 'clearreports',
     description: 'Clears all active reports.',
     category: 'Moderation',
-    permissionLevel: 2,
+
     allowConsole: true,
     execute: (executor: CommandExecutor) => {
         reportManager.clearAllReports();

--- a/src/features/moderation/commands/vanish.ts
+++ b/src/features/moderation/commands/vanish.ts
@@ -14,7 +14,7 @@ const vanishCommand: CustomCommand = {
     aliases: ['v'],
     description: 'Makes you invisible to other players.',
     category: 'Moderation',
-    permissionLevel: 2,
+
     allowConsole: false,
     execute: (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) {

--- a/src/features/moderation/commands/warn.ts
+++ b/src/features/moderation/commands/warn.ts
@@ -10,7 +10,7 @@ const warnCommand: CustomCommand = {
     name: 'warn',
     description: 'Warns a player for misconduct.',
     category: 'Moderation',
-    permissionLevel: 2, // Moderator
+
     parameters: [
         { name: 'player', type: 'player' },
         { name: 'reason', type: 'string' }

--- a/src/features/shop/commands/shop.ts
+++ b/src/features/shop/commands/shop.ts
@@ -14,7 +14,7 @@ const shopCommand: CustomCommand = {
     name: 'shop',
     description: 'Opens the server shop.',
     category: 'Economy',
-    permissionLevel: 1024,
+
     allowConsole: false,
     execute: async (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) {
@@ -32,7 +32,7 @@ const buyCommand: CustomCommand = {
     name: 'buy',
     description: 'Opens the shop to buy items.',
     category: 'Economy',
-    permissionLevel: 1024,
+
     allowConsole: false,
     execute: async (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) {
@@ -50,7 +50,7 @@ const sellCommand: CustomCommand = {
     name: 'sell',
     description: 'Opens the shop to sell items.',
     category: 'Economy',
-    permissionLevel: 1024,
+
     allowConsole: false,
     execute: async (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) {
@@ -69,7 +69,7 @@ const sellHandCommand: CustomCommand = {
     description: 'Sells the item currently in your main hand.',
     category: 'Economy',
     aliases: ['sh'],
-    permissionLevel: 1024,
+
     allowConsole: false,
     execute: (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) {
@@ -119,7 +119,7 @@ const addShopCommand: CustomCommand = {
     name: 'addshop',
     description: 'Adds the item in your hand to a shop category.',
     category: 'Economy',
-    permissionLevel: 1, // Admins only
+
     allowConsole: false,
     parameters: [
         { name: 'category', type: 'string' },

--- a/src/features/social/commands/friend.ts
+++ b/src/features/social/commands/friend.ts
@@ -8,7 +8,7 @@ const friendCommand: CustomCommand = {
     description: 'Manage your friend list.',
     category: 'Social',
     aliases: ['frnd', 'friends'],
-    permissionLevel: 1024,
+
     parameters: [
         { name: 'subcommand', type: 'string', optional: true }, // add, remove, list, accept
         { name: 'target', type: 'string', optional: true }

--- a/src/features/team/commands/team.ts
+++ b/src/features/team/commands/team.ts
@@ -23,7 +23,7 @@ export function isTeamChatEnabled(playerId: string): boolean {
 const teamChatCommand: CustomCommand = {
     name: 'teamchat',
     description: 'Toggle team chat mode.',
-    permissionLevel: 1024,
+
     aliases: ['tc'],
     execute: (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) {
@@ -49,7 +49,7 @@ const teamChatCommand: CustomCommand = {
 const hqCommand: CustomCommand = {
     name: 'hq',
     description: "Teleports you to your team's home.",
-    permissionLevel: 1024,
+
     aliases: ['teamhome'],
     execute: (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) {

--- a/src/features/teleport/commands/back.ts
+++ b/src/features/teleport/commands/back.ts
@@ -20,7 +20,7 @@ const backCommand: CustomCommand = {
     name: 'back',
     description: 'Teleports you to your previous location (before death or teleport).',
     category: 'Transportation',
-    permissionLevel: 1024,
+
     hasCooldown: true,
     cooldownId: 'back',
     execute: (executor: CommandExecutor) => {

--- a/src/features/teleport/commands/deathcoords.ts
+++ b/src/features/teleport/commands/deathcoords.ts
@@ -12,7 +12,7 @@ const deathCoordsCommand: CustomCommand = {
     aliases: ['deathlocation', 'lastdeath'],
     description: 'Shows your last death coordinates.',
     category: 'General',
-    permissionLevel: 1024,
+
     parameters: [{ name: 'target', type: 'string', optional: true }],
     execute: (executor: CommandExecutor, args: Record<string, unknown>) => {
         if (!(executor instanceof mc.Player)) {

--- a/src/features/teleport/commands/home.ts
+++ b/src/features/teleport/commands/home.ts
@@ -21,7 +21,7 @@ const homeCommand: CustomCommand = {
     name: 'home',
     description: 'Teleports you to one of your set homes.',
     category: 'Transportation',
-    permissionLevel: 1024,
+
     hasCooldown: true,
     cooldownId: 'homes',
     parameters: [{ name: 'homeName', type: 'string', optional: true }],
@@ -109,7 +109,7 @@ const homesCommand: CustomCommand = {
     description: 'Lists all of your set homes.',
     category: 'Transportation',
     aliases: ['homelist'],
-    permissionLevel: 1024,
+
     execute: (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) {
             return;
@@ -137,7 +137,7 @@ const delHomeCommand: CustomCommand = {
     aliases: ['remhome', 'deletehome', 'rmhome', '-home'],
     description: 'Deletes one of your set homes. Leave name blank to choose from a list.',
     category: 'Transportation',
-    permissionLevel: 1024,
+
     parameters: [{ name: 'homeName', type: 'string', optional: true }],
     execute: async (executor: CommandExecutor, args: HomeCommandArgs) => {
         if (!(executor instanceof mc.Player)) {
@@ -198,7 +198,7 @@ const setHomeCommand: CustomCommand = {
     aliases: ['addhome', '+home'],
     description: 'Sets a home at your current location.',
     category: 'Transportation',
-    permissionLevel: 1024,
+
     parameters: [{ name: 'homeName', type: 'string', optional: true }],
     execute: (executor: CommandExecutor, args: HomeCommandArgs) => {
         if (!(executor instanceof mc.Player)) {

--- a/src/features/teleport/commands/rtp.ts
+++ b/src/features/teleport/commands/rtp.ts
@@ -15,7 +15,7 @@ const rtpCommand: CustomCommand = {
     aliases: ['randomtp'],
     description: 'Teleports you to a random safe location in the world.',
     category: 'Transportation',
-    permissionLevel: 1024,
+
     hasCooldown: true,
     execute: async (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) {

--- a/src/features/teleport/commands/tp.ts
+++ b/src/features/teleport/commands/tp.ts
@@ -11,7 +11,7 @@ const command: CustomCommand = {
     aliases: ['teleport', 'xtp'],
     description: 'Teleports a player to another player or to coordinates.',
     category: 'Moderation',
-    permissionLevel: 1, // Admins only
+
     allowConsole: false, // This command is complex and safer for players only
     parameters: [
         { name: 'arg1', type: 'string', description: 'Target player or destination player/X-coordinate.' },

--- a/src/features/teleport/commands/tpa.ts
+++ b/src/features/teleport/commands/tpa.ts
@@ -79,7 +79,7 @@ const tpaCommand: CustomCommand = {
     description: 'Sends a request to teleport to another player.',
     category: 'Transportation',
     aliases: ['tprequest', 'asktp', 'requesttp'],
-    permissionLevel: 1024,
+
     hasCooldown: true,
     // Note: Using string type instead of 'player' to support non-op players (selector expansion requires permissions).
     // Dynamic suggestions for online players are not possible with static enums for string types.
@@ -96,7 +96,7 @@ const tpaHereCommand: CustomCommand = {
     description: 'Requests another player to teleport to you.',
     category: 'Transportation',
     aliases: ['tphere', 'tprequesthere'],
-    permissionLevel: 1024,
+
     hasCooldown: true,
     cooldownId: 'tpa',
     // Note: Using string type instead of 'player' to support non-op players.
@@ -113,7 +113,7 @@ const tpaAcceptCommand: CustomCommand = {
     aliases: ['tpyes', 'tpac'],
     description: 'Accepts an incoming TPA request.',
     category: 'Transportation',
-    permissionLevel: 1024,
+
     parameters: [{ name: 'player', type: 'string', optional: true }],
     execute: (executor: CommandExecutor, args: Record<string, unknown>) => {
         if (executor instanceof mc.Player) {
@@ -127,7 +127,7 @@ const tpaDenyCommand: CustomCommand = {
     aliases: ['tpno', 'tpdeny'],
     description: 'Denies an incoming TPA request.',
     category: 'Transportation',
-    permissionLevel: 1024,
+
     parameters: [{ name: 'player', type: 'string', optional: true }],
     execute: (executor: CommandExecutor, args: Record<string, unknown>) => {
         if (executor instanceof mc.Player) {
@@ -140,7 +140,7 @@ const tpaCancelCommand: CustomCommand = {
     name: 'tpacancel',
     description: 'Cancels your outgoing TPA request.',
     category: 'Transportation',
-    permissionLevel: 1024,
+
     execute: (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) return;
         const config = getConfig();
@@ -157,7 +157,7 @@ const tpaStatusCommand: CustomCommand = {
     name: 'tpastatus',
     description: 'Checks the status of your outgoing and incoming TPA requests.',
     category: 'Transportation',
-    permissionLevel: 1024,
+
     execute: (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) return;
 
@@ -203,7 +203,7 @@ const tpaStopCommand: CustomCommand = {
     aliases: ['tpstop', 'tpablock', 'tpblock'],
     description: 'Disables TPA requests or blocks specific players.',
     category: 'Transportation',
-    permissionLevel: 1024,
+
     parameters: [{ name: 'targets', type: 'string', optional: true }],
     execute: (executor: CommandExecutor, args: Record<string, unknown>) => {
         if (!(executor instanceof mc.Player)) return;
@@ -236,7 +236,7 @@ const tpaStartCommand: CustomCommand = {
     aliases: ['tpstart', 'tpaunblock', 'tpunblock'],
     description: 'Enables TPA requests or unblocks specific players.',
     category: 'Transportation',
-    permissionLevel: 1024,
+
     parameters: [{ name: 'targets', type: 'string', optional: true }],
     execute: (executor: CommandExecutor, args: Record<string, unknown>) => {
         if (!(executor instanceof mc.Player)) return;
@@ -295,7 +295,7 @@ const oTpaStopCommand: CustomCommand = {
     aliases: ['offlinetpastop', 'otpablock'],
     description: 'Blocks an offline player from sending TPA requests.',
     category: 'Transportation',
-    permissionLevel: 1024,
+
     hidden: true,
     parameters: [{ name: 'target', type: 'string' }],
     execute: (executor: CommandExecutor, args: Record<string, unknown>) => {
@@ -310,7 +310,7 @@ const oTpaStartCommand: CustomCommand = {
     aliases: ['offlinetpastart', 'otpaunblock'],
     description: 'Unblocks an offline player from sending TPA requests.',
     category: 'Transportation',
-    permissionLevel: 1024,
+
     hidden: true,
     parameters: [{ name: 'target', type: 'string' }],
     execute: (executor: CommandExecutor, args: Record<string, unknown>) => {

--- a/src/features/teleport/commands/warp.ts
+++ b/src/features/teleport/commands/warp.ts
@@ -22,7 +22,7 @@ const warpCommand: CustomCommand = {
     description: 'Teleports you to a set warp location.',
     category: 'Transportation',
     aliases: ['warps'],
-    permissionLevel: 1024,
+
     hasCooldown: true,
     cooldownId: 'warp',
     parameters: [
@@ -129,7 +129,7 @@ const addWarpCommand: CustomCommand = {
     description: 'Creates a new warp at your current location or at specified coordinates.',
     category: 'Transportation',
     aliases: ['setwarp'],
-    permissionLevel: 1, // Admin
+
     parameters: [
         { name: 'warpName', type: 'string' },
         { name: 'x', type: 'int', optional: true },
@@ -172,7 +172,7 @@ const delWarpCommand: CustomCommand = {
     name: 'delwarp',
     description: 'Deletes an existing warp.',
     category: 'Transportation',
-    permissionLevel: 1, // Admin
+
     parameters: [
         {
             name: 'warpName',

--- a/src/features/vote/commands/vote.ts
+++ b/src/features/vote/commands/vote.ts
@@ -13,7 +13,7 @@ const voteCommand: CustomCommand = {
     name: 'vote',
     description: 'Participate in server votes or create one.',
     category: 'General',
-    permissionLevel: 1024,
+
     parameters: [{ name: 'subcommand', type: 'string', optional: true }],
     execute: async (executor: CommandExecutor, args: { subcommand?: string }) => {
         if (!(executor instanceof mc.Player)) return;


### PR DESCRIPTION
Refactor command system to use string-based permission nodes

- Replaced `permissionLevel` with `permissionNode` in CustomCommand and CommandSettings.
- Updated CommandManager execution logic to verify string nodes using `hasPermission`.
- Removed numeric permission level editing fields from the UI panel in commandPanel.ts.
- Stripped legacy `permissionLevel` properties from all command definitions in src/features.
- Updated the help command logic to properly filter commands using new permission nodes.
- Handled console commands bypassing permission checks appropriately.

---
*PR created automatically by Jules for task [6062207896921691762](https://jules.google.com/task/6062207896921691762) started by @SjnExe*