### PR TITLE
Remove CodeQL from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -318,34 +318,3 @@ jobs:
                       AddonExe.Release.${{ env.ARCHIVE_VERSION }}.mcaddon \
                       AddonExe_BP.Release.${{ env.ARCHIVE_VERSION }}.mcpack \
                       AddonExe_RP.Release.${{ env.ARCHIVE_VERSION }}.mcpack
-
-    analyze:
-        name: Analyze
-        runs-on: ubuntu-latest
-        permissions:
-            actions: read
-            contents: read
-            security-events: write
-
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v7
-
-            - name: Initialize CodeQL
-              uses: github/codeql-action/init@v4
-              with:
-                  languages: javascript-typescript
-                  config: |
-                      paths-ignore:
-                          - '**/__tests__/**'
-                          - '**/__mocks__/**'
-                          - 'scripts/**'
-                          - '*.config.*'
-                  tools: latest
-
-            - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v4
-              with:
-                  category: '/language:javascript-typescript'
-                  ram: 14336
-                  threads: 4


### PR DESCRIPTION
- Completely removed the CodeQL `analyze` job from the `.github/workflows/build.yml` workflow.
- Answered questions regarding Regolith, `Bedrock-Validator`, and TypeScript config files (`tsconfig.json`, `tsconfig.test.json`).
- Verified code formatting using `bun format` as requested.

---
*PR created automatically by Jules for task [9404954604361074264](https://jules.google.com/task/9404954604361074264) started by @SjnExe*