### PR TITLE
Optimize CodeQL analyze job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -346,3 +346,5 @@ jobs:
               uses: github/codeql-action/analyze@v4
               with:
                   category: '/language:javascript-typescript'
+                  ram: 14579 # Matches the ram in the job log to fully utilize GitHub Action runners
+                  threads: 4 # Also matches threads

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -327,11 +327,6 @@ jobs:
             contents: read
             security-events: write
 
-        strategy:
-            fail-fast: false
-            matrix:
-                language: ['javascript-typescript']
-
         steps:
             - name: Checkout repository
               uses: actions/checkout@v7
@@ -339,9 +334,15 @@ jobs:
             - name: Initialize CodeQL
               uses: github/codeql-action/init@v4
               with:
-                  languages: ${{ matrix.language }}
+                  languages: javascript-typescript
+                  config: |
+                      paths-ignore:
+                          - '**/__tests__/**'
+                          - '**/__mocks__/**'
+                          - 'scripts/**'
+                          - '*.config.*'
 
             - name: Perform CodeQL Analysis
               uses: github/codeql-action/analyze@v4
               with:
-                  category: '/language:${{matrix.language}}'
+                  category: '/language:javascript-typescript'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -341,10 +341,11 @@ jobs:
                           - '**/__mocks__/**'
                           - 'scripts/**'
                           - '*.config.*'
+                  tools: latest
 
             - name: Perform CodeQL Analysis
               uses: github/codeql-action/analyze@v4
               with:
                   category: '/language:javascript-typescript'
-                  ram: 14579 # Matches the ram in the job log to fully utilize GitHub Action runners
-                  threads: 4 # Also matches threads
+                  ram: 14336
+                  threads: 4


### PR DESCRIPTION
Optimized the CodeQL analyze job in the build workflow by configuring `paths-ignore` and removing matrix overhead.

---
*PR created automatically by Jules for task [14726029160450917124](https://jules.google.com/task/14726029160450917124) started by @SjnExe*