### PR TITLE
Fix Dynamic UI Handling and HUD Elements

### DIFF
--- a/packs/resource/ui/hud_screen.json
+++ b/packs/resource/ui/hud_screen.json
@@ -2607,6 +2607,12 @@
             },
             {
                 "camera_renderer@camera_renderer": {}
+            },
+            {
+                "crosshair_renderer@crosshair_renderer": {}
+            },
+            {
+                "subtitle_container_host@subtitle_container_host": {}
             }
         ]
     }

--- a/src/core/ui/panelBuilder.ts
+++ b/src/core/ui/panelBuilder.ts
@@ -17,16 +17,25 @@ export function getStaticMenuItems(player: mc.Player, panelDef: PanelDefinition,
     const config = getConfig() as unknown as MainConfig;
     const items = (isDefined(panelDef.items) ? panelDef.items : [])
         .filter((item: PanelItem) => {
+            return hasPermission(player, item.permission ?? 'ui.panel.member');
+        })
+        .map((item: PanelItem) => {
+            const newItem = { ...item };
+            let isDisabled = false;
             if (isNonEmptyString(item.requiresFeature)) {
                 const isEnabled = getValueFromPath(config, item.requiresFeature);
                 if (isEnabled !== true) {
-                    return false;
+                    isDisabled = true;
                 }
             } else if (item.actionValue === 'shopMainPanel' && (isDefined(config.shop) ? config.shop.enabled : undefined) !== true) {
                 // Fallback for older hardcoded definition
-                return false;
+                isDisabled = true;
             }
-            return hasPermission(player, item.permission ?? 'ui.panel.member');
+
+            if (isDisabled) {
+                newItem.text += '\n[§4Disabled]';
+            }
+            return newItem;
         })
         .toSorted((a: PanelItem, b: PanelItem) => (a.sortId ?? 0) - (b.sortId ?? 0));
 

--- a/src/core/ui/panelHandlers.ts
+++ b/src/core/ui/panelHandlers.ts
@@ -12,9 +12,12 @@ export async function handleFormResponse(player: mc.Player, panelId: string, res
         // Global check for disabled items in ActionFormData dynamically built lists
         if (!response.canceled && 'selection' in response && response.selection !== undefined && handler.getItems) {
             const items = await handler.getItems(player, panelId, context);
-            if (items && items[response.selection] && items[response.selection].text.includes('[§4Disabled]')) {
-                player.sendMessage('§cThis feature is currently disabled.');
-                return showPanel(player, panelId, context);
+            if (items) {
+                const item = items[response.selection as number];
+                if (item && item.text && item.text.includes('[§4Disabled]')) {
+                    player.sendMessage('§cThis feature is currently disabled.');
+                    return showPanel(player, panelId, context);
+                }
             }
         }
 

--- a/src/core/ui/panelHandlers.ts
+++ b/src/core/ui/panelHandlers.ts
@@ -13,7 +13,7 @@ export async function handleFormResponse(player: mc.Player, panelId: string, res
         if (!response.canceled && 'selection' in response && response.selection !== undefined && handler.getItems) {
             const items = await handler.getItems(player, panelId, context);
             if (items) {
-                const item = items[response.selection as number];
+                const item = items[response.selection];
                 if (item && item.text && item.text.includes('[§4Disabled]')) {
                     player.sendMessage('§cThis feature is currently disabled.');
                     return showPanel(player, panelId, context);

--- a/src/core/ui/panelHandlers.ts
+++ b/src/core/ui/panelHandlers.ts
@@ -1,6 +1,7 @@
 import * as mc from '@minecraft/server';
 import { ActionFormResponse, ModalFormResponse } from '@minecraft/server-ui';
 
+import { showPanel } from '@core/uiManager.js';
 import { panelRouter } from '@ui/PanelRouter.js';
 import { UIContext } from '@ui/types.js';
 
@@ -8,6 +9,15 @@ export async function handleFormResponse(player: mc.Player, panelId: string, res
     // 1. Router Check (Modular System)
     const handler = panelRouter.getHandler(panelId);
     if (handler && handler.handleResponse) {
+        // Global check for disabled items in ActionFormData dynamically built lists
+        if (!response.canceled && 'selection' in response && response.selection !== undefined && handler.getItems) {
+            const items = await handler.getItems(player, panelId, context);
+            if (items && items[response.selection] && items[response.selection].text.includes('[§4Disabled]')) {
+                player.sendMessage('§cThis feature is currently disabled.');
+                return showPanel(player, panelId, context);
+            }
+        }
+
         return handler.handleResponse(player, panelId, response, context);
     }
 }


### PR DESCRIPTION
This patch updates the UI panel handler and builder to dynamically handle features that are currently disabled in the configuration by adding a `\n[§4Disabled]` suffix, and properly intercepting attempts to click on these to prevent silent crashes and safely redirect users. It also restores missing vanilla HUD identifiers `crosshair_renderer` and `subtitle_container_host`.

---
*PR created automatically by Jules for task [15852571582599848238](https://jules.google.com/task/15852571582599848238) started by @SjnExe*