### PR TITLE
Add development-only test feature and /test command

### DIFF
--- a/src/core/featureRegistry.ts
+++ b/src/core/featureRegistry.ts
@@ -125,6 +125,13 @@ if (!isProduction) {
             status: 'dev',
             dependencies: [],
             load: () => import('@features/team/index.js')
+        },
+        {
+            id: 'test',
+            name: 'Testing Framework',
+            status: 'dev',
+            dependencies: [],
+            load: () => import('@features/test/index.js')
         }
     );
 }

--- a/src/features/test/commands/index.ts
+++ b/src/features/test/commands/index.ts
@@ -1,0 +1,3 @@
+import './test.js';
+
+export function loadCommands() {}

--- a/src/features/test/commands/test.ts
+++ b/src/features/test/commands/test.ts
@@ -1,0 +1,42 @@
+import { CommandExecutor, CustomCommand, commandManager } from '@commands/commandManager.js';
+import { sendMessage } from '@core/messaging.js';
+import { runTests } from '../testRunner.js';
+import { registerAllSuites } from '../suites/index.js';
+
+// Pre-register all suites
+registerAllSuites();
+
+const testCommand: CustomCommand = {
+    name: 'test',
+    description: 'Runs tests on in-game APIs and systems.',
+    category: 'Development',
+    permissionNode: 'cmd.test',
+    parameters: [
+        {
+            name: 'context',
+            type: 'string',
+            optional: true
+        }
+    ],
+    execute: async (executor: CommandExecutor, args: Record<string, unknown>) => {
+        const contextArg = args['context'];
+        const context = typeof contextArg === 'string' ? contextArg.toLowerCase() : undefined;
+
+        sendMessage(`§a[TestRunner] Starting tests${context ? ` for context: ${context}` : ' (All Suites)'}... Check console for results.`, executor);
+
+        try {
+            const results = await runTests(context);
+
+            if (results.failed > 0) {
+                sendMessage(`§c[TestRunner] Tests finished with ${results.failed} failures. See console for details.`, executor);
+            } else {
+                sendMessage(`§a[TestRunner] All ${results.passed} tests passed successfully!`, executor);
+            }
+        } catch (error) {
+            sendMessage(`§c[TestRunner] An unexpected error occurred while running tests. See console.`, executor);
+            console.error(error);
+        }
+    }
+};
+
+commandManager.register(testCommand);

--- a/src/features/test/commands/test.ts
+++ b/src/features/test/commands/test.ts
@@ -1,7 +1,8 @@
 import { CommandExecutor, CustomCommand, commandManager } from '@commands/commandManager.js';
+import { errorLog } from '@core/logger.js';
 import { sendMessage } from '@core/messaging.js';
-import { runTests } from '../testRunner.js';
 import { registerAllSuites } from '../suites/index.js';
+import { runTests } from '../testRunner.js';
 
 // Pre-register all suites
 registerAllSuites();
@@ -34,9 +35,10 @@ const testCommand: CustomCommand = {
             }
         } catch (error) {
             sendMessage(`§c[TestRunner] An unexpected error occurred while running tests. See console.`, executor);
-            console.error(error);
+            errorLog('[TestRunner] Unexpected error: ', error);
         }
     }
 };
 
 commandManager.register(testCommand);
+export default testCommand;

--- a/src/features/test/index.ts
+++ b/src/features/test/index.ts
@@ -1,0 +1,9 @@
+import { infoLog } from '@core/logger.js';
+import { loadCommands } from './commands/index.js';
+
+export function initialize(isMigration: boolean) {
+    if (isMigration) return;
+
+    infoLog('[TestFeature] Initializing testing framework...');
+    loadCommands();
+}

--- a/src/features/test/suites/coreTests.ts
+++ b/src/features/test/suites/coreTests.ts
@@ -1,0 +1,30 @@
+import { addTest, assert } from '../testRunner.js';
+import { sanitizeString } from '@core/utils/sanitization.js';
+import { setCooldown, getCooldown } from '@core/cooldownManager.js';
+
+const SUITE_NAME = 'core';
+
+export function registerCoreTests() {
+    addTest(SUITE_NAME, 'sanitizeString removes invalid characters', () => {
+        const input = 'Hello §cWorld!';
+        const expected = 'Hello World!';
+        const result = sanitizeString(input, false);
+        assert.equal(result, expected, `Expected '${expected}', got '${result}'`);
+
+        const resultWithColors = sanitizeString(input, true);
+        assert.equal(resultWithColors, input, `Expected original with colors, got '${resultWithColors}'`);
+    });
+
+    addTest(SUITE_NAME, 'Cooldown Manager functionality', () => {
+        const playerId = 'testPlayer123';
+        const actionId = 'testAction';
+        const duration = 1; // 1 second
+
+        // Should not be active initially (0 cooldown time remaining)
+        assert.equal(getCooldown(playerId, actionId), 0, 'Cooldown should be 0 initially');
+
+        // Create cooldown
+        setCooldown(playerId, actionId, duration);
+        assert.ok(getCooldown(playerId, actionId) > 0, 'Cooldown should be active after creation');
+    });
+}

--- a/src/features/test/suites/coreTests.ts
+++ b/src/features/test/suites/coreTests.ts
@@ -1,6 +1,6 @@
-import { addTest, assert } from '../testRunner.js';
+import { getCooldown, setCooldown } from '@core/cooldownManager.js';
 import { sanitizeString } from '@core/utils/sanitization.js';
-import { setCooldown, getCooldown } from '@core/cooldownManager.js';
+import { addTest, assert } from '../testRunner.js';
 
 const SUITE_NAME = 'core';
 

--- a/src/features/test/suites/economyTests.ts
+++ b/src/features/test/suites/economyTests.ts
@@ -1,0 +1,21 @@
+import { addTest, assert } from '../testRunner.js';
+import { formatCurrency, parseCurrency } from '@core/utils/economy.js';
+
+const SUITE_NAME = 'economy';
+
+export function registerEconomyTests() {
+    addTest(SUITE_NAME, 'Economy format currency', () => {
+        const result = formatCurrency(1500);
+        // Result will likely be $1.5k or $1500.00 depending on symbol and implementation logic
+        assert.ok(typeof result === 'string', 'Result should be a string');
+        assert.ok(result.includes('1.5k') || result.includes('1500'), 'Should format to short string correctly');
+    });
+
+    addTest(SUITE_NAME, 'Economy parse currency', () => {
+        const result1 = parseCurrency('1.5k');
+        assert.equal(result1, 1500, 'Parsing 1.5k should be 1500');
+
+        const result2 = parseCurrency('2M');
+        assert.equal(result2, 2000000, 'Parsing 2M should be 2000000');
+    });
+}

--- a/src/features/test/suites/economyTests.ts
+++ b/src/features/test/suites/economyTests.ts
@@ -1,5 +1,5 @@
-import { addTest, assert } from '../testRunner.js';
 import { formatCurrency, parseCurrency } from '@core/utils/economy.js';
+import { addTest, assert } from '../testRunner.js';
 
 const SUITE_NAME = 'economy';
 

--- a/src/features/test/suites/index.ts
+++ b/src/features/test/suites/index.ts
@@ -1,0 +1,9 @@
+import { registerCoreTests } from './coreTests.js';
+import { registerEconomyTests } from './economyTests.js';
+import { registerMcApiTests } from './mcApiTests.js';
+
+export function registerAllSuites() {
+    registerCoreTests();
+    registerEconomyTests();
+    registerMcApiTests();
+}

--- a/src/features/test/suites/mcApiTests.ts
+++ b/src/features/test/suites/mcApiTests.ts
@@ -6,13 +6,13 @@ const SUITE_NAME = 'mc_api';
 export function registerMcApiTests() {
     addTest(SUITE_NAME, 'World dimensions exist', () => {
         const overworld = mc.world.getDimension('overworld');
-        assert.ok(overworld !== undefined, 'Overworld dimension should exist');
+        assert.ok(overworld, 'Overworld dimension should exist');
 
         const nether = mc.world.getDimension('nether');
-        assert.ok(nether !== undefined, 'Nether dimension should exist');
+        assert.ok(nether, 'Nether dimension should exist');
 
         const end = mc.world.getDimension('the_end');
-        assert.ok(end !== undefined, 'The End dimension should exist');
+        assert.ok(end, 'The End dimension should exist');
     });
 
     addTest(SUITE_NAME, 'System current tick is accessible', () => {

--- a/src/features/test/suites/mcApiTests.ts
+++ b/src/features/test/suites/mcApiTests.ts
@@ -1,0 +1,23 @@
+import * as mc from '@minecraft/server';
+import { addTest, assert } from '../testRunner.js';
+
+const SUITE_NAME = 'mc_api';
+
+export function registerMcApiTests() {
+    addTest(SUITE_NAME, 'World dimensions exist', () => {
+        const overworld = mc.world.getDimension('overworld');
+        assert.ok(overworld !== undefined, 'Overworld dimension should exist');
+
+        const nether = mc.world.getDimension('nether');
+        assert.ok(nether !== undefined, 'Nether dimension should exist');
+
+        const end = mc.world.getDimension('the_end');
+        assert.ok(end !== undefined, 'The End dimension should exist');
+    });
+
+    addTest(SUITE_NAME, 'System current tick is accessible', () => {
+        const tick = mc.system.currentTick;
+        assert.ok(typeof tick === 'number', 'Current tick should be a number');
+        assert.ok(tick >= 0, 'Current tick should be non-negative');
+    });
+}

--- a/src/features/test/testRunner.ts
+++ b/src/features/test/testRunner.ts
@@ -1,4 +1,4 @@
-import { infoLog, warnLog, errorLog, debugLog } from '@core/logger.js';
+import { debugLog, errorLog, infoLog, warnLog } from '@core/logger.js';
 
 export type TestFunction = () => void | Promise<void>;
 

--- a/src/features/test/testRunner.ts
+++ b/src/features/test/testRunner.ts
@@ -1,0 +1,152 @@
+import { infoLog, warnLog, errorLog, debugLog } from '@core/logger.js';
+
+export type TestFunction = () => void | Promise<void>;
+
+export interface TestCase {
+    name: string;
+    fn: TestFunction;
+}
+
+export interface TestSuite {
+    name: string;
+    tests: TestCase[];
+}
+
+const testSuites: Map<string, TestSuite> = new Map();
+
+/**
+ * Register a new test suite with a specific context name.
+ */
+export function registerSuite(name: string): TestSuite {
+    if (testSuites.has(name)) {
+        return testSuites.get(name)!;
+    }
+    const suite: TestSuite = { name, tests: [] };
+    testSuites.set(name, suite);
+    return suite;
+}
+
+/**
+ * Add a test to a suite.
+ */
+export function addTest(suiteName: string, testName: string, fn: TestFunction) {
+    const suite = registerSuite(suiteName);
+    suite.tests.push({ name: testName, fn });
+}
+
+export interface TestResult {
+    passed: number;
+    failed: number;
+    errors: { testName: string; error: unknown }[];
+}
+
+/**
+ * Runs a specific suite and returns the result.
+ */
+export async function runSuite(suite: TestSuite): Promise<TestResult> {
+    infoLog(`[TestRunner] Starting suite: '${suite.name}' (${suite.tests.length} tests)`);
+    const result: TestResult = { passed: 0, failed: 0, errors: [] };
+
+    for (const test of suite.tests) {
+        debugLog(`[TestRunner] Running test: ${suite.name} > ${test.name}`);
+        try {
+            await test.fn();
+            result.passed++;
+            debugLog(`[TestRunner] PASS: ${test.name}`);
+        } catch (e: unknown) {
+            result.failed++;
+            result.errors.push({ testName: `${suite.name} > ${test.name}`, error: e });
+            errorLog(`[TestRunner] FAIL: ${test.name}`, e);
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Runs one or all suites. Returns a combined TestResult.
+ */
+export async function runTests(context?: string): Promise<TestResult> {
+    const combinedResult: TestResult = { passed: 0, failed: 0, errors: [] };
+
+    let suitesToRun: TestSuite[] = [];
+
+    if (context) {
+        const suite = testSuites.get(context);
+        if (!suite) {
+            warnLog(`[TestRunner] Test suite '${context}' not found.`);
+            return combinedResult;
+        }
+        suitesToRun.push(suite);
+    } else {
+        suitesToRun = Array.from(testSuites.values());
+    }
+
+    if (suitesToRun.length === 0) {
+        warnLog(`[TestRunner] No test suites registered to run.`);
+        return combinedResult;
+    }
+
+    for (const suite of suitesToRun) {
+        const result = await runSuite(suite);
+        combinedResult.passed += result.passed;
+        combinedResult.failed += result.failed;
+        combinedResult.errors.push(...result.errors);
+    }
+
+    // Summary
+    const total = combinedResult.passed + combinedResult.failed;
+    const summaryHeader = `\n========== TEST RUN SUMMARY ==========`;
+    const summaryBody = `Total: ${total} | Passed: ${combinedResult.passed} | Failed: ${combinedResult.failed}`;
+
+    if (combinedResult.failed > 0) {
+        errorLog(summaryHeader);
+        errorLog(summaryBody);
+        errorLog(`Failures:`);
+        for (const err of combinedResult.errors) {
+            const errStr = err.error instanceof Error ? err.error.message : String(err.error);
+            errorLog(` - [${err.testName}]: ${errStr}`);
+        }
+        errorLog(`======================================\n`);
+    } else {
+        infoLog(summaryHeader);
+        infoLog(summaryBody);
+        infoLog(`All tests passed successfully!`);
+        infoLog(`======================================\n`);
+    }
+
+    return combinedResult;
+}
+
+/**
+ * Assertion utility functions
+ */
+export const assert = {
+    ok(value: unknown, message?: string) {
+        if (!value) throw new Error(message || `Expected truthy, got ${String(value)}`);
+    },
+    equal<T>(actual: T, expected: T, message?: string) {
+        if (actual !== expected) throw new Error(message || `Expected ${String(expected)}, got ${String(actual)}`);
+    },
+    notEqual<T>(actual: T, expected: T, message?: string) {
+        if (actual === expected) throw new Error(message || `Expected not equal to ${String(expected)}`);
+    },
+    throws(fn: () => void, message?: string) {
+        let threw = false;
+        try {
+            fn();
+        } catch {
+            threw = true;
+        }
+        if (!threw) throw new Error(message || `Expected function to throw`);
+    },
+    async throwsAsync(fn: () => Promise<void>, message?: string) {
+        let threw = false;
+        try {
+            await fn();
+        } catch {
+            threw = true;
+        }
+        if (!threw) throw new Error(message || `Expected async function to throw`);
+    }
+};


### PR DESCRIPTION
- Added `test` feature to `RAW_FEATURES` in `src/core/featureRegistry.ts` (dev only).
- Created `src/features/test` structure for test runner and suites.
- Implemented `testRunner.ts` with assertions, logging, and test registration.
- Added `/test` command that accepts an optional context parameter.
- Added initial test suites for `core`, `economy`, and `mc_api`.

---
*PR created automatically by Jules for task [15459975275513706853](https://jules.google.com/task/15459975275513706853) started by @SjnExe*