### PR TITLE
🧪 test: improve coverage for clearLastHit

### DIFF
--- a/src/core/__tests__/lastHitManager.test.ts
+++ b/src/core/__tests__/lastHitManager.test.ts
@@ -41,4 +41,21 @@ describe('lastHitManager', () => {
         const hitInfo = getLastHit('victim1');
         expect(hitInfo?.attackerId).toBe('attacker2');
     });
+
+    it('should gracefully handle clearing a non-existent victim', () => {
+        expect(() => {
+            clearLastHit('non_existent_victim');
+        }).not.toThrow();
+        expect(getLastHit('non_existent_victim')).toBeUndefined();
+    });
+
+    it('should only clear the specified victim and leave others intact', () => {
+        setLastHit('victim1', 'attacker1');
+        setLastHit('victim2', 'attacker2');
+
+        clearLastHit('victim1');
+
+        expect(getLastHit('victim1')).toBeUndefined();
+        expect(getLastHit('victim2')?.attackerId).toBe('attacker2');
+    });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap for the `clearLastHit` function in `lastHitManager.ts` has been addressed. The function was previously untested.
📊 **Coverage:** Added test cases cover graceful failure on non-existent victim IDs, and ensure that deleting a specific victim's data correctly leaves other tracked victims unmodified.
✨ **Result:** Test coverage for the `lastHitManager` module is improved, increasing reliability.

---
*PR created automatically by Jules for task [14696103571892935643](https://jules.google.com/task/14696103571892935643) started by @SjnExe*