### PR TITLE
Fix missing `rawLog` in logger mock

### DIFF
--- a/src/core/__tests__/ConfigManager.test.ts
+++ b/src/core/__tests__/ConfigManager.test.ts
@@ -28,6 +28,7 @@ mock.module('@features/anticheat/configLoader.js', () => ({
 }));
 
 mock.module('@core/logger.js', () => ({
+    rawLog: mock(),
     debugLog: mock(),
     errorLog: mock(),
     infoLog: mock(),

--- a/src/core/__tests__/UI.test.ts
+++ b/src/core/__tests__/UI.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, mock } from 'bun:test';
 
 // Mock logger to avoid rawLog not found error
 mock.module('@core/logger.js', () => ({
+    rawLog: mock(),
     debugLog: mock(),
     errorLog: mock(),
     warnLog: mock(),

--- a/src/features/anticheat/__tests__/ItemCheck.test.ts
+++ b/src/features/anticheat/__tests__/ItemCheck.test.ts
@@ -10,6 +10,7 @@ mock.module('../flagManager.js', () => ({
 }));
 
 mock.module('@core/logger.js', () => ({
+    rawLog: mock(),
     errorLog: mock(),
     warnLog: mock(),
     infoLog: mock(),

--- a/src/features/anticheat/__tests__/MovementCheck.test.ts
+++ b/src/features/anticheat/__tests__/MovementCheck.test.ts
@@ -13,6 +13,7 @@ mock.module('../flagManager.js', () => ({
 }));
 
 mock.module('@core/logger.js', () => ({
+    rawLog: mock(),
     errorLog: mock(),
     warnLog: mock(),
     infoLog: mock(),

--- a/src/features/economy/__tests__/BountyManager.test.ts
+++ b/src/features/economy/__tests__/BountyManager.test.ts
@@ -24,6 +24,7 @@ mock.module('@core/storage/StorageManager.js', () => ({
 }));
 
 mock.module('@core/logger.js', () => ({
+    rawLog: mock(),
     debugLog: mock(),
     errorLog: mock(),
     warnLog: mock(),

--- a/src/features/moderation/__tests__/ModerationHierarchy.test.ts
+++ b/src/features/moderation/__tests__/ModerationHierarchy.test.ts
@@ -34,6 +34,7 @@ mock.module('@core/utils.js', () => ({
 }));
 
 mock.module('@core/logger.js', () => ({
+    rawLog: mock(),
     errorLog: mock(),
     warnLog: mock()
 }));

--- a/src/features/teleport/__tests__/BackCommand.test.ts
+++ b/src/features/teleport/__tests__/BackCommand.test.ts
@@ -35,6 +35,7 @@ mock.module('@core/cooldownManager.js', () => ({
 }));
 
 mock.module('@core/logger.js', () => ({
+    rawLog: mock(),
     errorLog: mock(),
     warnLog: mock(),
     infoLog: mock(),


### PR DESCRIPTION
Fix failing `bun test` by providing the missing `rawLog` mock export in tests that use `@core/logger.js`.

---
*PR created automatically by Jules for task [13898548494177147524](https://jules.google.com/task/13898548494177147524) started by @SjnExe*