### PR TITLE
fix: register ranks feature to fix configuration initialization

### DIFF
--- a/scripts/features.yml
+++ b/scripts/features.yml
@@ -65,3 +65,7 @@ features:
         name: Voting
         status: prod
         dependencies: []
+    ranks:
+        name: Ranks
+        status: prod
+        dependencies: []

--- a/src/core/featureRegistry.ts
+++ b/src/core/featureRegistry.ts
@@ -17,5 +17,6 @@ export const featureRegistry = [
     { id: 'social', load: () => import('@features/social/index.js') as Promise<FeatureModule>, subfeatures: undefined },
     { id: 'team', load: () => import('@features/team/index.js') as Promise<FeatureModule>, subfeatures: undefined },
     { id: 'teleport', load: () => import('@features/teleport/index.js') as Promise<FeatureModule>, subfeatures: undefined },
-    { id: 'vote', load: () => import('@features/vote/index.js') as Promise<FeatureModule>, subfeatures: undefined }
+    { id: 'vote', load: () => import('@features/vote/index.js') as Promise<FeatureModule>, subfeatures: undefined },
+    { id: 'ranks', load: () => import('@features/ranks/index.js') as Promise<FeatureModule>, subfeatures: undefined },
 ];

--- a/src/core/featureRegistry.ts
+++ b/src/core/featureRegistry.ts
@@ -18,5 +18,5 @@ export const featureRegistry = [
     { id: 'team', load: () => import('@features/team/index.js') as Promise<FeatureModule>, subfeatures: undefined },
     { id: 'teleport', load: () => import('@features/teleport/index.js') as Promise<FeatureModule>, subfeatures: undefined },
     { id: 'vote', load: () => import('@features/vote/index.js') as Promise<FeatureModule>, subfeatures: undefined },
-    { id: 'ranks', load: () => import('@features/ranks/index.js') as Promise<FeatureModule>, subfeatures: undefined },
+    { id: 'ranks', load: () => import('@features/ranks/index.js') as Promise<FeatureModule>, subfeatures: undefined }
 ];


### PR DESCRIPTION
Added the `ranks` feature to `scripts/features.yml` and updated the generated `src/core/featureRegistry.ts`. This resolves the `cannot read property 'get' of undefined` crash that occurred during addon initialization because the rank configuration manager was never loaded.

---
*PR created automatically by Jules for task [7324544080412872699](https://jules.google.com/task/7324544080412872699) started by @SjnExe*