### PR TITLE
Fix default member UI access and harden panel permissions

### DIFF
--- a/src/core/permissionEngine.ts
+++ b/src/core/permissionEngine.ts
@@ -1,7 +1,7 @@
 import { config } from '@core/../config.default.js';
+import { getRanksConfig } from '@core/configurations.js';
 import { getPlayer } from '@core/playerDataManager.js';
 import { getAllRanks, getRankById } from '@core/rankManager.js';
-import { getRanksConfig } from '@core/configurations.js';
 import { RankDefinition } from '@features/ranks/ranksConfig.default.js';
 import { isDefined } from '@lib/guards.js';
 import * as mc from '@minecraft/server';

--- a/src/core/permissionEngine.ts
+++ b/src/core/permissionEngine.ts
@@ -1,7 +1,8 @@
 import { config } from '@core/../config.default.js';
 import { getPlayer } from '@core/playerDataManager.js';
 import { getAllRanks, getRankById } from '@core/rankManager.js';
-import { RankDefinition, permissionGroups } from '@features/ranks/ranksConfig.default.js';
+import { getRanksConfig } from '@core/configurations.js';
+import { RankDefinition } from '@features/ranks/ranksConfig.default.js';
 import { isDefined } from '@lib/guards.js';
 import * as mc from '@minecraft/server';
 
@@ -16,7 +17,7 @@ export function calculateRankMap(rank: RankDefinition): Record<string, boolean> 
 
     // 1. Process groups
     for (const group of rank.groups) {
-        const groupNodes = permissionGroups[group];
+        const groupNodes = getRanksConfig().permissionGroups[group];
         if (groupNodes) {
             for (const node of groupNodes) {
                 map[node] = true;

--- a/src/core/ui/panelRegistry.ts
+++ b/src/core/ui/panelRegistry.ts
@@ -331,11 +331,13 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
     configResetPanel: {
         title: 'Reset Configuration',
         parentPanelId: 'configCategoryPanel',
+        permission: 'ui.panel.owner',
         items: [] // Dynamically populated
     },
     shopManagementPanel: {
         title: 'Shop System',
         parentPanelId: 'configCategoryPanel',
+        permission: 'ui.panel.admin',
         items: [] // Dynamically populated
     },
     reportListPanel: {
@@ -485,11 +487,13 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
     kitManagementPanel: {
         title: 'Kit System',
         parentPanelId: 'configCategoryPanel',
+        permission: 'ui.panel.admin',
         items: [] // Dynamically populated
     },
     rankManagementPanel: {
         title: 'Rank System',
         parentPanelId: 'configCategoryPanel',
+        permission: 'ui.panel.admin',
         items: [
             {
                 id: 'addRank',
@@ -657,6 +661,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
     rulesManagementPanel: {
         title: 'Rules Management',
         parentPanelId: 'infoPanel',
+        permission: 'ui.panel.admin',
         items: [] // Dynamically populated
     },
     addRulePanel: {
@@ -672,6 +677,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
     helpfulLinksManagementPanel: {
         title: 'Links Management',
         parentPanelId: 'infoPanel',
+        permission: 'ui.panel.admin',
         items: [] // Dynamically populated
     },
     rulesPanel: {
@@ -779,6 +785,7 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
     xrayOresPanel: {
         title: '§l§cX-Ray Ores§r',
         parentPanelId: 'configCategoryPanel',
+        permission: 'ui.panel.admin',
         items: [
             {
                 id: 'addXrayOre',
@@ -793,11 +800,13 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
     addXrayOrePanel: {
         title: 'Add Monitored Ore',
         parentPanelId: 'xrayOresPanel',
+        permission: 'ui.panel.admin',
         items: [] // Modal form
     },
     editXrayOrePanel: {
         title: 'Edit Monitored Ore',
         parentPanelId: 'xrayOresPanel',
+        permission: 'ui.panel.admin',
         items: [] // Modal form
     },
     sidebarMainPanel: {

--- a/src/features/ranks/ranksConfig.default.ts
+++ b/src/features/ranks/ranksConfig.default.ts
@@ -46,6 +46,7 @@ export const permissionGroups: Record<string, string[]> = {
         'cmd.kit',
         'cmd.team',
         'cmd.vote',
+        'cmd.panel',
         'ui.panel.member'
     ],
     mod: ['cmd.kick', 'cmd.mute', 'cmd.unmute', 'cmd.freeze', 'cmd.unfreeze', 'cmd.inventory', 'cmd.vanish', 'ui.panel.mod'],


### PR DESCRIPTION
This commit fixes an issue where default members could not open the UI panel because they lacked the required `cmd.panel` permission, and resolves 9 security flaws detected in `UI-Permissions.test.ts`.

Details:
1. `cmd.panel` was missing from the default permission group in `ranksConfig.default.ts`. It's now explicitly listed so default members can use the `/panel` command.
2. `calculateRankMap` in `permissionEngine.ts` incorrectly used a static import of the default config for `permissionGroups`. It now dynamically retrieves `permissionGroups` from `getRanksConfig()`.
3. 9 sensitive panels (e.g. `shopManagementPanel`, `rankManagementPanel`, `configResetPanel`) in `panelRegistry.ts` were missing explicit permissions, allowing them to fall back to the generic default permission level. They've been updated to explicitly require `ui.panel.admin` or `ui.panel.owner` to prevent unauthorized access.

---
*PR created automatically by Jules for task [3662888272709124532](https://jules.google.com/task/3662888272709124532) started by @SjnExe*