### PR TITLE
fix: centralize configuration loading to prevent crashes

### DIFF
--- a/src/core/__tests__/ConfigManager.test.ts
+++ b/src/core/__tests__/ConfigManager.test.ts
@@ -21,6 +21,10 @@ vi.mock('../configManagerFactory.js', () => ({
     default: mockFactory
 }));
 
+vi.mock('../../features/anticheat/configLoader.js', () => ({
+    loadAnticheatConfig: vi.fn()
+}));
+
 vi.mock('../logger.js', () => ({
     debugLog: vi.fn(),
     errorLog: vi.fn(),
@@ -29,6 +33,18 @@ vi.mock('../logger.js', () => ({
 
 // Mock `configurations.ts` to prevent dynamic import issues in resetConfigSection
 vi.mock('../configurations.js', () => ({
+    loadWorldProtectionConfig: vi.fn(),
+    loadShopConfig: vi.fn(),
+    loadRanksConfig: vi.fn(),
+    loadEconomyConfig: vi.fn(),
+    loadXrayConfig: vi.fn(),
+    loadTeamConfig: vi.fn(),
+    loadFriendConfig: vi.fn(),
+    loadSidebarConfig: vi.fn(),
+    loadAuctionHouseConfig: vi.fn(),
+    loadDailyRewardsConfig: vi.fn(),
+    loadGamesConfig: vi.fn(),
+    loadWordleConfig: vi.fn(),
     configResetRegistry: {},
     configResetCallbacks: {}
 }));

--- a/src/core/configManager.ts
+++ b/src/core/configManager.ts
@@ -26,6 +26,25 @@ export async function initializeConfigManager(isMigration: boolean) {
     const defaultConfig = await asyncLoadConfig<typeof Config>('./config.js');
     mainConfigManager = createConfigManager('exe:config:current', defaultConfig, 'Main');
     mainConfigManager.load(isMigration);
+
+    const configs = await import('@core/configurations.js');
+    const { loadAnticheatConfig } = await import('@features/anticheat/configLoader.js');
+
+    await Promise.all([
+        configs.loadWorldProtectionConfig(isMigration),
+        configs.loadShopConfig(isMigration),
+        configs.loadRanksConfig(isMigration),
+        configs.loadEconomyConfig(isMigration),
+        configs.loadXrayConfig(isMigration),
+        configs.loadTeamConfig(isMigration),
+        configs.loadFriendConfig(isMigration),
+        configs.loadSidebarConfig(isMigration),
+        configs.loadAuctionHouseConfig(isMigration),
+        configs.loadDailyRewardsConfig(isMigration),
+        configs.loadGamesConfig(isMigration),
+        configs.loadWordleConfig(isMigration),
+        Promise.resolve().then(() => loadAnticheatConfig(isMigration))
+    ]);
 }
 
 export const getConfig = () => {

--- a/src/features/anticheat/index.ts
+++ b/src/features/anticheat/index.ts
@@ -5,7 +5,7 @@ import { startItemCheckLoop } from '@features/anticheat/itemCheck.js';
 import { addPunishmentLog, initializeLogManager } from '@features/anticheat/logManager.js';
 import { startMovementCheckLoop } from '@features/anticheat/movementCheck.js';
 
-export async function initialize(isMigration: boolean) {
+export async function initialize(_isMigration: boolean) {
     initializeLogManager();
     initializeFlagManager();
     startItemCheckLoop();

--- a/src/features/anticheat/index.ts
+++ b/src/features/anticheat/index.ts
@@ -1,13 +1,11 @@
 import { serviceLocator } from '@core/services/serviceLocator.js';
 import { showChatFilter } from '@features/anticheat/commands/logs.js';
-import { loadAnticheatConfig } from '@features/anticheat/configLoader.js';
 import { initializeFlagManager } from '@features/anticheat/flagManager.js';
 import { startItemCheckLoop } from '@features/anticheat/itemCheck.js';
 import { addPunishmentLog, initializeLogManager } from '@features/anticheat/logManager.js';
 import { startMovementCheckLoop } from '@features/anticheat/movementCheck.js';
 
 export async function initialize(isMigration: boolean) {
-    loadAnticheatConfig(isMigration);
     initializeLogManager();
     initializeFlagManager();
     startItemCheckLoop();
@@ -19,8 +17,7 @@ export async function initialize(isMigration: boolean) {
     });
 
     // Register configurations
-    const { loadXrayConfig, resetXrayConfig, registerConfigReset } = await import('@core/configurations.js');
-    await loadXrayConfig(isMigration);
+    const { resetXrayConfig, registerConfigReset } = await import('@core/configurations.js');
     registerConfigReset('xray', {
         reset: resetXrayConfig,
         message: 'The X-ray configuration section has been reset to default.'

--- a/src/features/auction/index.ts
+++ b/src/features/auction/index.ts
@@ -4,8 +4,7 @@ export async function initialize(isMigration: boolean) {
     initializeAuctionHouse();
 
     // Register configurations
-    const { loadAuctionHouseConfig, resetAuctionHouseConfig, registerConfigReset } = await import('@core/configurations.js');
-    await loadAuctionHouseConfig(isMigration);
+    const { resetAuctionHouseConfig, registerConfigReset } = await import('@core/configurations.js');
     registerConfigReset('auctionHouse', {
         reset: resetAuctionHouseConfig,
         message: 'The Auction House configuration section has been reset to default.'

--- a/src/features/auction/index.ts
+++ b/src/features/auction/index.ts
@@ -1,6 +1,6 @@
 import { initializeAuctionHouse } from '@features/auction/manager.js';
 
-export async function initialize(isMigration: boolean) {
+export async function initialize(_isMigration: boolean) {
     initializeAuctionHouse();
 
     // Register configurations

--- a/src/features/daily/index.ts
+++ b/src/features/daily/index.ts
@@ -2,8 +2,7 @@ export async function initialize(isMigration: boolean) {
     // Empty index for now
 
     // Register configurations
-    const { loadDailyRewardsConfig, resetDailyRewardsConfig, registerConfigReset } = await import('@core/configurations.js');
-    await loadDailyRewardsConfig(isMigration);
+    const { resetDailyRewardsConfig, registerConfigReset } = await import('@core/configurations.js');
     registerConfigReset('dailyRewards', {
         reset: resetDailyRewardsConfig,
         message: 'The Daily Rewards configuration section has been reset to default.'

--- a/src/features/daily/index.ts
+++ b/src/features/daily/index.ts
@@ -1,4 +1,4 @@
-export async function initialize(isMigration: boolean) {
+export async function initialize(_isMigration: boolean) {
     // Empty index for now
 
     // Register configurations

--- a/src/features/economy/index.ts
+++ b/src/features/economy/index.ts
@@ -4,7 +4,7 @@ import { BountyPanelHandler } from '@features/economy/ui/bountyPanel.js';
 import { EconomyPanelHandler } from '@features/economy/ui/panel.js';
 import { panelRouter } from '@ui/PanelRouter.js';
 
-export async function initialize(isMigration: boolean) {
+export async function initialize(_isMigration: boolean) {
     panelRouter.register(new EconomyPanelHandler());
     panelRouter.register(new BountyPanelHandler());
 

--- a/src/features/economy/index.ts
+++ b/src/features/economy/index.ts
@@ -13,8 +13,7 @@ export async function initialize(isMigration: boolean) {
     });
 
     // Register configurations
-    const { loadEconomyConfig, resetEconomyConfig, registerConfigReset } = await import('@core/configurations.js');
-    await loadEconomyConfig(isMigration);
+    const { resetEconomyConfig, registerConfigReset } = await import('@core/configurations.js');
     registerConfigReset('economy', {
         reset: resetEconomyConfig,
         message: 'The economy configuration section has been reset to default.'

--- a/src/features/essentials/index.ts
+++ b/src/features/essentials/index.ts
@@ -5,8 +5,7 @@ export async function initialize(isMigration: boolean) {
     panelRouter.register(new WorldProtectionPanelHandler());
 
     // Register configurations
-    const { loadWorldProtectionConfig, resetWorldProtectionConfig, registerConfigReset } = await import('@core/configurations.js');
-    await loadWorldProtectionConfig(isMigration);
+    const { resetWorldProtectionConfig, registerConfigReset } = await import('@core/configurations.js');
     registerConfigReset('worldProtection', {
         reset: resetWorldProtectionConfig,
         message: 'The World Protection configuration section has been reset to default.'

--- a/src/features/essentials/index.ts
+++ b/src/features/essentials/index.ts
@@ -1,7 +1,7 @@
 import { WorldProtectionPanelHandler } from '@features/essentials/ui/worldProtectionPanel.js';
 import { panelRouter } from '@ui/PanelRouter.js';
 
-export async function initialize(isMigration: boolean) {
+export async function initialize(_isMigration: boolean) {
     panelRouter.register(new WorldProtectionPanelHandler());
 
     // Register configurations

--- a/src/features/games/index.ts
+++ b/src/features/games/index.ts
@@ -2,7 +2,7 @@ import { panelRouter } from '@ui/PanelRouter.js';
 import { GamesPanelHandler } from './ui/gamesPanel.js';
 import { WordlePanelHandler } from './wordle/ui/wordlePanel.js';
 
-export async function initialize(isMigration: boolean) {
+export async function initialize(_isMigration: boolean) {
     panelRouter.register(new GamesPanelHandler());
     panelRouter.register(new WordlePanelHandler());
 

--- a/src/features/games/index.ts
+++ b/src/features/games/index.ts
@@ -7,15 +7,13 @@ export async function initialize(isMigration: boolean) {
     panelRouter.register(new WordlePanelHandler());
 
     // Register configurations
-    const { loadGamesConfig, resetGamesConfig, registerConfigReset } = await import('@core/configurations.js');
-    await loadGamesConfig(isMigration);
+    const { resetGamesConfig, registerConfigReset } = await import('@core/configurations.js');
     registerConfigReset('games', {
         reset: resetGamesConfig,
         message: 'The games configuration section has been reset to default.'
     });
 
-    const { loadWordleConfig, resetWordleConfig } = await import('@core/configurations.js');
-    await loadWordleConfig(isMigration);
+    const { resetWordleConfig } = await import('@core/configurations.js');
     registerConfigReset('wordle', {
         reset: resetWordleConfig,
         message: 'The wordle configuration section has been reset to default.'

--- a/src/features/ranks/index.ts
+++ b/src/features/ranks/index.ts
@@ -1,7 +1,6 @@
 export async function initialize(isMigration: boolean) {
     // Register configurations
-    const { loadRanksConfig, resetRanksConfig, registerConfigReset } = await import('@core/configurations.js');
-    await loadRanksConfig(isMigration);
+    const { resetRanksConfig, registerConfigReset } = await import('@core/configurations.js');
     registerConfigReset('ranks', {
         reset: resetRanksConfig,
         message: 'The ranks configuration section has been reset to default.'

--- a/src/features/ranks/index.ts
+++ b/src/features/ranks/index.ts
@@ -1,4 +1,4 @@
-export async function initialize(isMigration: boolean) {
+export async function initialize(_isMigration: boolean) {
     // Register configurations
     const { resetRanksConfig, registerConfigReset } = await import('@core/configurations.js');
     registerConfigReset('ranks', {

--- a/src/features/shop/index.ts
+++ b/src/features/shop/index.ts
@@ -2,7 +2,7 @@ import { ShopAdminPanelHandler } from '@features/shop/ui/adminPanel.js';
 import { ShopUserPanelHandler } from '@features/shop/ui/userPanel.js';
 import { panelRouter } from '@ui/PanelRouter.js';
 
-export async function initialize(isMigration: boolean) {
+export async function initialize(_isMigration: boolean) {
     panelRouter.register(new ShopAdminPanelHandler());
     panelRouter.register(new ShopUserPanelHandler());
 

--- a/src/features/shop/index.ts
+++ b/src/features/shop/index.ts
@@ -7,8 +7,7 @@ export async function initialize(isMigration: boolean) {
     panelRouter.register(new ShopUserPanelHandler());
 
     // Register configurations
-    const { loadShopConfig, resetShopConfig, registerConfigReset } = await import('@core/configurations.js');
-    await loadShopConfig(isMigration);
+    const { resetShopConfig, registerConfigReset } = await import('@core/configurations.js');
     registerConfigReset('shop', {
         reset: resetShopConfig,
         message: 'The shop configuration section has been reset to default.'

--- a/src/features/sidebar/index.ts
+++ b/src/features/sidebar/index.ts
@@ -13,8 +13,7 @@ export async function initialize(isMigration: boolean) {
     });
 
     // Register configurations
-    const { loadSidebarConfig, resetSidebarConfig, registerConfigReset } = await import('@core/configurations.js');
-    await loadSidebarConfig(isMigration);
+    const { resetSidebarConfig, registerConfigReset } = await import('@core/configurations.js');
     registerConfigReset('sidebar', {
         reset: resetSidebarConfig,
         message: 'The sidebar configuration section has been reset to default.'

--- a/src/features/sidebar/index.ts
+++ b/src/features/sidebar/index.ts
@@ -1,7 +1,7 @@
 import { serviceLocator } from '@core/services/serviceLocator.js';
 import { forceUpdate, initializeSidebar, resolveGlobalPlaceholders } from '@features/sidebar/manager.js';
 
-export async function initialize(isMigration: boolean) {
+export async function initialize(_isMigration: boolean) {
     initializeSidebar();
 
     serviceLocator.registerService('sidebar.manager', {

--- a/src/features/social/index.ts
+++ b/src/features/social/index.ts
@@ -1,7 +1,7 @@
 import { serviceLocator } from '@core/services/serviceLocator.js';
 import { initialize as initSocial, isFriend } from '@features/social/friendManager.js';
 
-export async function initialize(isMigration: boolean) {
+export async function initialize(_isMigration: boolean) {
     initSocial();
 
     serviceLocator.registerService('social.friends', {

--- a/src/features/social/index.ts
+++ b/src/features/social/index.ts
@@ -9,8 +9,7 @@ export async function initialize(isMigration: boolean) {
     });
 
     // Register configurations
-    const { loadFriendConfig, resetFriendConfig, registerConfigReset } = await import('@core/configurations.js');
-    await loadFriendConfig(isMigration);
+    const { resetFriendConfig, registerConfigReset } = await import('@core/configurations.js');
     registerConfigReset('friend', {
         reset: resetFriendConfig,
         message: 'The friend configuration section has been reset to default.'

--- a/src/features/team/index.ts
+++ b/src/features/team/index.ts
@@ -11,8 +11,7 @@ export async function initialize(isMigration: boolean) {
     });
 
     // Register configurations
-    const { loadTeamConfig, resetTeamConfig, registerConfigReset } = await import('@core/configurations.js');
-    await loadTeamConfig(isMigration);
+    const { resetTeamConfig, registerConfigReset } = await import('@core/configurations.js');
     registerConfigReset('team', {
         reset: resetTeamConfig,
         message: 'The team configuration section has been reset to default.'

--- a/src/features/team/index.ts
+++ b/src/features/team/index.ts
@@ -3,7 +3,7 @@ import { getTeamByPlayer } from '@features/team/manager.js';
 import { TeamPanelHandler } from '@features/team/ui/panel.js';
 import { panelRouter } from '@ui/PanelRouter.js';
 
-export async function initialize(isMigration: boolean) {
+export async function initialize(_isMigration: boolean) {
     panelRouter.register(new TeamPanelHandler());
 
     serviceLocator.registerService('team.manager', {


### PR DESCRIPTION
Fixes a `TypeError: cannot read property 'get' of undefined` crash occurring when disabling certain features (like economy) that other systems still attempt to read the configuration of.

---
*PR created automatically by Jules for task [10684180147002484085](https://jules.google.com/task/10684180147002484085) started by @SjnExe*