### PR TITLE
🔒 Fix command injection vulnerability in RTP ticking area fallback

### DIFF
--- a/src/features/teleport/commands/rtp.ts
+++ b/src/features/teleport/commands/rtp.ts
@@ -48,7 +48,10 @@ async function createTickingArea(dimension: mc.Dimension, name: string, x: numbe
     } catch {
         // Fallback to command if API method fails (e.g., if there's no space in the manager)
         try {
-            const sanitizedName = name.replaceAll('\\', String.raw`\\`).replaceAll('"', String.raw`\"`).replaceAll('\n', ' ');
+            const sanitizedName = name
+                .replaceAll('\\', String.raw`\\`)
+                .replaceAll('"', String.raw`\"`)
+                .replaceAll('\n', ' ');
             dimension.runCommand(`tickingarea add circle ${x} 0 ${z} 1 "${sanitizedName}"`);
             await new Promise<void>((resolve) => mc.system.runTimeout(resolve, 60));
         } catch {
@@ -179,7 +182,10 @@ function safeRemoveTickingArea(dimension: mc.Dimension, name: string) {
     } catch {
         // Fallback to command
         try {
-            const sanitizedName = name.replaceAll('\\', String.raw`\\`).replaceAll('"', String.raw`\"`).replaceAll('\n', ' ');
+            const sanitizedName = name
+                .replaceAll('\\', String.raw`\\`)
+                .replaceAll('"', String.raw`\"`)
+                .replaceAll('\n', ' ');
             dimension.runCommand(`tickingarea remove "${sanitizedName}"`);
         } catch {
             // Ignore if it doesn't exist

--- a/src/features/teleport/commands/rtp.ts
+++ b/src/features/teleport/commands/rtp.ts
@@ -48,7 +48,8 @@ async function createTickingArea(dimension: mc.Dimension, name: string, x: numbe
     } catch {
         // Fallback to command if API method fails (e.g., if there's no space in the manager)
         try {
-            dimension.runCommand(`tickingarea add circle ${x} 0 ${z} 1 ${name}`);
+            const sanitizedName = name.replaceAll('\\', String.raw`\\`).replaceAll('"', String.raw`\"`).replaceAll('\n', ' ');
+            dimension.runCommand(`tickingarea add circle ${x} 0 ${z} 1 "${sanitizedName}"`);
             await new Promise<void>((resolve) => mc.system.runTimeout(resolve, 60));
         } catch {
             // Ignore error
@@ -178,7 +179,8 @@ function safeRemoveTickingArea(dimension: mc.Dimension, name: string) {
     } catch {
         // Fallback to command
         try {
-            dimension.runCommand(`tickingarea remove ${name}`);
+            const sanitizedName = name.replaceAll('\\', String.raw`\\`).replaceAll('"', String.raw`\"`).replaceAll('\n', ' ');
+            dimension.runCommand(`tickingarea remove "${sanitizedName}"`);
         } catch {
             // Ignore if it doesn't exist
         }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Command injection in the `/rtp` command's ticking area creation and removal process. The `name` parameter was directly interpolated into the `runCommand` string without sanitization.

⚠️ **Risk:** The potential impact if left unfixed
Malicious players could potentially exploit this by crafting special player names or causing the `name` parameter to include malicious command structures, allowing them to execute arbitrary server commands (like granting themselves operator status, banning users, or modifying game rules) as the server dimension.

🛡️ **Solution:** How the fix addresses the vulnerability
The `name` variable is now strictly sanitized before being interpolated into the `runCommand`. It escapes backslashes (`\`) and double quotes (`"`), replaces newlines, and securely wraps the argument in double quotes within the command string.

---
*PR created automatically by Jules for task [9915179131621934495](https://jules.google.com/task/9915179131621934495) started by @SjnExe*