### PR TITLE
🧪 Add tests for `isNumber` type guard

### DIFF
--- a/src/lib/__tests__/guards.test.ts
+++ b/src/lib/__tests__/guards.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'bun:test';
+import { isNumber } from '../guards.js';
+
+describe('Guards', () => {
+    describe('isNumber', () => {
+        it('should return true for regular numbers', () => {
+            expect(isNumber(42)).toBe(true);
+            expect(isNumber(0)).toBe(true);
+            expect(isNumber(-10.5)).toBe(true);
+        });
+
+        it('should return false for NaN', () => {
+            expect(isNumber(NaN)).toBe(false);
+            expect(isNumber(Number.NaN)).toBe(false);
+        });
+
+        it('should return false for strings', () => {
+            expect(isNumber('42')).toBe(false);
+            expect(isNumber('')).toBe(false);
+        });
+
+        it('should return false for null and undefined', () => {
+            expect(isNumber(null)).toBe(false);
+            expect(isNumber(undefined)).toBe(false);
+        });
+
+        it('should return false for other types', () => {
+            expect(isNumber({})).toBe(false);
+            expect(isNumber([])).toBe(false);
+            expect(isNumber(() => {})).toBe(false);
+            expect(isNumber(true)).toBe(false);
+            expect(isNumber(false)).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Tested the `isNumber` type guard in `src/lib/guards.ts` which previously lacked coverage.

📊 **Coverage:** What scenarios are now tested
Added tests for valid positive/negative numbers, zero, `NaN`, strings, null, undefined, objects, arrays, and booleans. Specifically ensures that it successfully rejects `NaN`.

✨ **Result:** The improvement in test coverage
The `isNumber` utility function is now fully tested and its behavior is verified.

---
*PR created automatically by Jules for task [15146076389275379339](https://jules.google.com/task/15146076389275379339) started by @SjnExe*