### PR TITLE
🧪 [Testing] Add coverage for calculateRankMap

### DIFF
--- a/src/core/__tests__/permissionEngine.test.ts
+++ b/src/core/__tests__/permissionEngine.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { RankDefinition } from '@features/ranks/ranksConfig.js';
+
+mock.module('../configurations.js', () => ({
+    getRanksConfig: () => ({
+        permissionGroups: {
+            groupA: ['node.a', 'node.b'],
+            groupB: ['node.c'],
+            groupOverride: ['node.a']
+        }
+    })
+}));
+
+// Import after the mock
+import { calculateRankMap } from '../permissionEngine.js';
+
+describe('calculateRankMap', () => {
+    it('should merge permissions from multiple groups', () => {
+        const rank = {
+            id: 'test',
+            name: 'Test',
+            priority: 1,
+            permissionLevel: 1,
+            conditions: [],
+            groups: ['groupA', 'groupB'],
+            allow: [],
+            deny: []
+        } as unknown as RankDefinition;
+
+        const map = calculateRankMap(rank);
+        expect(map['node.a']).toBe(true);
+        expect(map['node.b']).toBe(true);
+        expect(map['node.c']).toBe(true);
+        expect(Object.keys(map).length).toBe(3);
+    });
+
+    it('should handle missing groups gracefully', () => {
+        const rank = {
+            id: 'test',
+            name: 'Test',
+            priority: 1,
+            permissionLevel: 1,
+            conditions: [],
+            groups: ['groupA', 'nonExistentGroup'],
+            allow: [],
+            deny: []
+        } as unknown as RankDefinition;
+
+        const map = calculateRankMap(rank);
+        expect(map['node.a']).toBe(true);
+        expect(map['node.b']).toBe(true);
+        expect(Object.keys(map).length).toBe(2);
+    });
+
+    it('should combine group permissions with allow array', () => {
+        const rank = {
+            id: 'test',
+            name: 'Test',
+            priority: 1,
+            permissionLevel: 1,
+            conditions: [],
+            groups: ['groupA'],
+            allow: ['node.x', 'node.y'],
+            deny: []
+        } as unknown as RankDefinition;
+
+        const map = calculateRankMap(rank);
+        expect(map['node.a']).toBe(true);
+        expect(map['node.b']).toBe(true);
+        expect(map['node.x']).toBe(true);
+        expect(map['node.y']).toBe(true);
+        expect(Object.keys(map).length).toBe(4);
+    });
+
+    it('should override group and allow permissions with deny array', () => {
+        const rank = {
+            id: 'test',
+            name: 'Test',
+            priority: 1,
+            permissionLevel: 1,
+            conditions: [],
+            groups: ['groupA', 'groupB'],
+            allow: ['node.x', 'node.a'], // node.a is both in group and allow
+            deny: ['node.a', 'node.c', 'node.y'] // node.a overlaps, node.c from groupB overlaps
+        } as unknown as RankDefinition;
+
+        const map = calculateRankMap(rank);
+        expect(map['node.a']).toBe(false); // Deny overrides allow and group
+        expect(map['node.b']).toBe(true);  // From groupA
+        expect(map['node.c']).toBe(false); // Deny overrides groupB
+        expect(map['node.x']).toBe(true);  // From allow
+        expect(map['node.y']).toBe(false); // From deny
+        expect(Object.keys(map).length).toBe(5);
+    });
+
+    it('should handle empty inputs gracefully', () => {
+        const rank = {
+            id: 'test',
+            name: 'Test',
+            priority: 1,
+            permissionLevel: 1,
+            conditions: [],
+            groups: [],
+            allow: [],
+            deny: []
+        } as unknown as RankDefinition;
+
+        const map = calculateRankMap(rank);
+        expect(Object.keys(map).length).toBe(0);
+    });
+});

--- a/src/core/__tests__/permissionEngine.test.ts
+++ b/src/core/__tests__/permissionEngine.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, mock } from 'bun:test';
 import { RankDefinition } from '@features/ranks/ranksConfig.js';
+import { describe, expect, it, mock } from 'bun:test';
 
 mock.module('../configurations.js', () => ({
     getRanksConfig: () => ({
@@ -86,9 +86,9 @@ describe('calculateRankMap', () => {
 
         const map = calculateRankMap(rank);
         expect(map['node.a']).toBe(false); // Deny overrides allow and group
-        expect(map['node.b']).toBe(true);  // From groupA
+        expect(map['node.b']).toBe(true); // From groupA
         expect(map['node.c']).toBe(false); // Deny overrides groupB
-        expect(map['node.x']).toBe(true);  // From allow
+        expect(map['node.x']).toBe(true); // From allow
         expect(map['node.y']).toBe(false); // From deny
         expect(Object.keys(map).length).toBe(5);
     });


### PR DESCRIPTION
🎯 **What:** The testing gap in `src/core/permissionEngine.ts:15` addressed by introducing unit tests for the `calculateRankMap` group processing function.

📊 **Coverage:** Test scenarios cover:
- Merging permissions from multiple groups
- Graceful handling of missing/undefined groups
- Correctly combining group permissions with the `allow` array
- Correctly overriding both groups and `allow` permissions with the `deny` array 
- Graceful handling of entirely empty inputs

✨ **Result:** Test coverage for this crucial module significantly improved. The new tests provide a robust safety net against regressions in permission processing rules.

---
*PR created automatically by Jules for task [7968787850764669046](https://jules.google.com/task/7968787850764669046) started by @SjnExe*