### PR TITLE
ci: allow dependabot to update bun.lock

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
               uses: oven-sh/setup-bun@v2
               with:
                   bun-version: latest
-            - run: bun install --frozen-lockfile
+            - run: ${{ github.actor == 'dependabot[bot]' && 'bun install' || 'bun install --frozen-lockfile' }}
             - run: bun run lint
 
     format:
@@ -64,7 +64,7 @@ jobs:
               uses: oven-sh/setup-bun@v2
               with:
                   bun-version: latest
-            - run: bun install --frozen-lockfile
+            - run: ${{ github.actor == 'dependabot[bot]' && 'bun install' || 'bun install --frozen-lockfile' }}
             - run: bun run format:check
 
     typecheck:
@@ -79,7 +79,7 @@ jobs:
               uses: oven-sh/setup-bun@v2
               with:
                   bun-version: latest
-            - run: bun install --frozen-lockfile
+            - run: ${{ github.actor == 'dependabot[bot]' && 'bun install' || 'bun install --frozen-lockfile' }}
             - name: Cache TypeScript Build Info
               uses: actions/cache@v6
               with:
@@ -101,7 +101,7 @@ jobs:
               uses: oven-sh/setup-bun@v2
               with:
                   bun-version: latest
-            - run: bun install --frozen-lockfile
+            - run: ${{ github.actor == 'dependabot[bot]' && 'bun install' || 'bun install --frozen-lockfile' }}
             - run: bun run test
 
     build:
@@ -121,7 +121,7 @@ jobs:
                   bun-version: latest
             - name: Install dependencies
               run: |
-                  bun install --frozen-lockfile
+                  ${{ github.actor == 'dependabot[bot]' && 'bun install' || 'bun install --frozen-lockfile' }}
 
             - name: Determine Build Type
               id: build_type

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,27 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    update-lockfile:
+        runs-on: ubuntu-latest
+        if: github.actor == 'dependabot[bot]'
+        timeout-minutes: 5
+        permissions:
+            contents: write
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.head_ref }}
+                  token: ${{ secrets.GITHUB_TOKEN }}
+            - name: Setup Bun
+              uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: latest
+            - run: bun install
+            - uses: stefanzweifel/git-auto-commit-action@v5
+              with:
+                  commit_message: 'chore(deps): update bun.lock'
+                  file_pattern: 'bun.lock'
+
     lint:
         runs-on: ubuntu-latest
         timeout-minutes: 10
@@ -323,4 +344,4 @@ jobs:
             - name: Perform CodeQL Analysis
               uses: github/codeql-action/analyze@v4
               with:
-                  category: "/language:${{matrix.language}}"
+                  category: '/language:${{matrix.language}}'


### PR DESCRIPTION
Resolves an issue where Dependabot updates fail in CI due to the frozen lockfile flag.
A new CI job was added specifically for Dependabot to update the lockfile (`bun.lock`) and commit the changes.
Formatting issues were fixed via `bun run format`.

---
*PR created automatically by Jules for task [4266239070795396576](https://jules.google.com/task/4266239070795396576) started by @SjnExe*