### PR TITLE
Fix 'process is not defined' crash

### DIFF
--- a/src/core/featureRegistry.ts
+++ b/src/core/featureRegistry.ts
@@ -13,7 +13,7 @@ export interface RawFeatureDef {
     load: () => Promise<FeatureModule>;
 }
 
-const isProduction = process.env.NODE_ENV === 'production';
+const isProduction = typeof process !== 'undefined' ? process.env.NODE_ENV === 'production' : false;
 
 // The raw list of features
 export const RAW_FEATURES: RawFeatureDef[] = [


### PR DESCRIPTION
This fixes a crash that occurred when `process.env.NODE_ENV` was accessed in an environment where `process` was not defined (like Minecraft Bedrock). It adds a `typeof process !== 'undefined'` guard to safely fallback when `process` is not available.

---
*PR created automatically by Jules for task [15776189097580871984](https://jules.google.com/task/15776189097580871984) started by @SjnExe*