### PR TITLE
ci: optimize validate step in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,26 +79,6 @@ jobs:
             - run: npm ci
             - run: npm test
 
-    validate:
-        needs: build
-        runs-on: ubuntu-latest
-        timeout-minutes: 10
-        steps:
-            - uses: actions/checkout@v6
-            - name: Setup Node.js
-              uses: actions/setup-node@v6
-              with:
-                  node-version: 'current'
-                  cache: 'npm'
-            - run: npm install -g npm@latest
-            - run: npm ci
-            - name: Download compiled build artifacts
-              uses: actions/download-artifact@v8
-              with:
-                  name: build-dir
-                  path: build/
-            - run: npm run validate
-
     build:
         runs-on: ubuntu-latest
         timeout-minutes: 30
@@ -243,9 +223,11 @@ jobs:
                   name: build-meta
                   path: build_meta.env
                   retention-days: 7
+            - name: Validate build
+              run: npm run validate
 
     release:
-        needs: [build, lint, format, typecheck, test, validate]
+        needs: [build, lint, format, typecheck, test]
         runs-on: ubuntu-latest
         timeout-minutes: 10
         permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 /dist
 /staging/
 /out
+*.mcpack
+*.mcaddon
 
 # misc
 .DS_Store


### PR DESCRIPTION
To avoid the overhead of spinning up a separate runner, checking out code, and re-downloading artifacts, the validate command has been moved to the very end of the build job. Since the build job naturally produces the `.mcaddon` artifacts locally within the workflow context, moving the validate step directly here speeds up the overall CI pipeline considerably while maintaining the correct dependency chain for the release job.

---
*PR created automatically by Jules for task [6388467794707024169](https://jules.google.com/task/6388467794707024169) started by @SjnExe*