### PR TITLE
🧪 [Test Improvement] Add isolated test for `setLastHit`

### DIFF
--- a/src/core/__tests__/lastHitManager.test.ts
+++ b/src/core/__tests__/lastHitManager.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, spyOn, afterEach } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
 import { clearLastHit, getLastHit, setLastHit } from '../lastHitManager.js';
 
 describe('lastHitManager', () => {
@@ -64,5 +64,4 @@ describe('lastHitManager', () => {
         clearLastHit('victim1');
         expect(getLastHit('victim1')).toBeUndefined();
     });
-
 });

--- a/src/core/__tests__/lastHitManager.test.ts
+++ b/src/core/__tests__/lastHitManager.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'bun:test';
+import { beforeEach, describe, expect, it, spyOn, afterEach } from 'bun:test';
 import { clearLastHit, getLastHit, setLastHit } from '../lastHitManager.js';
 
 describe('lastHitManager', () => {
@@ -8,7 +8,38 @@ describe('lastHitManager', () => {
         clearLastHit('victim2');
     });
 
-    it('should correctly set and get last hit data', () => {
+    describe('setLastHit', () => {
+        let dateNowSpy: ReturnType<typeof spyOn>;
+
+        beforeEach(() => {
+            dateNowSpy = spyOn(Date, 'now').mockReturnValue(1234567890);
+        });
+
+        afterEach(() => {
+            dateNowSpy.mockRestore();
+        });
+
+        it('should correctly set last hit data with the current timestamp', () => {
+            setLastHit('victim1', 'attacker1');
+
+            const hitInfo = getLastHit('victim1');
+            expect(hitInfo).toBeDefined();
+            expect(hitInfo?.attackerId).toBe('attacker1');
+            expect(hitInfo?.timestamp).toBe(1234567890);
+        });
+
+        it('should overwrite previous hit data for the same victim', () => {
+            setLastHit('victim1', 'attacker1');
+            dateNowSpy.mockReturnValue(1234567899);
+            setLastHit('victim1', 'attacker2');
+
+            const hitInfo = getLastHit('victim1');
+            expect(hitInfo?.attackerId).toBe('attacker2');
+            expect(hitInfo?.timestamp).toBe(1234567899);
+        });
+    });
+
+    it('should correctly set and get last hit data without mocking', () => {
         const beforeTime = Date.now();
         setLastHit('victim1', 'attacker1');
         const afterTime = Date.now();
@@ -34,11 +65,4 @@ describe('lastHitManager', () => {
         expect(getLastHit('victim1')).toBeUndefined();
     });
 
-    it('should overwrite previous hit data for the same victim', () => {
-        setLastHit('victim1', 'attacker1');
-        setLastHit('victim1', 'attacker2');
-
-        const hitInfo = getLastHit('victim1');
-        expect(hitInfo?.attackerId).toBe('attacker2');
-    });
 });


### PR DESCRIPTION
🎯 **What:** The `setLastHit` function in `src/core/lastHitManager.ts` lacked isolated, deterministic unit testing. It only had a basic integration test along with `getLastHit`.
📊 **Coverage:** The test suite now explicitly covers `setLastHit`, mocking `Date.now()` to ensure deterministic verification of the exact timestamp and attacker ID set. It also verifies that subsequent hits properly overwrite earlier hits.
✨ **Result:** Test coverage for `setLastHit` is now explicit and deterministic, allowing for safe refactoring. Unmocked integration tests were preserved to ensure broader coverage.

---
*PR created automatically by Jules for task [18396379291195679018](https://jules.google.com/task/18396379291195679018) started by @SjnExe*