### PR TITLE
Feature: Wildcard Permissions and Rank-based Shop Pricing Multipliers

### DIFF
--- a/src/core/permissionEngine.ts
+++ b/src/core/permissionEngine.ts
@@ -164,7 +164,7 @@ export function hasPermission(player: mc.Player, node: string): boolean {
 
     // Admin core permissions
     if (ranks.some((r) => r.id === 'admin')) {
-        const adminCorePermissions = ['cmd.ban', 'cmd.unban', 'cmd.tp', 'cmd.warp', 'cmd.setbalance', 'ui.panel.admin'];
+        const adminCorePermissions = ['cmd.ban.admin', 'cmd.unban.admin', 'cmd.tp.admin', 'cmd.warp.admin', 'cmd.setbalance.admin', 'ui.panel.admin'];
         if (adminCorePermissions.includes(node)) {
             return true;
         }
@@ -178,24 +178,68 @@ export function hasPermission(player: mc.Player, node: string): boolean {
         return playerMap[node];
     }
 
-    // Wildcard matching (e.g., cmd.*)
-    const segments = node.split('.');
-    let currentWildcard = '';
+    // Check wildcards using Linux-style rules (* for 1 segment, ** for 0 or more)
+    // Because a node could match multiple patterns (e.g. `cmd.**` allowed, but `cmd.pay.**` denied),
+    // and because `calculatePlayerMap` processes higher priority ranks last (overwriting `playerMap` keys),
+    // we need to be careful. Currently, `playerMap` stores `pattern -> boolean`.
+    // We should return `false` if any matched pattern explicitly denies it. Wait, the exact rules:
+    // If a pattern matches and it's false, and there's another pattern that matches and it's true, which wins?
+    // Since we merged everything into `playerMap`, all we have are the final effective patterns for the player.
+    // Usually, explicit deny overrides allow, or longest match wins.
+    // For simplicity: If ANY matching pattern is FALSE, deny it. Otherwise if ANY matching pattern is TRUE, allow it.
 
-    for (let i = 0; i < segments.length - 1; i++) {
-        currentWildcard += (i === 0 ? '' : '.') + segments[i];
-        const wildcardNode = currentWildcard + '.*';
-        if (playerMap[wildcardNode] !== undefined) {
-            return playerMap[wildcardNode];
+    const nSegs = node.split('.');
+    let hasMatch = false;
+    let allowed = false;
+
+    // To respect specificity or order, we can check all matches.
+    // If ANY match is `false`, we explicitly return `false` (deny overrides).
+    // If NO match is `false` but AT LEAST ONE match is `true`, we return `true`.
+
+    for (const [pattern, patternAllowed] of Object.entries(playerMap)) {
+        if (pattern === '*') {
+            // Support legacy global '*' just in case
+            if (patternAllowed === false) return false;
+            hasMatch = true;
+            allowed = true;
+            continue;
+        }
+
+        const pSegs = pattern.split('.');
+        if (matchPermissionSegments(pSegs, nSegs, 0, 0)) {
+            if (patternAllowed === false) {
+                return false; // Explicit deny wins immediately
+            }
+            hasMatch = true;
+            allowed = true;
         }
     }
 
-    // Global wildcard
-    if (playerMap['*'] !== undefined) {
-        return playerMap['*'];
-    }
+    return hasMatch ? allowed : false;
+}
 
-    return false;
+function matchPermissionSegments(pSegs: string[], nSegs: string[], pIdx: number, nIdx: number): boolean {
+    if (pIdx === pSegs.length && nIdx === nSegs.length) return true;
+    if (pIdx === pSegs.length) return false;
+
+    const pSeg = pSegs[pIdx];
+
+    if (pSeg === '**') {
+        // ** can match 0 or more segments
+        if (matchPermissionSegments(pSegs, nSegs, pIdx + 1, nIdx)) return true;
+        if (nIdx < nSegs.length && matchPermissionSegments(pSegs, nSegs, pIdx, nIdx + 1)) return true;
+        return false;
+    } else if (pSeg === '*') {
+        // * matches exactly 1 segment
+        if (nIdx < nSegs.length && matchPermissionSegments(pSegs, nSegs, pIdx + 1, nIdx + 1)) return true;
+        return false;
+    } else {
+        // Exact match
+        if (nIdx < nSegs.length && pSeg === nSegs[nIdx]) {
+            return matchPermissionSegments(pSegs, nSegs, pIdx + 1, nIdx + 1);
+        }
+        return false;
+    }
 }
 
 export function canGrantPermissions(editor: mc.Player, nodes: string[]): boolean {

--- a/src/features/anticheat/commands/logs.ts
+++ b/src/features/anticheat/commands/logs.ts
@@ -25,7 +25,7 @@ const logsCommand: CustomCommand = {
     name: 'logs',
     description: 'View punishment, anticheat, and chat logs.',
     category: 'Moderation',
-    permissionNode: 'cmd.logs', // Admin only
+    permissionNode: 'cmd.logs.admin', // Admin only
     execute: async (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) return;
         await showLogsMenu(executor);

--- a/src/features/anticheat/commands/notify.ts
+++ b/src/features/anticheat/commands/notify.ts
@@ -10,11 +10,11 @@ const notifyCommand: CustomCommand = {
     name: 'notify',
     description: 'Toggle anti-cheat notifications.',
     category: 'Moderation',
-    permissionNode: 'cmd.notify', // Mod
+    permissionNode: 'cmd.notify.mod', // Mod
     execute: (executor: CommandExecutor) => {
         if (executor instanceof mc.Player) {
             const pData = getPlayer(executor.id);
-            if (!pData || !hasPermission(executor, 'cmd.notify')) {
+            if (!pData || !hasPermission(executor, 'cmd.notify.mod')) {
                 executor.sendMessage('§cYou do not have permission to use this command.');
                 return;
             }

--- a/src/features/anticheat/commands/xraynotify.ts
+++ b/src/features/anticheat/commands/xraynotify.ts
@@ -14,7 +14,7 @@ const command: CustomCommand = {
     aliases: ['xray'],
     description: 'Toggles X-ray notifications for yourself or the console.',
     category: 'Administration',
-    permissionNode: 'cmd.xraynotify', // Moderator
+    permissionNode: 'cmd.xraynotify.mod', // Moderator
     allowConsole: true,
     parameters: [],
     execute: (executor) => {

--- a/src/features/auction/commands/ah.ts
+++ b/src/features/auction/commands/ah.ts
@@ -15,7 +15,7 @@ const mainCommand: CustomCommand = {
     aliases: ['auction'],
     description: 'Auction House commands.',
     category: 'Economy',
-    permissionNode: 'cmd.ah',
+    permissionNode: 'cmd.ah.member',
     parameters: [
         { name: 'subcommand', type: 'string', optional: true, enumOptions: ['sell', 'help', 'search'] },
         { name: 'price', type: 'string', optional: true },

--- a/src/features/daily/commands/daily.ts
+++ b/src/features/daily/commands/daily.ts
@@ -11,7 +11,7 @@ const dailyCommand: CustomCommand = {
     aliases: ['reward'],
     description: 'Claim your daily reward.',
     category: 'Economy',
-    permissionNode: 'cmd.daily',
+    permissionNode: 'cmd.daily.member',
     execute: (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) return;
 

--- a/src/features/economy/commands/balance.ts
+++ b/src/features/economy/commands/balance.ts
@@ -13,7 +13,7 @@ const balanceCommand: CustomCommand = {
     aliases: ['bal', 'money', 'cash'],
     description: "Checks your or another player's balance.",
     category: 'Economy',
-    permissionNode: 'cmd.balance',
+    permissionNode: 'cmd.balance.member',
     parameters: [{ name: 'targets', type: 'string', optional: true }],
     execute: (executor: CommandExecutor, args: Record<string, unknown>) => {
         const config = getConfig();
@@ -57,7 +57,7 @@ const oBalanceCommand: CustomCommand = {
     aliases: ['obal', 'offlinebalance'],
     description: "Checks an offline player's balance.",
     category: 'Economy',
-    permissionNode: 'cmd.obalance',
+    permissionNode: 'cmd.obalance.admin',
     allowConsole: true,
     hidden: true,
     parameters: [{ name: 'target', type: 'string' }],
@@ -89,7 +89,7 @@ const baltopCommand: CustomCommand = {
     aliases: ['topbal', 'leaderboard', 'richlist'],
     description: 'Shows the players with the highest balances on the server.',
     category: 'Economy',
-    permissionNode: 'cmd.baltop',
+    permissionNode: 'cmd.baltop.member',
     allowConsole: true,
     execute: (executor: CommandExecutor) => {
         const config = getConfig();

--- a/src/features/economy/commands/bounty.ts
+++ b/src/features/economy/commands/bounty.ts
@@ -67,7 +67,7 @@ const bountyCommand: CustomCommand = {
     description: 'Place a bounty on a player.',
     category: 'Economy',
     aliases: ['setbounty', 'addbounty', '+bounty', 'abounty'],
-    permissionNode: 'cmd.bounty',
+    permissionNode: 'cmd.bounty.member',
     parameters: [
         { name: 'target', type: 'string' },
         { name: 'amount', type: 'string' }
@@ -143,7 +143,7 @@ const oBountyCommand: CustomCommand = {
     aliases: ['offlinebounty'],
     description: 'Place a bounty on an offline player.',
     category: 'Economy',
-    permissionNode: 'cmd.obounty',
+    permissionNode: 'cmd.obounty.admin',
     hidden: true,
     parameters: [
         { name: 'target', type: 'string' },
@@ -173,7 +173,7 @@ const oRemoveBountyCommand: CustomCommand = {
     aliases: ['offlineremovebounty'],
     description: 'Removes a bounty from an offline player.',
     category: 'Economy',
-    permissionNode: 'cmd.oremovebounty',
+    permissionNode: 'cmd.oremovebounty.admin',
     hidden: true,
     parameters: [
         { name: 'target', type: 'string' },
@@ -266,7 +266,7 @@ const listBountyCommand: CustomCommand = {
     aliases: ['lbounty', 'bounties', 'bountylist', 'showbounties', 'hitlist'],
     description: "Lists all active bounties or a specific player's bounty.",
     category: 'Economy',
-    permissionNode: 'cmd.listbounty',
+    permissionNode: 'cmd.listbounty.member',
     allowConsole: true,
     parameters: [{ name: 'target', type: 'string', optional: true }],
     execute: (executor: CommandExecutor, args: Record<string, unknown>) => {
@@ -287,7 +287,7 @@ const oListBountyCommand: CustomCommand = {
     aliases: ['offlinelistbounty'],
     description: "Checks an offline player's bounty.",
     category: 'Economy',
-    permissionNode: 'cmd.olistbounty',
+    permissionNode: 'cmd.olistbounty.admin',
     allowConsole: true,
     hidden: true,
     parameters: [{ name: 'target', type: 'string' }],

--- a/src/features/economy/commands/pay.ts
+++ b/src/features/economy/commands/pay.ts
@@ -15,7 +15,7 @@ const payCommand: CustomCommand = {
     aliases: ['givemoney', 'transfer'],
     description: 'Pays another player from your balance.',
     category: 'Economy',
-    permissionNode: 'cmd.pay',
+    permissionNode: 'cmd.pay.member',
     parameters: [
         { name: 'targets', type: 'string' },
         { name: 'amount', type: 'string' }
@@ -69,7 +69,7 @@ const oPayCommand: CustomCommand = {
     aliases: ['offlinepay'],
     description: 'Pays an offline player.',
     category: 'Economy',
-    permissionNode: 'cmd.opay',
+    permissionNode: 'cmd.opay.admin',
     hidden: true,
     parameters: [
         { name: 'target', type: 'string' },
@@ -119,7 +119,7 @@ const payConfirmCommand: CustomCommand = {
     aliases: ['confirmpay'],
     description: 'Confirms a pending payment.',
     category: 'Economy',
-    permissionNode: 'cmd.payconfirm',
+    permissionNode: 'cmd.payconfirm.member',
     execute: (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) return;
 

--- a/src/features/economy/commands/setbalance.ts
+++ b/src/features/economy/commands/setbalance.ts
@@ -69,7 +69,7 @@ const setBalanceCommand: CustomCommand = {
     aliases: ['setbal', 'setmoney'],
     description: "Sets a player's (or players') balance to a specific amount.",
     category: 'Economy',
-    permissionNode: 'cmd.setbalance',
+    permissionNode: 'cmd.setbalance.admin',
     allowConsole: true,
     hidden: true,
     parameters: [
@@ -86,7 +86,7 @@ const addBalanceCommand: CustomCommand = {
     aliases: ['addbal', '+bal'],
     description: "Adds a specific amount to a player's (or players') balance.",
     category: 'Economy',
-    permissionNode: 'cmd.addbalance',
+    permissionNode: 'cmd.addbalance.admin',
     allowConsole: true,
     hidden: true,
     parameters: [
@@ -103,7 +103,7 @@ const removeBalanceCommand: CustomCommand = {
     aliases: ['removebal', '-bal', 'rembal'],
     description: "Removes a specific amount from a player's (or players') balance.",
     category: 'Economy',
-    permissionNode: 'cmd.removebalance',
+    permissionNode: 'cmd.removebalance.admin',
     allowConsole: true,
     hidden: true,
     parameters: [
@@ -167,7 +167,7 @@ const oSetBalanceCommand: CustomCommand = {
     aliases: ['osetbal', 'offlinesetbalance'],
     description: "Sets an offline player's balance.",
     category: 'Economy',
-    permissionNode: 'cmd.osetbalance',
+    permissionNode: 'cmd.osetbalance.admin',
     allowConsole: true,
     parameters: [
         { name: 'target', type: 'string', description: "The player's name." },
@@ -183,7 +183,7 @@ const oAddBalanceCommand: CustomCommand = {
     aliases: ['oaddbal', 'offlineaddbalance'],
     description: "Adds amount to an offline player's balance.",
     category: 'Economy',
-    permissionNode: 'cmd.oaddbalance',
+    permissionNode: 'cmd.oaddbalance.admin',
     allowConsole: true,
     parameters: [
         { name: 'target', type: 'string' },
@@ -199,7 +199,7 @@ const oRemoveBalanceCommand: CustomCommand = {
     aliases: ['oremovebal', 'offlineremovebalance'],
     description: "Removes amount from an offline player's balance.",
     category: 'Economy',
-    permissionNode: 'cmd.oremovebalance',
+    permissionNode: 'cmd.oremovebalance.admin',
     allowConsole: true,
     parameters: [
         { name: 'target', type: 'string' },

--- a/src/features/essentials/commands/announcement.ts
+++ b/src/features/essentials/commands/announcement.ts
@@ -6,7 +6,7 @@ const announcementCommand: CustomCommand = {
     name: 'announce',
     description: 'Broadcasts an announcement to all players.',
     category: 'Essentials',
-    permissionNode: 'cmd.announce',
+    permissionNode: 'cmd.announce.admin',
     parameters: [{ name: 'message', type: 'text' }],
     execute: (_executor: CommandExecutor, args: Record<string, unknown>) => {
         const message = args.message as string;

--- a/src/features/essentials/commands/chattoconsole.ts
+++ b/src/features/essentials/commands/chattoconsole.ts
@@ -8,7 +8,7 @@ const command: CustomCommand = {
     aliases: ['ctc', 'chat'],
     description: 'Toggles or sets whether player chat is logged to the server console.',
     category: 'Administration',
-    permissionNode: 'cmd.chattoconsole', // Admins only
+    permissionNode: 'cmd.chattoconsole.admin', // Admins only
     allowConsole: true,
     parameters: [
         {

--- a/src/features/essentials/commands/clear.ts
+++ b/src/features/essentials/commands/clear.ts
@@ -18,7 +18,7 @@ const clearCommand: CustomCommand = {
     slashName: 'xclear',
     description: 'Clears the inventory of a player or yourself.',
     aliases: ['ci', 'clearinv'],
-    permissionNode: 'cmd.clear',
+    permissionNode: 'cmd.clear.admin',
     allowConsole: true,
     parameters: [{ name: 'target', type: 'player', optional: true }],
 

--- a/src/features/essentials/commands/debug.ts
+++ b/src/features/essentials/commands/debug.ts
@@ -9,7 +9,7 @@ const debugCommand: CustomCommand = {
     name: 'debug',
     description: 'Displays debug information.',
     category: 'Essentials',
-    permissionNode: 'cmd.debug', // Admin only
+    permissionNode: 'cmd.debug.owner', // Admin only
     execute: (executor: CommandExecutor) => {
         const memory = mc.system.currentTick;
         // Optimization: Use cached player count

--- a/src/features/essentials/commands/fixplayer.ts
+++ b/src/features/essentials/commands/fixplayer.ts
@@ -7,7 +7,7 @@ const fixPlayerCommand: CustomCommand = {
     name: 'fixplayer',
     description: 'Fixes a player state (e.g. stuck in spawn protection, invulnerable).',
     category: 'Administration',
-    permissionNode: 'cmd.fixplayer', // Anyone can use it on themselves
+    permissionNode: 'cmd.fixplayer.member', // Anyone can use it on themselves
     execute: (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) return;
 

--- a/src/features/essentials/commands/floatingtext.ts
+++ b/src/features/essentials/commands/floatingtext.ts
@@ -8,7 +8,7 @@ const command: CustomCommand = {
     name: 'floatingtext',
     description: 'Manages floating text entities.',
     category: 'Essentials',
-    permissionNode: 'cmd.floatingtext', // Admin
+    permissionNode: 'cmd.floatingtext.admin', // Admin
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     execute: (executor: CommandExecutor, args: any) => {
         if (!(executor instanceof mc.Player)) {

--- a/src/features/essentials/commands/gamemode.ts
+++ b/src/features/essentials/commands/gamemode.ts
@@ -82,7 +82,7 @@ const mainGamemodeCommand: CustomCommand = {
     aliases: ['gm'],
     description: "Sets your or another player's gamemode.",
     category: 'Administration',
-    permissionNode: 'cmd.gamemode',
+    permissionNode: 'cmd.gamemode.admin',
     allowConsole: true,
     parameters: [
         {
@@ -128,7 +128,7 @@ const legacyCommands: CustomCommand[] = legacyCommandDefs.map((cmd) => ({
     aliases: cmd.aliases,
     description: cmd.description,
     category: 'Administration',
-    permissionNode: 'cmd.gamemode',
+    permissionNode: 'cmd.gamemode.admin',
     allowConsole: true,
     parameters: [{ name: 'targets', type: 'player', description: 'The player(s) to set the gamemode for', optional: true }],
     execute: (executor, args) => {

--- a/src/features/essentials/commands/help.ts
+++ b/src/features/essentials/commands/help.ts
@@ -253,7 +253,7 @@ const helpCommand: CustomCommand = {
     aliases: ['?', 'h', 'cmds', 'commands'],
     description: 'Displays a list of available commands or help for a specific command.',
     category: 'General',
-    permissionNode: 'cmd.help',
+    permissionNode: 'cmd.help.member',
     allowConsole: true,
     parameters: [{ name: 'command', type: 'string', optional: true }],
     execute: (executor: CommandExecutor, args: HelpCommandArgs) => {

--- a/src/features/essentials/commands/links.ts
+++ b/src/features/essentials/commands/links.ts
@@ -10,7 +10,7 @@ const linksCommand: CustomCommand = {
     aliases: ['link', 'websites'],
     description: 'Displays helpful server links.',
     category: 'General',
-    permissionNode: 'cmd.links',
+    permissionNode: 'cmd.links.member',
     allowConsole: true,
     execute: (executor: CommandExecutor) => {
         const config = getConfig();

--- a/src/features/essentials/commands/panel.ts
+++ b/src/features/essentials/commands/panel.ts
@@ -9,7 +9,7 @@ const panelCommand: CustomCommand = {
     aliases: ['ui', 'menu'],
     description: 'Opens the main UI panel.',
     category: 'Administration',
-    permissionNode: 'cmd.panel',
+    permissionNode: 'cmd.panel.member',
     execute: async (executor: CommandExecutor) => {
         if (executor instanceof mc.Player) {
             await showPanel(executor, 'mainPanel');

--- a/src/features/essentials/commands/pvp.ts
+++ b/src/features/essentials/commands/pvp.ts
@@ -10,7 +10,7 @@ const command: CustomCommand = {
     name: 'pvp',
     description: 'Challenge a player to a PvP duel with an optional wager.',
     category: 'PvP',
-    permissionNode: 'cmd.pvp', // Everyone
+    permissionNode: 'cmd.pvp.member', // Everyone
     allowConsole: false,
     parameters: [
         { name: 'target', type: 'string', description: 'The player to challenge, or "accept"/"deny".' },

--- a/src/features/essentials/commands/rank.ts
+++ b/src/features/essentials/commands/rank.ts
@@ -7,7 +7,7 @@ const rankCommand: CustomCommand = {
     name: 'rank',
     description: 'Manage player ranks.',
     category: 'Essentials',
-    permissionNode: 'cmd.rank', // Admin
+    permissionNode: 'cmd.rank.admin', // Admin
     parameters: [
         { name: 'action', type: 'string', enumOptions: ['set', 'get', 'list'] },
         { name: 'target', type: 'string', optional: true },

--- a/src/features/essentials/commands/reload.ts
+++ b/src/features/essentials/commands/reload.ts
@@ -10,7 +10,7 @@ const command: CustomCommand = {
     aliases: ['xreload'],
     description: 'Reloads the addon configuration from the config file.',
     category: 'Administration',
-    permissionNode: 'cmd.reload', // Admins only
+    permissionNode: 'cmd.reload.admin', // Admins only
     allowConsole: true,
     parameters: [],
     execute: (_executor) => {

--- a/src/features/essentials/commands/restart.ts
+++ b/src/features/essentials/commands/restart.ts
@@ -6,7 +6,7 @@ const command: CustomCommand = {
     name: 'restart',
     description: 'Initiates the server restart sequence.',
     category: 'Administration',
-    permissionNode: 'cmd.restart', // Admin only
+    permissionNode: 'cmd.restart.admin', // Admin only
     allowConsole: true,
     parameters: [],
     execute: (executor, _args) => {

--- a/src/features/essentials/commands/rules.ts
+++ b/src/features/essentials/commands/rules.ts
@@ -14,7 +14,7 @@ const rulesCommand: CustomCommand = {
     aliases: ['rule'],
     description: 'Displays the server rules.',
     category: 'General',
-    permissionNode: 'cmd.rules',
+    permissionNode: 'cmd.rules.member',
     allowConsole: true,
     parameters: [{ name: 'ruleNumber', type: 'int', optional: true }],
 

--- a/src/features/essentials/commands/save.ts
+++ b/src/features/essentials/commands/save.ts
@@ -12,7 +12,7 @@ const command: CustomCommand = {
     aliases: ['xsave'],
     description: 'Manually saves all server data to disk.',
     category: 'Administration',
-    permissionNode: 'cmd.save', // Admins only
+    permissionNode: 'cmd.save.admin', // Admins only
     allowConsole: true,
     parameters: [],
     execute: (executor) => {

--- a/src/features/essentials/commands/sidebar.ts
+++ b/src/features/essentials/commands/sidebar.ts
@@ -8,7 +8,7 @@ const command: CustomCommand = {
     name: 'sidebar',
     description: 'Toggles the sidebar/HUD.',
     aliases: ['sb'],
-    permissionNode: 'cmd.sidebar', // Member
+    permissionNode: 'cmd.sidebar.member', // Member
     category: 'General',
     execute: (executor) => {
         if (!(executor instanceof mc.Player)) {

--- a/src/features/essentials/commands/spawn.ts
+++ b/src/features/essentials/commands/spawn.ts
@@ -31,7 +31,7 @@ const spawnCommand: CustomCommand = {
     aliases: ['lobby', 'hub'],
     description: 'Teleports you to the server spawn point.',
     category: 'Transportation',
-    permissionNode: 'cmd.spawn',
+    permissionNode: 'cmd.spawn.member',
     execute: (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) {
             return;
@@ -42,7 +42,7 @@ const spawnCommand: CustomCommand = {
 
         if (!spawnLocation || typeof spawnLocation.x !== 'number') {
             sendMessage('§cThe server spawn point has not been set.', executor);
-            if (hasPermission(executor, 'cmd.setspawn')) {
+            if (hasPermission(executor, 'cmd.setspawn.admin')) {
                 // Is admin or owner
                 sendMessage('§eAs an admin, you can set it by running §a/setspawn§e at the desired location.', executor, { raw: true });
             }
@@ -147,7 +147,7 @@ const setSpawnCommand: CustomCommand = {
     aliases: ['setworldspawn', 'spawnset'],
     description: "Sets the server's spawn location to your current position or specified coordinates.",
     category: 'Transportation',
-    permissionNode: 'cmd.setspawn', // Admins only
+    permissionNode: 'cmd.setspawn.admin', // Admins only
     allowConsole: true,
     parameters: [
         { name: 'x', type: 'float', optional: true },

--- a/src/features/essentials/commands/status.ts
+++ b/src/features/essentials/commands/status.ts
@@ -8,7 +8,7 @@ const statusCommand: CustomCommand = {
     name: 'status',
     description: 'Shows server status.',
     category: 'Essentials',
-    permissionNode: 'cmd.status',
+    permissionNode: 'cmd.status.owner',
     execute: (executor: CommandExecutor) => {
         const playerCount = getPlayerCount();
         const tick = mc.system.currentTick;

--- a/src/features/essentials/commands/version.ts
+++ b/src/features/essentials/commands/version.ts
@@ -10,7 +10,7 @@ const command: CustomCommand = {
     aliases: ['ver'],
     description: 'Displays the current version of the addon.',
     category: 'General',
-    permissionNode: 'cmd.version', // Everyone
+    permissionNode: 'cmd.version.member', // Everyone
     parameters: [],
     execute: (executor: CommandExecutor) => {
         const config = getConfig();

--- a/src/features/kit/commands/kit.ts
+++ b/src/features/kit/commands/kit.ts
@@ -94,7 +94,7 @@ const kitCommand: CustomCommand = {
     name: 'kit',
     description: 'Claims a specific kit. Leave blank to see a list of available kits.',
     category: 'Economy',
-    permissionNode: 'cmd.kit',
+    permissionNode: 'cmd.kit.member',
     parameters: [
         {
             name: 'kitName',
@@ -141,7 +141,7 @@ const addKitCommand: CustomCommand = {
     name: 'addkit',
     description: 'Create a new kit from your inventory and open the editor.',
     category: 'Economy',
-    permissionNode: 'cmd.addkit', // Admins only
+    permissionNode: 'cmd.addkit.admin', // Admins only
     allowConsole: false,
     parameters: [{ name: 'kitName', type: 'string', optional: true }],
     execute: async (executor: CommandExecutor, args: KitCommandArgs) => {

--- a/src/features/moderation/commands/ban.ts
+++ b/src/features/moderation/commands/ban.ts
@@ -71,7 +71,7 @@ const banCommand: CustomCommand = {
     name: 'ban',
     description: 'Bans a player for a specified duration with a reason.',
     category: 'Moderation',
-    permissionNode: 'cmd.ban',
+    permissionNode: 'cmd.ban.admin',
     allowConsole: true,
     hidden: true,
     parameters: [
@@ -150,7 +150,7 @@ const unbanCommand: CustomCommand = {
     aliases: ['pardon'],
     description: 'Unbans a player.',
     category: 'Moderation',
-    permissionNode: 'cmd.unban',
+    permissionNode: 'cmd.unban.admin',
     allowConsole: true,
     parameters: [{ name: 'target', type: 'string' }],
     execute: (executor: CommandExecutor, args: Record<string, unknown>) => {
@@ -216,7 +216,7 @@ const offlineBanCommand: CustomCommand = {
     aliases: ['oban'],
     description: 'Bans a player who is currently offline.',
     category: 'Moderation',
-    permissionNode: 'cmd.offlineban',
+    permissionNode: 'cmd.offlineban.admin',
     allowConsole: true,
     parameters: [
         { name: 'target', type: 'string' },

--- a/src/features/moderation/commands/chatlog.ts
+++ b/src/features/moderation/commands/chatlog.ts
@@ -10,7 +10,7 @@ const chatlogCommand: CustomCommand = {
     name: 'chatlog',
     description: 'View chat logs directly.',
     category: 'Moderation',
-    permissionNode: 'cmd.chatlog',
+    permissionNode: 'cmd.chatlog.admin',
     allowConsole: false,
     execute: async (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) return;

--- a/src/features/moderation/commands/clearchat.ts
+++ b/src/features/moderation/commands/clearchat.ts
@@ -10,7 +10,7 @@ const clearchatCommand: CustomCommand = {
     aliases: ['cc'],
     description: 'Clears the chat for all players.',
     category: 'Moderation',
-    permissionNode: 'cmd.clearchat',
+    permissionNode: 'cmd.clearchat.admin',
     allowConsole: true,
     execute: (executor: CommandExecutor) => {
         try {

--- a/src/features/moderation/commands/dimensionLock.ts
+++ b/src/features/moderation/commands/dimensionLock.ts
@@ -41,7 +41,7 @@ const netherLockCommand: CustomCommand = {
     name: 'netherlock',
     description: 'Toggles or sets the lock for the Nether dimension.',
     category: 'Administration',
-    permissionNode: 'cmd.netherlock',
+    permissionNode: 'cmd.netherlock.admin',
     allowConsole: true,
     parameters: [
         {
@@ -58,7 +58,7 @@ const endLockCommand: CustomCommand = {
     name: 'endlock',
     description: 'Toggles or sets the lock for the End dimension.',
     category: 'Administration',
-    permissionNode: 'cmd.endlock',
+    permissionNode: 'cmd.endlock.admin',
     allowConsole: true,
     parameters: [
         {

--- a/src/features/moderation/commands/freeze.ts
+++ b/src/features/moderation/commands/freeze.ts
@@ -114,7 +114,7 @@ const freezeCommand: CustomCommand = {
     name: 'freeze',
     description: 'Freezes a player, preventing them from moving or looking around.',
     category: 'Moderation',
-    permissionNode: 'cmd.freeze',
+    permissionNode: 'cmd.freeze.mod',
     allowConsole: true,
     parameters: [{ name: 'target', type: 'player' }],
     execute: (executor: CommandExecutor, args: FreezeCommandArgs) => {
@@ -145,7 +145,7 @@ const unfreezeCommand: CustomCommand = {
     name: 'unfreeze',
     description: 'Unfreezes a player, allowing them to move and look around again.',
     category: 'Moderation',
-    permissionNode: 'cmd.unfreeze',
+    permissionNode: 'cmd.unfreeze.mod',
     allowConsole: true,
     parameters: [{ name: 'target', type: 'player' }],
     execute: (executor: CommandExecutor, args: FreezeCommandArgs) => {

--- a/src/features/moderation/commands/inventory.ts
+++ b/src/features/moderation/commands/inventory.ts
@@ -45,7 +45,7 @@ const invseeCommand: CustomCommand = {
     name: 'invsee',
     description: 'View the inventory of another player.',
     category: 'Moderation',
-    permissionNode: 'cmd.invsee',
+    permissionNode: 'cmd.invsee.mod',
     parameters: [{ name: 'player', type: 'string', optional: false }],
     execute: (executor: CommandExecutor, params: Record<string, unknown>) => {
         if (!(executor instanceof mc.Player)) {
@@ -95,7 +95,7 @@ const ecseeCommand: CustomCommand = {
     name: 'ecsee',
     description: 'View the ender chest of another player.',
     category: 'Moderation',
-    permissionNode: 'cmd.ecsee',
+    permissionNode: 'cmd.ecsee.admin',
     parameters: [{ name: 'player', type: 'string', optional: false }],
     execute: (executor: CommandExecutor, _params: Record<string, unknown>) => {
         executor.sendMessage('§cEnder Chest inspection is not yet fully supported in this API version.');
@@ -106,7 +106,7 @@ const ecwipeCommand: CustomCommand = {
     name: 'ecwipe',
     description: "Clears a player's Ender Chest.",
     category: 'Moderation',
-    permissionNode: 'cmd.ecwipe',
+    permissionNode: 'cmd.ecwipe.admin',
     parameters: [{ name: 'player', type: 'string', optional: false }],
     execute: (executor: CommandExecutor, params: Record<string, unknown>) => {
         const targetName = params.player;
@@ -163,7 +163,7 @@ const copyinvCommand: CustomCommand = {
     name: 'copyinv',
     description: "Copies another player's inventory to yours.",
     category: 'Moderation',
-    permissionNode: 'cmd.copyinv',
+    permissionNode: 'cmd.copyinv.admin',
     parameters: [{ name: 'player', type: 'string', optional: false }],
     execute: (executor: CommandExecutor, params: Record<string, unknown>) => {
         if (!(executor instanceof mc.Player)) {

--- a/src/features/moderation/commands/kick.ts
+++ b/src/features/moderation/commands/kick.ts
@@ -71,7 +71,7 @@ const kickCommand: CustomCommand = {
     description: 'Kicks a player from the server.',
     category: 'Moderation',
     aliases: ['boot'],
-    permissionNode: 'cmd.kick',
+    permissionNode: 'cmd.kick.mod',
     allowConsole: true,
     parameters: [
         { name: 'target', type: 'string' },

--- a/src/features/moderation/commands/mute.ts
+++ b/src/features/moderation/commands/mute.ts
@@ -65,7 +65,7 @@ const muteCommand: CustomCommand = {
     description: 'Mutes a player for a specified duration with a reason.',
     category: 'Moderation',
     aliases: ['silence'],
-    permissionNode: 'cmd.mute',
+    permissionNode: 'cmd.mute.mod',
     allowConsole: true,
     parameters: [
         { name: 'target', type: 'player' },
@@ -145,7 +145,7 @@ const unmuteCommand: CustomCommand = {
     description: 'Unmutes a player.',
     category: 'Moderation',
     aliases: ['um'],
-    permissionNode: 'cmd.unmute',
+    permissionNode: 'cmd.unmute.mod',
     allowConsole: true,
     parameters: [{ name: 'target', type: 'string' }],
     execute: (executor: CommandExecutor, args: Record<string, unknown>) => {

--- a/src/features/moderation/commands/report.ts
+++ b/src/features/moderation/commands/report.ts
@@ -13,7 +13,7 @@ const reportCommand: CustomCommand = {
     name: 'report',
     description: 'Reports a player. Usage: /report [target] [reason]',
     category: 'Moderation',
-    permissionNode: 'cmd.report',
+    permissionNode: 'cmd.report.member',
     parameters: [
         { name: 'target', type: 'string', optional: true },
         { name: 'message', type: 'text', optional: true }
@@ -72,7 +72,7 @@ const reportsCommand: CustomCommand = {
     name: 'reports',
     description: 'Views the list of active reports.',
     category: 'Moderation',
-    permissionNode: 'cmd.reports',
+    permissionNode: 'cmd.reports.admin',
     execute: async (executor: CommandExecutor) => {
         if (executor instanceof mc.Player) {
             await showPanel(executor, 'reportListPanel');
@@ -84,7 +84,7 @@ const clearReportsCommand: CustomCommand = {
     name: 'clearreports',
     description: 'Clears all active reports.',
     category: 'Moderation',
-    permissionNode: 'cmd.clearreports',
+    permissionNode: 'cmd.clearreports.admin',
     allowConsole: true,
     execute: (executor: CommandExecutor) => {
         reportManager.clearAllReports();

--- a/src/features/moderation/commands/vanish.ts
+++ b/src/features/moderation/commands/vanish.ts
@@ -14,7 +14,7 @@ const vanishCommand: CustomCommand = {
     aliases: ['v'],
     description: 'Makes you invisible to other players.',
     category: 'Moderation',
-    permissionNode: 'cmd.vanish',
+    permissionNode: 'cmd.vanish.mod',
     allowConsole: false,
     execute: (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) {

--- a/src/features/moderation/commands/warn.ts
+++ b/src/features/moderation/commands/warn.ts
@@ -14,7 +14,7 @@ const warnCommand: CustomCommand = {
     name: 'warn',
     description: 'Warns a player for misconduct.',
     category: 'Moderation',
-    permissionNode: 'cmd.warn', // Moderator
+    permissionNode: 'cmd.warn.mod', // Moderator
     parameters: [
         { name: 'player', type: 'player' },
         { name: 'reason', type: 'string' }

--- a/src/features/ranks/ranksConfig.default.ts
+++ b/src/features/ranks/ranksConfig.default.ts
@@ -21,6 +21,10 @@ export interface RankDefinition {
     groups: string[];
     allow: string[];
     deny: string[];
+    shopMultiplier?: {
+        buy: number;
+        sell: number;
+    };
 }
 
 export const defaultChatFormatting: Required<ChatFormatting> = {
@@ -30,28 +34,10 @@ export const defaultChatFormatting: Required<ChatFormatting> = {
 };
 
 export const permissionGroups: Record<string, string[]> = {
-    default: [
-        'cmd.help',
-        'cmd.spawn',
-        'cmd.tpa',
-        'cmd.tpahere',
-        'cmd.home',
-        'cmd.sethome',
-        'cmd.delhome',
-        'cmd.pay',
-        'cmd.balance',
-        'cmd.bounty',
-        'cmd.rtp',
-        'cmd.daily',
-        'cmd.kit',
-        'cmd.team',
-        'cmd.vote',
-        'cmd.panel',
-        'ui.panel.member'
-    ],
-    mod: ['cmd.kick', 'cmd.mute', 'cmd.unmute', 'cmd.freeze', 'cmd.unfreeze', 'cmd.inventory', 'cmd.vanish', 'ui.panel.mod'],
-    admin: ['cmd.ban', 'cmd.unban', 'cmd.tp', 'cmd.warp', 'cmd.setbalance', 'ui.panel.admin'],
-    owner: ['cmd.op', 'ui.panel.owner', 'cmd.debug', 'cmd.status', 'cmd.fixplayer', 'cmd.deathcoords']
+    default: ['cmd.**.member', 'ui.**.member', 'command.member'],
+    mod: ['cmd.**.mod', 'ui.**.mod'],
+    admin: ['cmd.**.admin', 'ui.**.admin'],
+    owner: ['cmd.**.owner', 'ui.**.owner']
 };
 
 export const rankDefinitions: RankDefinition[] = [
@@ -118,7 +104,7 @@ export const rankDefinitions: RankDefinition[] = [
         nametagPrefix: '§eHelper',
         conditions: [{ type: 'hasTag', value: 'helper' }],
         groups: ['default'],
-        allow: ['cmd.kick', 'cmd.mute'], // Specific permissions just for example
+        allow: ['cmd.kick.mod', 'cmd.mute.mod'], // Specific permissions just for example
         deny: []
     },
     {
@@ -135,7 +121,8 @@ export const rankDefinitions: RankDefinition[] = [
         conditions: [{ type: 'hasTag', value: 'donator' }],
         groups: ['default'],
         allow: [],
-        deny: []
+        deny: [],
+        shopMultiplier: { buy: 0.9, sell: 1.1 } // 10% discount on buy, 10% bonus on sell
     },
     {
         id: 'vip',
@@ -151,7 +138,8 @@ export const rankDefinitions: RankDefinition[] = [
         conditions: [{ type: 'hasTag', value: 'vip' }],
         groups: ['default'],
         allow: [],
-        deny: []
+        deny: [],
+        shopMultiplier: { buy: 0.8, sell: 1.2 } // 20% discount on buy, 20% bonus on sell
     },
     {
         id: 'verified',

--- a/src/features/shop/adminManager.ts
+++ b/src/features/shop/adminManager.ts
@@ -31,6 +31,7 @@ interface UpdateItemData {
     buyPrice: number;
     sellPrice: number;
     permission: string;
+    rankOverrides?: Record<string, { buy: number; sell: number }>;
 }
 
 /**
@@ -466,6 +467,11 @@ function updateMasterItemList(itemId: string, newData: UpdateItemData) {
         itemsRecord[itemId].displayName = newData.displayName;
         itemsRecord[itemId].itemId = newData.minecraftId;
         itemsRecord[itemId].icon = newData.icon;
+        if (isDefined(newData.rankOverrides)) {
+            itemsRecord[itemId].rankMultiplierOverrides = newData.rankOverrides;
+        } else {
+            delete itemsRecord[itemId].rankMultiplierOverrides;
+        }
     } else {
         addCustomItemToConfig(itemId, {
             displayName: newData.displayName,
@@ -514,6 +520,13 @@ export function updateShopItem(categoryName: string, subCategoryName: string | u
     targetContainer.items[itemId].buyPrice = newData.buyPrice;
     targetContainer.items[itemId].sellPrice = newData.sellPrice;
     targetContainer.items[itemId].permission = newData.permission;
+
+    if (isDefined(newData.rankOverrides)) {
+        targetContainer.items[itemId].rankMultiplierOverrides = newData.rankOverrides;
+    } else {
+        delete targetContainer.items[itemId].rankMultiplierOverrides;
+    }
+
     // Also update denormalized data like icon and displayName for consistency
     targetContainer.items[itemId].icon = newData.icon;
     targetContainer.items[itemId].displayName = newData.displayName;

--- a/src/features/shop/adminManager.ts
+++ b/src/features/shop/adminManager.ts
@@ -22,6 +22,7 @@ interface ItemData {
     sellPrice: number;
     permission?: string;
     category?: string;
+    rankMultiplierOverrides?: Record<string, { buy: number; sell: number }>;
 }
 
 interface UpdateItemData {

--- a/src/features/shop/commands/shop.ts
+++ b/src/features/shop/commands/shop.ts
@@ -14,7 +14,7 @@ const shopCommand: CustomCommand = {
     name: 'shop',
     description: 'Opens the server shop.',
     category: 'Economy',
-    permissionNode: 'cmd.shop',
+    permissionNode: 'cmd.shop.member',
     allowConsole: false,
     execute: async (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) {
@@ -32,7 +32,7 @@ const buyCommand: CustomCommand = {
     name: 'buy',
     description: 'Opens the shop to buy items.',
     category: 'Economy',
-    permissionNode: 'cmd.buy',
+    permissionNode: 'cmd.buy.member',
     allowConsole: false,
     execute: async (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) {
@@ -50,7 +50,7 @@ const sellCommand: CustomCommand = {
     name: 'sell',
     description: 'Opens the shop to sell items.',
     category: 'Economy',
-    permissionNode: 'cmd.sell',
+    permissionNode: 'cmd.sell.member',
     allowConsole: false,
     execute: async (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) {
@@ -69,7 +69,7 @@ const sellHandCommand: CustomCommand = {
     description: 'Sells the item currently in your main hand.',
     category: 'Economy',
     aliases: ['sh'],
-    permissionNode: 'cmd.sellhand',
+    permissionNode: 'cmd.sellhand.member',
     allowConsole: false,
     execute: (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) {
@@ -119,7 +119,7 @@ const addShopCommand: CustomCommand = {
     name: 'addshop',
     description: 'Adds the item in your hand to a shop category.',
     category: 'Economy',
-    permissionNode: 'cmd.addshop', // Admins only
+    permissionNode: 'cmd.addshop.admin', // Admins only
     allowConsole: false,
     parameters: [
         { name: 'category', type: 'string' },

--- a/src/features/shop/itemsConfig.default.ts
+++ b/src/features/shop/itemsConfig.default.ts
@@ -27,6 +27,7 @@ export interface ItemData {
         id: string;
         level: number;
     };
+    rankMultiplierOverrides?: Record<string, { buy: number; sell: number }>;
 }
 
 export const items: Record<string, ItemData> = {

--- a/src/features/shop/manager.ts
+++ b/src/features/shop/manager.ts
@@ -2,6 +2,7 @@ import * as mc from '@minecraft/server';
 
 import { getShopConfig } from '@core/configurations.js';
 import { errorLog } from '@core/logger.js';
+import { getPlayerRanks } from '@core/permissionEngine.js';
 import { getOrCreatePlayer, incrementPlayerBalance } from '@core/playerDataManager.js';
 import { formatCurrency } from '@core/utils.js';
 import { items as allItems } from '@features/shop/itemsConfig.default.js';
@@ -13,6 +14,7 @@ interface ItemInfo {
     enchantment?: { id: string; level: number };
     buyPrice?: number;
     sellPrice?: number;
+    rankMultiplierOverrides?: Record<string, { buy: number; sell: number }>;
 }
 
 interface ShopTransactionResult {
@@ -67,7 +69,7 @@ function createShopItemStack(itemInfo: ItemInfo, quantity: number): mc.ItemStack
  * @param itemId The item ID to look up.
  * @returns The item definition or undefined if not found.
  */
-function findShopItem(itemId: string): ItemInfo | undefined {
+export function findShopItem(itemId: string): ItemInfo | undefined {
     const shopConfig = getShopConfig();
     const categories = shopConfig.categories;
     const items = allItems as Record<string, ItemInfo>;
@@ -88,6 +90,44 @@ function findShopItem(itemId: string): ItemInfo | undefined {
         }
     }
     return undefined;
+}
+
+/**
+ * Calculates the dynamic price of an item based on the player's ranks and item overrides.
+ * @param player The player to calculate the price for.
+ * @param shopItem The shop item definition.
+ * @param type Whether we are calculating 'buy' or 'sell' price.
+ * @returns The calculated price, rounded to 2 decimal places.
+ */
+export function getPlayerShopItemPrice(player: mc.Player, shopItem: ItemInfo, type: 'buy' | 'sell'): number {
+    const basePrice = type === 'buy' ? shopItem.buyPrice : shopItem.sellPrice;
+    if (!isDefined(basePrice) || basePrice <= 0) return basePrice ?? -1;
+
+    const ranks = getPlayerRanks(player);
+    let bestMultiplier = 1;
+
+    for (const rank of ranks) {
+        let currentMultiplier = 1;
+
+        // First check item-specific override for this rank
+        if (isDefined(shopItem.rankMultiplierOverrides) && isDefined(shopItem.rankMultiplierOverrides[rank.id])) {
+            currentMultiplier = shopItem.rankMultiplierOverrides[rank.id]![type];
+        }
+        // Fallback to global rank multiplier
+        else if (isDefined(rank.shopMultiplier)) {
+            currentMultiplier = rank.shopMultiplier[type];
+        }
+
+        // We want the lowest buy price (lowest multiplier) and highest sell price (highest multiplier)
+        if (type === 'buy') {
+            if (currentMultiplier < bestMultiplier) bestMultiplier = currentMultiplier;
+        } else {
+            if (currentMultiplier > bestMultiplier) bestMultiplier = currentMultiplier;
+        }
+    }
+
+    const calculatedPrice = basePrice * bestMultiplier;
+    return Math.round(calculatedPrice * 100) / 100;
 }
 
 /**
@@ -135,7 +175,7 @@ export function buyItem(player: mc.Player, itemId: string, quantity: number): Sh
         return { success: false, message: '§cThis item is not available in the shop.' };
     }
 
-    const buyPrice = shopItem.buyPrice;
+    const buyPrice = getPlayerShopItemPrice(player, shopItem, 'buy');
     if (!isDefined(buyPrice) || buyPrice <= 0) {
         return { success: false, message: '§cThis item cannot be purchased.' };
     }
@@ -280,7 +320,7 @@ export function sellItem(player: mc.Player, itemId: string, quantity: number): S
         return { success: false, message: '§cThis item cannot be sold to the shop.' };
     }
 
-    const sellPrice = shopItem.sellPrice;
+    const sellPrice = getPlayerShopItemPrice(player, shopItem, 'sell');
     if (!isDefined(sellPrice) || sellPrice <= 0) {
         return { success: false, message: '§cThis item cannot be sold.' };
     }

--- a/src/features/shop/shopConfig.ts
+++ b/src/features/shop/shopConfig.ts
@@ -5,6 +5,7 @@ export interface ShopItem {
     icon?: string;
     displayName?: string;
     itemId?: string;
+    rankMultiplierOverrides?: Record<string, { buy: number; sell: number }>;
 }
 
 export interface ShopSubCategory {

--- a/src/features/shop/ui/adminPanel.ts
+++ b/src/features/shop/ui/adminPanel.ts
@@ -410,7 +410,8 @@ export class ShopAdminPanelHandler implements IPanelHandler {
                 .textField('Icon Path', 'e.g., textures/items/diamond_sword')
                 .textField('Buy Price', '-1 to disable', { defaultValue: '-1' })
                 .textField('Sell Price', '-1 to disable', { defaultValue: '-1' })
-                .textField('Permission Level', 'e.g., 1024', { defaultValue: '1024' });
+                .textField('Permission Node', 'e.g., ui.panel.member', { defaultValue: 'ui.panel.member' })
+                .textField('Rank Multipliers (rank=buy,sell;)', 'e.g., vip=0.8,1.2', { defaultValue: '' });
         }
 
         if (panelId === 'addItemFromListPanel') {
@@ -455,6 +456,15 @@ export class ShopAdminPanelHandler implements IPanelHandler {
         const itemId = context.selectedItemId as string;
         const masterItem = allItems[itemId];
         if (!isDefined(masterItem)) return undefined;
+
+        // Serialize overrides for the text field
+        let overridesStr = '';
+        if (isDefined(masterItem.rankMultiplierOverrides)) {
+            overridesStr = Object.entries(masterItem.rankMultiplierOverrides)
+                .map(([rankId, multipliers]) => `${rankId}=${multipliers.buy},${multipliers.sell}`)
+                .join('; ');
+        }
+
         return new ModalFormData()
             .title(`Add ${String(masterItem.displayName ?? itemId)}`)
             .textField('Icon Path', 'e.g., textures/items/diamond_sword', {
@@ -462,7 +472,8 @@ export class ShopAdminPanelHandler implements IPanelHandler {
             })
             .textField('Buy Price', '-1 to disable', { defaultValue: String(masterItem.buyPrice ?? -1) })
             .textField('Sell Price', '-1 to disable', { defaultValue: String(masterItem.sellPrice ?? -1) })
-            .textField('Permission Level', 'e.g., 1024', { defaultValue: '1024' });
+            .textField('Permission Node', 'e.g., ui.panel.member', { defaultValue: 'ui.panel.member' })
+            .textField('Rank Multipliers (rank=buy,sell;)', 'e.g., vip=0.8,1.2', { defaultValue: overridesStr });
     }
 
     private buildEditItemFormModal(context: UIContext): ModalFormData | undefined {
@@ -473,6 +484,14 @@ export class ShopAdminPanelHandler implements IPanelHandler {
         const shopItem = isNonEmptyString(subCategoryName) ? shopConfig.categories[categoryName]?.subCategories[subCategoryName]?.items[itemId] : shopConfig.categories[categoryName]?.items[itemId];
 
         if (!isDefined(shopItem)) return undefined;
+
+        // Serialize overrides for the text field
+        let overridesStr = '';
+        if (isDefined(shopItem.rankMultiplierOverrides)) {
+            overridesStr = Object.entries(shopItem.rankMultiplierOverrides)
+                .map(([rankId, multipliers]) => `${rankId}=${multipliers.buy},${multipliers.sell}`)
+                .join('; ');
+        }
 
         return new ModalFormData()
             .title(`Edit Item: ${String(itemId)}`)
@@ -485,7 +504,8 @@ export class ShopAdminPanelHandler implements IPanelHandler {
             .textField('Icon', 'Icon', { defaultValue: isNonEmptyString(shopItem.icon) ? shopItem.icon : '' })
             .textField('Buy Price', 'Price', { defaultValue: String(shopItem.buyPrice) })
             .textField('Sell Price', 'Price', { defaultValue: String(shopItem.sellPrice) })
-            .textField('Permission Node', 'ui.panel.member', { defaultValue: shopItem.permission });
+            .textField('Permission Node', 'ui.panel.member', { defaultValue: shopItem.permission })
+            .textField('Rank Multipliers (rank=buy,sell;)', 'e.g., vip=0.8,1.2', { defaultValue: overridesStr });
     }
 
     async handleResponse(player: mc.Player, panelId: string, response: ActionFormResponse | ModalFormResponse, context: UIContext): Promise<void> {
@@ -600,11 +620,36 @@ export class ShopAdminPanelHandler implements IPanelHandler {
         const buyPriceStr = values[4];
         const sellPriceStr = values[5];
         const permLevelStr = values[6];
+        const overridesRaw = values[7] ?? '';
 
         const icon = iconStr;
         const buyPrice = Number.parseInt(isNonEmptyString(buyPriceStr) ? buyPriceStr : '-1', 10);
         const sellPrice = Number.parseInt(isNonEmptyString(sellPriceStr) ? sellPriceStr : '-1', 10);
         const permission = isNonEmptyString(permLevelStr) ? permLevelStr : 'ui.panel.member';
+
+        let parsedOverrides: Record<string, { buy: number; sell: number }> | undefined = undefined;
+
+        if (isNonEmptyString(overridesRaw)) {
+            parsedOverrides = {};
+            const pairs = overridesRaw.split(';');
+            for (const pair of pairs) {
+                const parts = pair.trim().split('=');
+                if (parts.length === 2 && isNonEmptyString(parts[0]) && isNonEmptyString(parts[1])) {
+                    const rankId = parts[0].trim();
+                    const multiParts = parts[1].split(',');
+                    if (multiParts.length === 2) {
+                        const buyM = Number.parseFloat(multiParts[0]!);
+                        const sellM = Number.parseFloat(multiParts[1]!);
+                        if (!Number.isNaN(buyM) && !Number.isNaN(sellM)) {
+                            parsedOverrides[rankId] = { buy: buyM, sell: sellM };
+                        }
+                    }
+                }
+            }
+            if (Object.keys(parsedOverrides).length === 0) {
+                parsedOverrides = undefined;
+            }
+        }
 
         if (isNonEmptyString(customId) && isNonEmptyString(displayName) && isNonEmptyString(mcId) && !Number.isNaN(buyPrice)) {
             shopAdminManager.addCustomItemToConfig(customId, {
@@ -612,7 +657,8 @@ export class ShopAdminPanelHandler implements IPanelHandler {
                 icon: icon ?? '',
                 buyPrice,
                 sellPrice,
-                displayName
+                displayName,
+                rankMultiplierOverrides: parsedOverrides
             });
             shopAdminManager.setItem(context.categoryName as string, (context.subCategoryName as string) || undefined, customId, {
                 buyPrice,
@@ -620,7 +666,8 @@ export class ShopAdminPanelHandler implements IPanelHandler {
                 permission,
                 icon: icon ?? '',
                 displayName,
-                itemId: customId
+                itemId: customId,
+                rankOverrides: parsedOverrides
             });
             player.sendMessage(`§2Added ${displayName}.`);
         }
@@ -643,11 +690,36 @@ export class ShopAdminPanelHandler implements IPanelHandler {
         const buyPriceStr = values[1];
         const sellPriceStr = values[2];
         const permLevelStr = values[3];
+        const overridesRaw = values[4] ?? '';
 
         const icon = iconStr;
         const buyPrice = Number.parseInt(isNonEmptyString(buyPriceStr) ? buyPriceStr : '-1', 10);
         const sellPrice = Number.parseInt(isNonEmptyString(sellPriceStr) ? sellPriceStr : '-1', 10);
         const permission = isNonEmptyString(permLevelStr) ? permLevelStr : 'ui.panel.member';
+
+        let parsedOverrides: Record<string, { buy: number; sell: number }> | undefined = undefined;
+
+        if (isNonEmptyString(overridesRaw)) {
+            parsedOverrides = {};
+            const pairs = overridesRaw.split(';');
+            for (const pair of pairs) {
+                const parts = pair.trim().split('=');
+                if (parts.length === 2 && isNonEmptyString(parts[0]) && isNonEmptyString(parts[1])) {
+                    const rankId = parts[0].trim();
+                    const multiParts = parts[1].split(',');
+                    if (multiParts.length === 2) {
+                        const buyM = Number.parseFloat(multiParts[0]!);
+                        const sellM = Number.parseFloat(multiParts[1]!);
+                        if (!Number.isNaN(buyM) && !Number.isNaN(sellM)) {
+                            parsedOverrides[rankId] = { buy: buyM, sell: sellM };
+                        }
+                    }
+                }
+            }
+            if (Object.keys(parsedOverrides).length === 0) {
+                parsedOverrides = undefined;
+            }
+        }
 
         if (!Number.isNaN(buyPrice) && isDefined(masterItem)) {
             shopAdminManager.setItem(context.categoryName as string, (context.subCategoryName as string) || undefined, itemId, {
@@ -656,7 +728,8 @@ export class ShopAdminPanelHandler implements IPanelHandler {
                 permission,
                 icon: icon ?? '',
                 displayName: masterItem.displayName ?? '',
-                itemId: itemId
+                itemId: itemId,
+                rankOverrides: parsedOverrides
             });
             player.sendMessage(`§2Added ${masterItem.displayName}.`);
         }
@@ -683,6 +756,31 @@ export class ShopAdminPanelHandler implements IPanelHandler {
         const bPrice = vals[3] ?? undefined;
         const sPrice = vals[4] ?? undefined;
         const pLevel = vals[5];
+        const overridesRaw = vals[6] ?? '';
+
+        let parsedOverrides: Record<string, { buy: number; sell: number }> | undefined = undefined;
+
+        if (isNonEmptyString(overridesRaw)) {
+            parsedOverrides = {};
+            const pairs = overridesRaw.split(';');
+            for (const pair of pairs) {
+                const parts = pair.trim().split('=');
+                if (parts.length === 2 && isNonEmptyString(parts[0]) && isNonEmptyString(parts[1])) {
+                    const rankId = parts[0].trim();
+                    const multiParts = parts[1].split(',');
+                    if (multiParts.length === 2) {
+                        const buyM = Number.parseFloat(multiParts[0]!);
+                        const sellM = Number.parseFloat(multiParts[1]!);
+                        if (!Number.isNaN(buyM) && !Number.isNaN(sellM)) {
+                            parsedOverrides[rankId] = { buy: buyM, sell: sellM };
+                        }
+                    }
+                }
+            }
+            if (Object.keys(parsedOverrides).length === 0) {
+                parsedOverrides = undefined;
+            }
+        }
 
         shopAdminManager.updateShopItem(categoryName, subCategoryName ?? undefined, itemId, {
             buyPrice: isDefined(bPrice) ? Number(bPrice) : -1,
@@ -690,7 +788,8 @@ export class ShopAdminPanelHandler implements IPanelHandler {
             permission: pLevel ?? 'ui.panel.member',
             icon: icon ?? '',
             minecraftId: mId ?? itemId,
-            displayName: dName ?? itemId
+            displayName: dName ?? itemId,
+            rankOverrides: parsedOverrides
         });
         player.sendMessage('§2Item updated.');
         return showPanel(player, parent, context);

--- a/src/features/shop/ui/adminPanel.ts
+++ b/src/features/shop/ui/adminPanel.ts
@@ -667,7 +667,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
                 icon: icon ?? '',
                 displayName,
                 itemId: customId,
-                rankOverrides: parsedOverrides
+                rankMultiplierOverrides: parsedOverrides
             });
             player.sendMessage(`§2Added ${displayName}.`);
         }
@@ -729,7 +729,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
                 icon: icon ?? '',
                 displayName: masterItem.displayName ?? '',
                 itemId: itemId,
-                rankOverrides: parsedOverrides
+                rankMultiplierOverrides: parsedOverrides
             });
             player.sendMessage(`§2Added ${masterItem.displayName}.`);
         }

--- a/src/features/shop/ui/userPanel.ts
+++ b/src/features/shop/ui/userPanel.ts
@@ -5,6 +5,7 @@ import { getShopConfig } from '@core/configurations.js';
 import { showPanel } from '@core/uiManager.js';
 import { formatCurrency, parseCurrency } from '@core/utils.js';
 import * as shopManager from '@features/shop/manager.js';
+import { getPlayerShopItemPrice, findShopItem } from '@features/shop/manager.js';
 import { ShopCategory } from '@features/shop/shopConfig.js';
 import { ensureItemsConfig, getAllItems, Item } from '@features/shop/utils.js';
 import { isDefined, isNonEmptyString, isNumber } from '@lib/guards.js';
@@ -57,15 +58,15 @@ export class ShopUserPanelHandler implements IPanelHandler {
         }
 
         if (panelId === 'shopSearchResultsPanel') {
-            return this.getSearchResultsItems(context, page);
+            return this.getSearchResultsItems(_player, context, page);
         }
 
         if (panelId.startsWith('shopCategoryPanel_')) {
-            return this.getCategoryPanelItems(context, page);
+            return this.getCategoryPanelItems(_player, context, page);
         }
 
         if (panelId.startsWith('shopItemListPanel_')) {
-            return this.getItemListPanelItems(context, page);
+            return this.getItemListPanelItems(_player, context, page);
         }
 
         return [];
@@ -107,7 +108,7 @@ export class ShopUserPanelHandler implements IPanelHandler {
         return items;
     }
 
-    private getSearchResultsItems(context: UIContext, page: number): PanelItem[] {
+    private getSearchResultsItems(player: mc.Player, context: UIContext, page: number): PanelItem[] {
         const items: PanelItem[] = [];
         const allItems = getAllItems();
         addBackButton(items, 'shopMainPanel');
@@ -122,7 +123,7 @@ export class ShopUserPanelHandler implements IPanelHandler {
             for (const itemId in cat.items) {
                 const item = cat.items[itemId];
                 if (!isDefined(item)) continue;
-                this.addItemToResults(results, itemId, item, query, allItems);
+                this.addItemToResults(player, results, itemId, item, query, allItems);
             }
             // Subcategories
             for (const subName in cat.subCategories) {
@@ -131,7 +132,7 @@ export class ShopUserPanelHandler implements IPanelHandler {
                 for (const itemId in sub.items) {
                     const item = sub.items[itemId];
                     if (!isDefined(item)) continue;
-                    this.addItemToResults(results, itemId, item, query, allItems);
+                    this.addItemToResults(player, results, itemId, item, query, allItems);
                 }
             }
         }
@@ -145,7 +146,7 @@ export class ShopUserPanelHandler implements IPanelHandler {
         return items;
     }
 
-    private addItemToResults(results: ShopItemEntry[], itemId: string, item: ShopItem, query: string, allItems: Record<string, Item>): void {
+    private addItemToResults(player: mc.Player, results: ShopItemEntry[], itemId: string, item: ShopItem, query: string, allItems: Record<string, Item>): void {
         const master: Item = allItems[itemId] ?? {};
         // Ensure string safety before calling string methods
         const displayNameRaw = item.displayName ?? master.displayName ?? itemId;
@@ -153,19 +154,20 @@ export class ShopUserPanelHandler implements IPanelHandler {
         const itemIdStr = String(itemId);
 
         if (displayName.toLowerCase().includes(query) || itemIdStr.toLowerCase().includes(query)) {
+            const fullShopItem = findShopItem(itemId);
             results.push({
                 id: itemId,
                 type: 'item',
                 ...(isNonEmptyString(item.icon) ? { icon: item.icon } : {}),
                 displayName,
-                buyPrice: item.buyPrice,
-                sellPrice: item.sellPrice,
+                buyPrice: isDefined(fullShopItem) ? getPlayerShopItemPrice(player, fullShopItem, 'buy') : item.buyPrice,
+                sellPrice: isDefined(fullShopItem) ? getPlayerShopItemPrice(player, fullShopItem, 'sell') : item.sellPrice,
                 permission: item.permission
             });
         }
     }
 
-    private generateCategoryEntries(category: ShopCategory): ShopEntry[] {
+    private generateCategoryEntries(category: ShopCategory, player: mc.Player): ShopEntry[] {
         const allEntries: ShopEntry[] = [];
 
         // Add Subcategories
@@ -187,10 +189,11 @@ export class ShopUserPanelHandler implements IPanelHandler {
         for (const id of itemIds) {
             const item = category.items[id];
             if (isDefined(item)) {
+                const fullShopItem = findShopItem(id);
                 const entry: ShopItemEntry = {
                     id,
-                    buyPrice: item.buyPrice,
-                    sellPrice: item.sellPrice,
+                    buyPrice: isDefined(fullShopItem) ? getPlayerShopItemPrice(player, fullShopItem, 'buy') : item.buyPrice,
+                    sellPrice: isDefined(fullShopItem) ? getPlayerShopItemPrice(player, fullShopItem, 'sell') : item.sellPrice,
                     permission: item.permission,
                     type: 'item'
                 };
@@ -202,7 +205,7 @@ export class ShopUserPanelHandler implements IPanelHandler {
         return allEntries;
     }
 
-    private getCategoryPanelItems(context: UIContext, page: number): PanelItem[] {
+    private getCategoryPanelItems(player: mc.Player, context: UIContext, page: number): PanelItem[] {
         const items: PanelItem[] = [];
         const categoryName = context.categoryName as string;
         addBackButton(items, 'shopMainPanel');
@@ -210,7 +213,7 @@ export class ShopUserPanelHandler implements IPanelHandler {
         const category = shopConfig.categories[categoryName];
 
         if (isDefined(category)) {
-            const allEntries = this.generateCategoryEntries(category);
+            const allEntries = this.generateCategoryEntries(category, player);
             const paginated = getPaginatedItems(allEntries, page);
 
             for (const entry of paginated) {
@@ -233,7 +236,7 @@ export class ShopUserPanelHandler implements IPanelHandler {
         return items;
     }
 
-    private getItemListPanelItems(context: UIContext, page: number): PanelItem[] {
+    private getItemListPanelItems(player: mc.Player, context: UIContext, page: number): PanelItem[] {
         const items: PanelItem[] = [];
         const categoryName = context.categoryName as string;
         const subCategoryName = context.subCategoryName as string;
@@ -249,10 +252,11 @@ export class ShopUserPanelHandler implements IPanelHandler {
             for (const id of itemIds) {
                 const item = subCategory.items[id];
                 if (isDefined(item)) {
+                    const fullShopItem = findShopItem(id);
                     const entry: ShopItemEntry = {
                         id,
-                        buyPrice: item.buyPrice,
-                        sellPrice: item.sellPrice,
+                        buyPrice: isDefined(fullShopItem) ? getPlayerShopItemPrice(player, fullShopItem, 'buy') : item.buyPrice,
+                        sellPrice: isDefined(fullShopItem) ? getPlayerShopItemPrice(player, fullShopItem, 'sell') : item.sellPrice,
                         permission: item.permission,
                         type: 'item'
                     };

--- a/src/features/shop/ui/userPanel.ts
+++ b/src/features/shop/ui/userPanel.ts
@@ -5,7 +5,7 @@ import { getShopConfig } from '@core/configurations.js';
 import { showPanel } from '@core/uiManager.js';
 import { formatCurrency, parseCurrency } from '@core/utils.js';
 import * as shopManager from '@features/shop/manager.js';
-import { getPlayerShopItemPrice, findShopItem } from '@features/shop/manager.js';
+import { findShopItem, getPlayerShopItemPrice } from '@features/shop/manager.js';
 import { ShopCategory } from '@features/shop/shopConfig.js';
 import { ensureItemsConfig, getAllItems, Item } from '@features/shop/utils.js';
 import { isDefined, isNonEmptyString, isNumber } from '@lib/guards.js';

--- a/src/features/shop/utils.ts
+++ b/src/features/shop/utils.ts
@@ -6,6 +6,7 @@ export interface Item {
     buyPrice?: number;
     sellPrice?: number;
     itemId?: string;
+    rankMultiplierOverrides?: Record<string, { buy: number; sell: number }>;
 }
 
 let allItems: Record<string, Item> = {};

--- a/src/features/social/commands/friend.ts
+++ b/src/features/social/commands/friend.ts
@@ -8,7 +8,7 @@ const friendCommand: CustomCommand = {
     description: 'Manage your friend list.',
     category: 'Social',
     aliases: ['frnd', 'friends'],
-    permissionNode: 'cmd.friend',
+    permissionNode: 'cmd.friend.member',
     parameters: [
         { name: 'subcommand', type: 'string', optional: true }, // add, remove, list, accept
         { name: 'target', type: 'string', optional: true }

--- a/src/features/team/commands/team.ts
+++ b/src/features/team/commands/team.ts
@@ -23,7 +23,7 @@ export function isTeamChatEnabled(playerId: string): boolean {
 const teamChatCommand: CustomCommand = {
     name: 'teamchat',
     description: 'Toggle team chat mode.',
-    permissionNode: 'cmd.teamchat',
+    permissionNode: 'cmd.teamchat.member',
     aliases: ['tc'],
     execute: (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) {
@@ -49,7 +49,7 @@ const teamChatCommand: CustomCommand = {
 const hqCommand: CustomCommand = {
     name: 'hq',
     description: "Teleports you to your team's home.",
-    permissionNode: 'cmd.hq',
+    permissionNode: 'cmd.hq.member',
     aliases: ['teamhome'],
     execute: (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) {

--- a/src/features/teleport/commands/deathcoords.ts
+++ b/src/features/teleport/commands/deathcoords.ts
@@ -13,7 +13,7 @@ const deathCoordsCommand: CustomCommand = {
     aliases: ['deathlocation', 'lastdeath'],
     description: 'Shows your last death coordinates.',
     category: 'General',
-    permissionNode: 'cmd.deathcoords',
+    permissionNode: 'cmd.deathcoords.owner',
     parameters: [{ name: 'target', type: 'string', optional: true }],
     execute: (executor: CommandExecutor, args: Record<string, unknown>) => {
         if (!(executor instanceof mc.Player)) {

--- a/src/features/teleport/commands/home.ts
+++ b/src/features/teleport/commands/home.ts
@@ -21,7 +21,7 @@ const homeCommand: CustomCommand = {
     name: 'home',
     description: 'Teleports you to one of your set homes.',
     category: 'Transportation',
-    permissionNode: 'cmd.home',
+    permissionNode: 'cmd.home.member',
     parameters: [{ name: 'homeName', type: 'string', optional: true }],
     execute: async (executor: CommandExecutor, args: HomeCommandArgs) => {
         if (!(executor instanceof mc.Player)) {
@@ -107,7 +107,7 @@ const homesCommand: CustomCommand = {
     description: 'Lists all of your set homes.',
     category: 'Transportation',
     aliases: ['homelist'],
-    permissionNode: 'cmd.homes',
+    permissionNode: 'cmd.homes.member',
     execute: (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) {
             return;
@@ -135,7 +135,7 @@ const delHomeCommand: CustomCommand = {
     aliases: ['remhome', 'deletehome', 'rmhome', '-home'],
     description: 'Deletes one of your set homes. Leave name blank to choose from a list.',
     category: 'Transportation',
-    permissionNode: 'cmd.delhome',
+    permissionNode: 'cmd.delhome.member',
     parameters: [{ name: 'homeName', type: 'string', optional: true }],
     execute: async (executor: CommandExecutor, args: HomeCommandArgs) => {
         if (!(executor instanceof mc.Player)) {
@@ -196,7 +196,7 @@ const setHomeCommand: CustomCommand = {
     aliases: ['addhome', '+home'],
     description: 'Sets a home at your current location.',
     category: 'Transportation',
-    permissionNode: 'cmd.sethome',
+    permissionNode: 'cmd.sethome.member',
     parameters: [{ name: 'homeName', type: 'string', optional: true }],
     execute: (executor: CommandExecutor, args: HomeCommandArgs) => {
         if (!(executor instanceof mc.Player)) {

--- a/src/features/teleport/commands/rtp.ts
+++ b/src/features/teleport/commands/rtp.ts
@@ -15,7 +15,7 @@ const rtpCommand: CustomCommand = {
     aliases: ['randomtp'],
     description: 'Teleports you to a random safe location in the world.',
     category: 'Transportation',
-    permissionNode: 'cmd.rtp',
+    permissionNode: 'cmd.rtp.member',
     execute: async (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) {
             return;

--- a/src/features/teleport/commands/tp.ts
+++ b/src/features/teleport/commands/tp.ts
@@ -11,7 +11,7 @@ const command: CustomCommand = {
     aliases: ['teleport', 'xtp'],
     description: 'Teleports a player to another player or to coordinates.',
     category: 'Moderation',
-    permissionNode: 'cmd.tp', // Admins only
+    permissionNode: 'cmd.tp.admin', // Admins only
     allowConsole: false, // This command is complex and safer for players only
     parameters: [
         { name: 'arg1', type: 'string', description: 'Target player or destination player/X-coordinate.' },

--- a/src/features/teleport/commands/tpa.ts
+++ b/src/features/teleport/commands/tpa.ts
@@ -79,7 +79,7 @@ const tpaCommand: CustomCommand = {
     description: 'Sends a request to teleport to another player.',
     category: 'Transportation',
     aliases: ['tprequest', 'asktp', 'requesttp'],
-    permissionNode: 'cmd.tpa',
+    permissionNode: 'cmd.tpa.member',
     // Note: Using string type instead of 'player' to support non-op players (selector expansion requires permissions).
     // Dynamic suggestions for online players are not possible with static enums for string types.
     parameters: [{ name: 'target', type: 'string' }],
@@ -95,7 +95,7 @@ const tpaHereCommand: CustomCommand = {
     description: 'Requests another player to teleport to you.',
     category: 'Transportation',
     aliases: ['tphere', 'tprequesthere'],
-    permissionNode: 'cmd.tpahere',
+    permissionNode: 'cmd.tpahere.member',
     // Note: Using string type instead of 'player' to support non-op players.
     parameters: [{ name: 'target', type: 'string' }],
     execute: (executor: CommandExecutor, args: Record<string, unknown>) => {
@@ -110,7 +110,7 @@ const tpaAcceptCommand: CustomCommand = {
     aliases: ['tpyes', 'tpac'],
     description: 'Accepts an incoming TPA request.',
     category: 'Transportation',
-    permissionNode: 'cmd.tpaccept',
+    permissionNode: 'cmd.tpaccept.member',
     parameters: [{ name: 'player', type: 'string', optional: true }],
     execute: (executor: CommandExecutor, args: Record<string, unknown>) => {
         if (executor instanceof mc.Player) {
@@ -124,7 +124,7 @@ const tpaDenyCommand: CustomCommand = {
     aliases: ['tpno', 'tpdeny'],
     description: 'Denies an incoming TPA request.',
     category: 'Transportation',
-    permissionNode: 'cmd.tpadeny',
+    permissionNode: 'cmd.tpadeny.member',
     parameters: [{ name: 'player', type: 'string', optional: true }],
     execute: (executor: CommandExecutor, args: Record<string, unknown>) => {
         if (executor instanceof mc.Player) {
@@ -137,7 +137,7 @@ const tpaCancelCommand: CustomCommand = {
     name: 'tpacancel',
     description: 'Cancels your outgoing TPA request.',
     category: 'Transportation',
-    permissionNode: 'cmd.tpacancel',
+    permissionNode: 'cmd.tpacancel.member',
     execute: (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) return;
         const config = getConfig();
@@ -154,7 +154,7 @@ const tpaStatusCommand: CustomCommand = {
     name: 'tpastatus',
     description: 'Checks the status of your outgoing and incoming TPA requests.',
     category: 'Transportation',
-    permissionNode: 'cmd.tpastatus',
+    permissionNode: 'cmd.tpastatus.member',
     execute: (executor: CommandExecutor) => {
         if (!(executor instanceof mc.Player)) return;
 
@@ -200,7 +200,7 @@ const tpaStopCommand: CustomCommand = {
     aliases: ['tpstop', 'tpablock', 'tpblock'],
     description: 'Disables TPA requests or blocks specific players.',
     category: 'Transportation',
-    permissionNode: 'cmd.tpastop',
+    permissionNode: 'cmd.tpastop.admin',
     parameters: [{ name: 'targets', type: 'string', optional: true }],
     execute: (executor: CommandExecutor, args: Record<string, unknown>) => {
         if (!(executor instanceof mc.Player)) return;
@@ -233,7 +233,7 @@ const tpaStartCommand: CustomCommand = {
     aliases: ['tpstart', 'tpaunblock', 'tpunblock'],
     description: 'Enables TPA requests or unblocks specific players.',
     category: 'Transportation',
-    permissionNode: 'cmd.tpastart',
+    permissionNode: 'cmd.tpastart.admin',
     parameters: [{ name: 'targets', type: 'string', optional: true }],
     execute: (executor: CommandExecutor, args: Record<string, unknown>) => {
         if (!(executor instanceof mc.Player)) return;
@@ -292,7 +292,7 @@ const oTpaStopCommand: CustomCommand = {
     aliases: ['offlinetpastop', 'otpablock'],
     description: 'Blocks an offline player from sending TPA requests.',
     category: 'Transportation',
-    permissionNode: 'cmd.otpastop',
+    permissionNode: 'cmd.otpastop.admin',
     hidden: true,
     parameters: [{ name: 'target', type: 'string' }],
     execute: (executor: CommandExecutor, args: Record<string, unknown>) => {
@@ -307,7 +307,7 @@ const oTpaStartCommand: CustomCommand = {
     aliases: ['offlinetpastart', 'otpaunblock'],
     description: 'Unblocks an offline player from sending TPA requests.',
     category: 'Transportation',
-    permissionNode: 'cmd.otpastart',
+    permissionNode: 'cmd.otpastart.admin',
     hidden: true,
     parameters: [{ name: 'target', type: 'string' }],
     execute: (executor: CommandExecutor, args: Record<string, unknown>) => {

--- a/src/features/teleport/commands/warp.ts
+++ b/src/features/teleport/commands/warp.ts
@@ -22,7 +22,7 @@ const warpCommand: CustomCommand = {
     description: 'Teleports you to a set warp location.',
     category: 'Transportation',
     aliases: ['warps'],
-    permissionNode: 'cmd.warp',
+    permissionNode: 'cmd.warp.admin',
     parameters: [
         {
             name: 'warpName',
@@ -127,7 +127,7 @@ const addWarpCommand: CustomCommand = {
     description: 'Creates a new warp at your current location or at specified coordinates.',
     category: 'Transportation',
     aliases: ['setwarp'],
-    permissionNode: 'cmd.addwarp', // Admin
+    permissionNode: 'cmd.addwarp.admin', // Admin
     parameters: [
         { name: 'warpName', type: 'string' },
         { name: 'x', type: 'int', optional: true },
@@ -170,7 +170,7 @@ const delWarpCommand: CustomCommand = {
     name: 'delwarp',
     description: 'Deletes an existing warp.',
     category: 'Transportation',
-    permissionNode: 'cmd.delwarp', // Admin
+    permissionNode: 'cmd.delwarp.admin', // Admin
     parameters: [
         {
             name: 'warpName',

--- a/src/features/vote/commands/vote.ts
+++ b/src/features/vote/commands/vote.ts
@@ -12,7 +12,7 @@ const voteCommand: CustomCommand = {
     name: 'vote',
     description: 'Participate in server votes or create one.',
     category: 'General',
-    permissionNode: 'cmd.vote',
+    permissionNode: 'cmd.vote.member',
     parameters: [{ name: 'subcommand', type: 'string', optional: true }],
     execute: async (executor: CommandExecutor, args: { subcommand?: string }) => {
         if (!(executor instanceof mc.Player)) return;


### PR DESCRIPTION
Implemented a flexible permission engine update to handle Linux-style wildcards (* matches one segment, ** matches zero or more). Standardized permission nodes across the codebase to take advantage of this feature (e.g. `ui.*.member`, `cmd.**.admin`). Also integrated a shop pricing strategy involving base multipliers by rank and item-specific overrides using custom multipliers. Prices adjust visually in the shop's user panels and calculate properly at the point of sale.

---
*PR created automatically by Jules for task [6050953198397346994](https://jules.google.com/task/6050953198397346994) started by @SjnExe*