### PR TITLE
chore: modernize legacy hack implementations with native `@minecraft/server` apis

### DIFF
--- a/src/core/events/playerSpawn.ts
+++ b/src/core/events/playerSpawn.ts
@@ -48,9 +48,8 @@ export function handlePlayerJoin(player: mc.Player) {
 
     // Re-apply freeze if needed
     if (player.hasTag(frozenTag)) {
-        const p = player as unknown as { inputPermissions: { setCameraEnabled(val: boolean): void; setMovementEnabled(val: boolean): void } };
-        p.inputPermissions.setCameraEnabled(false);
-        p.inputPermissions.setMovementEnabled(false);
+        player.inputPermissions.setPermissionCategory(mc.InputPermissionCategory.Camera, false);
+        player.inputPermissions.setPermissionCategory(mc.InputPermissionCategory.Movement, false);
         player.addEffect('resistance', 20_000_000, { amplifier: 255, showParticles: false });
         player.addEffect('weakness', 20_000_000, { amplifier: 255, showParticles: false });
         sendMessage('§cYou are currently frozen.', player);

--- a/src/core/utils/ui.ts
+++ b/src/core/utils/ui.ts
@@ -28,18 +28,16 @@ export async function forceCloseChat(player: mc.Player): Promise<void> {
         if (!player.isValid) return;
 
         // Toggle permissions to force close UI/Chat
-
-        const p = player as unknown as { inputPermissions: { setCameraEnabled(val: boolean): void; setMovementEnabled(val: boolean): void } };
-        p.inputPermissions.setCameraEnabled(false);
-        p.inputPermissions.setMovementEnabled(false);
+        player.inputPermissions.setPermissionCategory(mc.InputPermissionCategory.Camera, false);
+        player.inputPermissions.setPermissionCategory(mc.InputPermissionCategory.Movement, false);
 
         // Small delay to let client process the state change
         await new Promise<void>((resolve) => mc.system.runTimeout(() => resolve(), 2));
 
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (player.isValid) {
-            p.inputPermissions.setCameraEnabled(true);
-            p.inputPermissions.setMovementEnabled(true);
+            player.inputPermissions.setPermissionCategory(mc.InputPermissionCategory.Camera, true);
+            player.inputPermissions.setPermissionCategory(mc.InputPermissionCategory.Movement, true);
         }
     } catch {
         // Ignore errors (e.g. cheats not enabled, or permissions issue)

--- a/src/features/moderation/commands/freeze.ts
+++ b/src/features/moderation/commands/freeze.ts
@@ -27,9 +27,8 @@ export function freezePlayer(executor: CommandExecutor, targetPlayer: mc.Player)
         return;
     }
     try {
-        const p = targetPlayer as unknown as { inputPermissions: { setCameraEnabled(val: boolean): void; setMovementEnabled(val: boolean): void } };
-        p.inputPermissions.setCameraEnabled(false);
-        p.inputPermissions.setMovementEnabled(false);
+        targetPlayer.inputPermissions.setPermissionCategory(mc.InputPermissionCategory.Camera, false);
+        targetPlayer.inputPermissions.setPermissionCategory(mc.InputPermissionCategory.Movement, false);
         targetPlayer.addTag(frozenTag);
 
         // Add invulnerability (Resistance 255)
@@ -78,9 +77,8 @@ export function unfreezePlayer(executor: CommandExecutor, targetPlayer: mc.Playe
         return;
     }
     try {
-        const p = targetPlayer as unknown as { inputPermissions: { setCameraEnabled(val: boolean): void; setMovementEnabled(val: boolean): void } };
-        p.inputPermissions.setCameraEnabled(true);
-        p.inputPermissions.setMovementEnabled(true);
+        targetPlayer.inputPermissions.setPermissionCategory(mc.InputPermissionCategory.Camera, true);
+        targetPlayer.inputPermissions.setPermissionCategory(mc.InputPermissionCategory.Movement, true);
         targetPlayer.removeTag(frozenTag);
 
         // Remove effects

--- a/src/features/moderation/commands/inventory.ts
+++ b/src/features/moderation/commands/inventory.ts
@@ -132,13 +132,22 @@ const ecwipeCommand: CustomCommand = {
         let success = true;
         try {
             const overworld = mc.world.getDimension('overworld');
+            const targetPlayer = mc.world.getPlayers({ name: targetNameResolved })[0];
 
-            // Ender Chest has 27 slots (0-26)
-            for (let i = 0; i < 27; i++) {
-                // Using runCommand to bypass API limitation
-                // Quote name to handle spaces
-                const command = `replaceitem entity "${targetNameResolved}" slot.enderchest ${i} air`;
-                overworld.runCommand(command);
+            if (isDefined(targetPlayer)) {
+                const enderInv = targetPlayer.getComponent('minecraft:ender_inventory') as mc.EntityEnderInventoryComponent;
+                if (isDefined(enderInv) && isDefined(enderInv.container)) {
+                    enderInv.container.clearAll();
+                } else {
+                    success = false;
+                }
+            } else {
+                // Fallback to command if player is offline but exists
+                // Ender Chest has 27 slots (0-26)
+                for (let i = 0; i < 27; i++) {
+                    const command = `replaceitem entity "${targetNameResolved}" slot.enderchest ${i} air`;
+                    overworld.runCommand(command);
+                }
             }
         } catch {
             success = false;

--- a/src/features/teleport/commands/rtp.ts
+++ b/src/features/teleport/commands/rtp.ts
@@ -38,11 +38,21 @@ const rtpCommand: CustomCommand = {
 
 async function createTickingArea(dimension: mc.Dimension, name: string, x: number, z: number): Promise<void> {
     try {
-        dimension.runCommand(`tickingarea add circle ${x} 0 ${z} 1 ${name}`);
+        await mc.world.tickingAreaManager.createTickingArea(name, {
+            dimension: dimension,
+            from: { x: x - 16, y: 0, z: z - 16 },
+            to: { x: x + 16, y: 0, z: z + 16 }
+        });
         // Allow time for command to register
         await new Promise<void>((resolve) => mc.system.runTimeout(resolve, 60));
     } catch {
-        // Ignore error
+        // Fallback to command if API method fails (e.g., if there's no space in the manager)
+        try {
+            dimension.runCommand(`tickingarea add circle ${x} 0 ${z} 1 ${name}`);
+            await new Promise<void>((resolve) => mc.system.runTimeout(resolve, 60));
+        } catch {
+            // Ignore error
+        }
     }
 }
 
@@ -164,9 +174,14 @@ async function findSafeLocationAndTeleport(player: mc.Player, minRange: number, 
 
 function safeRemoveTickingArea(dimension: mc.Dimension, name: string) {
     try {
-        dimension.runCommand(`tickingarea remove ${name}`);
+        mc.world.tickingAreaManager.removeTickingArea(name);
     } catch {
-        // Ignore if it doesn't exist
+        // Fallback to command
+        try {
+            dimension.runCommand(`tickingarea remove ${name}`);
+        } catch {
+            // Ignore if it doesn't exist
+        }
     }
 }
 


### PR DESCRIPTION
This PR updates multiple areas of the Addon where workarounds or "hacks" were used in place of missing Bedrock APIs that have since been added.

**Changes:**
1. Replaced the cast `inputPermissions` workarounds for freezing/unfreezing camera and movement with the newer native `mc.InputPermissionCategory` API methods.
2. Updated the `ecwipe` ender chest wipe command to prefer wiping natively via `minecraft:ender_inventory` `.clearAll()` over string commands, falling back to commands for offline player cases.
3. Modernized the temporary chunk ticking area initialization in the random teleport script using `mc.world.tickingAreaManager`.

Tests and lints run cleanly, and the repository remains free of leftover test data files.

---
*PR created automatically by Jules for task [7697988840223380173](https://jules.google.com/task/7697988840223380173) started by @SjnExe*