### PR TITLE
🧪 [testing improvement] improve coverage of calculateRankMap in permission engine

### DIFF
--- a/src/core/__tests__/permissionEngine.test.ts
+++ b/src/core/__tests__/permissionEngine.test.ts
@@ -6,7 +6,8 @@ mock.module('../configurations.js', () => ({
         permissionGroups: {
             groupA: ['node.a', 'node.b'],
             groupB: ['node.c'],
-            groupOverride: ['node.a']
+            groupOverride: ['node.a'],
+            emptyGroup: []
         }
     })
 }));
@@ -101,6 +102,58 @@ describe('calculateRankMap', () => {
             permissionLevel: 1,
             conditions: [],
             groups: [],
+            allow: [],
+            deny: []
+        } as unknown as RankDefinition;
+
+        const map = calculateRankMap(rank);
+        expect(Object.keys(map).length).toBe(0);
+    });
+
+    it('should handle overlapping group permissions', () => {
+        const rank = {
+            id: 'test',
+            name: 'Test',
+            priority: 1,
+            permissionLevel: 1,
+            conditions: [],
+            groups: ['groupA', 'groupOverride'],
+            allow: [],
+            deny: []
+        } as unknown as RankDefinition;
+
+        const map = calculateRankMap(rank);
+        expect(map['node.a']).toBe(true);
+        expect(map['node.b']).toBe(true);
+        expect(Object.keys(map).length).toBe(2);
+    });
+
+    it('should handle duplicate groups', () => {
+        const rank = {
+            id: 'test',
+            name: 'Test',
+            priority: 1,
+            permissionLevel: 1,
+            conditions: [],
+            groups: ['groupA', 'groupA'],
+            allow: [],
+            deny: []
+        } as unknown as RankDefinition;
+
+        const map = calculateRankMap(rank);
+        expect(map['node.a']).toBe(true);
+        expect(map['node.b']).toBe(true);
+        expect(Object.keys(map).length).toBe(2);
+    });
+
+    it('should handle empty groups', () => {
+        const rank = {
+            id: 'test',
+            name: 'Test',
+            priority: 1,
+            permissionLevel: 1,
+            conditions: [],
+            groups: ['emptyGroup'],
             allow: [],
             deny: []
         } as unknown as RankDefinition;


### PR DESCRIPTION
🎯 **What:** Improved the test coverage for the `calculateRankMap` function's group iteration logic in `permissionEngine.ts`.
📊 **Coverage:** The test suite now explicitly covers scenarios involving overlapping group nodes, duplicate groups within the rank configuration, and empty groups.
✨ **Result:** Enhanced the reliability of the permission engine unit tests by successfully validating complex and empty edge cases.

---
*PR created automatically by Jules for task [5099849958833790830](https://jules.google.com/task/5099849958833790830) started by @SjnExe*