### PR TITLE
🧹 Refactor: Eliminate unsafe any cast in PunishmentManager

### DIFF
--- a/src/features/moderation/punishmentManager.ts
+++ b/src/features/moderation/punishmentManager.ts
@@ -44,9 +44,8 @@ export function loadPunishments() {
 
         for (const [playerId, record] of data) {
             // Check if legacy format (has 'type' property directly)
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
-            if (isDefined((record as any).type)) {
-                const legacyPunishment = record as unknown as Punishment;
+            if ('type' in record) {
+                const legacyPunishment = record;
                 if (legacyPunishment.type === 'ban') {
                     punishments.set(playerId, { ban: legacyPunishment });
                 } else {
@@ -54,7 +53,7 @@ export function loadPunishments() {
                 }
                 migratedCount++;
             } else {
-                punishments.set(playerId, record as PlayerPunishmentRecord);
+                punishments.set(playerId, record);
             }
         }
 


### PR DESCRIPTION
🎯 **What:** Replaced the unsafe `(record as any).type` check and casting (`as unknown as Punishment`, `as PlayerPunishmentRecord`) with a type-safe `'type' in record` runtime check. Removed the associated `eslint-disable` comment.
💡 **Why:** This leverages TypeScript's built-in type narrowing to safely discriminate between `Punishment` and `PlayerPunishmentRecord` in the union type. It eliminates unsafe any casts, improves type safety, removes the need for linting suppression, and enhances code readability.
✅ **Verification:** Verified by checking types locally and running `npm run lint`, `npm run build`, and `npm run test` which all passed successfully, ensuring no regressions.
✨ **Result:** Improved maintainability, type safety, and clean code without changing behavior.

---
*PR created automatically by Jules for task [5799917197976236392](https://jules.google.com/task/5799917197976236392) started by @SjnExe*