### PR TITLE
🧪 Testing Improvement: Items Manager

### DIFF
--- a/src/core/__tests__/__mocks__/minecraftMock.ts
+++ b/src/core/__tests__/__mocks__/minecraftMock.ts
@@ -217,3 +217,19 @@ export class MessageFormData {
         return { selection: 0, canceled: false };
     });
 }
+
+// --- added for itemsManager tests ---
+export class ItemStack {
+    typeId: string;
+    amount: number;
+    maxAmount: number;
+
+    constructor(typeId: string, amount: number) {
+        if (typeId === 'invalid:item') {
+            throw new Error('Invalid item type');
+        }
+        this.typeId = typeId;
+        this.amount = amount;
+        this.maxAmount = 64; // Default max stack size
+    }
+}

--- a/src/features/kit/__tests__/itemsManager.test.ts
+++ b/src/features/kit/__tests__/itemsManager.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, mock, beforeEach } from 'bun:test';
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
 
 // Mocks
 const mockGetConfig = mock();
@@ -29,10 +29,10 @@ describe('Kit Items Manager', () => {
         mockGetConfig.mockReturnValue({
             kits: {
                 kitDefinitions: {
-                    'TestKit': {
+                    TestKit: {
                         items: []
                     },
-                    'FullKit': {
+                    FullKit: {
                         items: new Array(36).fill({ typeId: 'minecraft:stone', amount: 1 })
                     }
                 }

--- a/src/features/kit/__tests__/itemsManager.test.ts
+++ b/src/features/kit/__tests__/itemsManager.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, mock, beforeEach } from 'bun:test';
+
+// Mocks
+const mockGetConfig = mock();
+const mockUpdateMultipleConfig = mock();
+const mockDebugLog = mock();
+const mockErrorLog = mock((msg) => console.log('ERROR LOG:', msg));
+
+mock.module('@core/configManager.js', () => ({
+    getConfig: mockGetConfig,
+    updateMultipleConfig: mockUpdateMultipleConfig
+}));
+
+mock.module('@core/logger.js', () => ({
+    debugLog: mockDebugLog,
+    errorLog: mockErrorLog
+}));
+
+const { addItemToKit } = await import('../itemsManager.js');
+
+describe('Kit Items Manager', () => {
+    beforeEach(() => {
+        mockGetConfig.mockClear();
+        mockUpdateMultipleConfig.mockClear();
+        mockDebugLog.mockClear();
+        mockErrorLog.mockClear();
+
+        // Setup default config mock
+        mockGetConfig.mockReturnValue({
+            kits: {
+                kitDefinitions: {
+                    'TestKit': {
+                        items: []
+                    },
+                    'FullKit': {
+                        items: new Array(36).fill({ typeId: 'minecraft:stone', amount: 1 })
+                    }
+                }
+            }
+        });
+    });
+
+    describe('addItemToKit', () => {
+        it('should add a valid item successfully', () => {
+            const result = addItemToKit('TestKit', { typeId: 'minecraft:apple', amount: 5 });
+            expect(result.success).toBe(true);
+            expect(result.message).toBe('Item added successfully.');
+            expect(mockUpdateMultipleConfig).toHaveBeenCalled();
+        });
+
+        it('should cap the amount to maxAmount', () => {
+            const result = addItemToKit('TestKit', { typeId: 'minecraft:apple', amount: 100 });
+            expect(result.success).toBe(true);
+
+            // Check what updateMultipleConfig was called with
+            const callArgs = mockUpdateMultipleConfig.mock.calls[0][0];
+            const updatedKit = callArgs['kits.kitDefinitions']['TestKit'];
+            expect(updatedKit.items[0].amount).toBe(64); // capped at maxAmount from MockItemStack
+        });
+
+        it('should catch error for invalid item type ID', () => {
+            const result = addItemToKit('TestKit', { typeId: 'invalid:item', amount: 1 });
+            expect(result.success).toBe(false);
+            expect(result.message).toContain('Invalid item type ID');
+            expect(mockUpdateMultipleConfig).not.toHaveBeenCalled();
+        });
+
+        it('should fail if kit is full', () => {
+            const result = addItemToKit('FullKit', { typeId: 'minecraft:apple', amount: 1 });
+            expect(result.success).toBe(false);
+            expect(result.message).toContain('is full');
+        });
+
+        it('should fail if kit is not found', () => {
+            const result = addItemToKit('NonExistentKit', { typeId: 'minecraft:apple', amount: 1 });
+            expect(result.success).toBe(false);
+            expect(result.message).toContain('not found');
+        });
+
+        it('should fail if amount is 0 or less', () => {
+            const result = addItemToKit('TestKit', { typeId: 'minecraft:apple', amount: 0 });
+            expect(result.success).toBe(false);
+            expect(result.message).toContain('amount must be greater than 0');
+        });
+    });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing test coverage for the error handling logic in `addItemToKit` when adding invalid items to a kit. Added an `ItemStack` mock to the Minecraft mock file that throws errors for invalid IDs.
📊 **Coverage:** Tests now cover successfully adding an item, capping item amounts to their max stack sizes, failing gracefully upon receiving invalid item type IDs, failing on a full kit, failing on a nonexistent kit, and failing on zero or negative amounts.
✨ **Result:** Improved test coverage and reliability for kit operations.

---
*PR created automatically by Jules for task [1658800796191999903](https://jules.google.com/task/1658800796191999903) started by @SjnExe*