### PR TITLE
🧹 Fix throwing non-Error object in result unwrap

### DIFF
--- a/src/lib/result.ts
+++ b/src/lib/result.ts
@@ -40,6 +40,8 @@ export function unwrap<T, E>(result: Result<T, E>): T {
     if (result.success) {
         return result.data;
     }
-    // eslint-disable-next-line @typescript-eslint/only-throw-error
-    throw result.error;
+    if (result.error instanceof Error) {
+        throw result.error;
+    }
+    throw new Error(String(result.error));
 }


### PR DESCRIPTION
🎯 **What:** The `unwrap` function in `src/lib/result.ts` threw `result.error` directly. If `result.error` was not an `Error` object (e.g., a primitive), it would cause code health and linting issues.
💡 **Why:** By wrapping the thrown primitive in an `Error` object, we ensure that stack trace information is preserved and standard error-handling mechanisms work correctly. This also allows us to remove the `@typescript-eslint/only-throw-error` disable comment.
✅ **Verification:** I ran `npm run test` and `npm run lint`. The tests passed and the linter reported no errors. Code review also approved the change.
✨ **Result:** The `unwrap` function now safely wraps non-Error objects into `Error` objects before throwing, resolving the code health issue.

---
*PR created automatically by Jules for task [3752467837050192883](https://jules.google.com/task/3752467837050192883) started by @SjnExe*