### PR TITLE
🔒 Fix prototype pollution and add permission checks to config transfer

### DIFF
--- a/src/core/ui/panels/configPanel.ts
+++ b/src/core/ui/panels/configPanel.ts
@@ -567,6 +567,7 @@ export class ConfigPanelHandler implements IPanelHandler {
                 if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
                     return undefined;
                 }
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-return
                 return value;
             });
         } catch {

--- a/src/core/ui/panels/configPanel.ts
+++ b/src/core/ui/panels/configPanel.ts
@@ -492,6 +492,11 @@ export class ConfigPanelHandler implements IPanelHandler {
     }
 
     private handleExportConfig(player: mc.Player, response: ModalFormResponse, context: UIContext): Promise<void> | void {
+        if (!hasPermission(player, 'ui.panel.owner')) {
+            player.sendMessage('§4You do not have permission to export configurations.');
+            return showPanel(player, 'configTransferPanel', context);
+        }
+
         if (response.canceled) return showPanel(player, 'configTransferPanel', context);
 
         const values = response.formValues;
@@ -534,6 +539,11 @@ export class ConfigPanelHandler implements IPanelHandler {
     }
 
     private handleImportConfig(player: mc.Player, response: ModalFormResponse, context: UIContext): Promise<void> | void {
+        if (!hasPermission(player, 'ui.panel.owner')) {
+            player.sendMessage('§4You do not have permission to import configurations.');
+            return showPanel(player, 'configTransferPanel', context);
+        }
+
         if (response.canceled) return showPanel(player, 'configTransferPanel', context);
 
         const values = response.formValues;
@@ -553,7 +563,12 @@ export class ConfigPanelHandler implements IPanelHandler {
 
         let importData: unknown;
         try {
-            importData = JSON.parse(jsonString);
+            importData = JSON.parse(jsonString, (key, value) => {
+                if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+                    return undefined;
+                }
+                return value;
+            });
         } catch {
             player.sendMessage('§4Invalid JSON format. Please ensure you copied the entire exported string correctly.');
             return showPanel(player, 'configTransferPanel', context);


### PR DESCRIPTION
🎯 **What:** This PR fixes a security vulnerability in the configuration transfer system (`src/core/ui/panels/configPanel.ts`) where imported configurations were not validated for authorization or safe data parsing.

⚠️ **Risk:** If left unfixed, the vulnerability allowed unauthorized users to submit malicious JSON data to the config system. Because `JSON.parse` was used without any sanitizer, an attacker could inject special properties (like `__proto__`, `constructor`, or `prototype`) into the configuration object. This could result in **prototype pollution**, potentially allowing the attacker to change default behavior across the server, cause crashes, or elevate their privileges. Furthermore, without permission checks at the handler level, a user could bypass the UI (e.g. by exploiting Bedrock UI packet bugs or other means) to directly trigger the import/export functions.

🛡️ **Solution:**
- Added explicit `hasPermission(player, 'ui.panel.owner')` checks at the beginning of both `handleImportConfig` and `handleExportConfig`. If a player does not have the owner permission level, the action is blocked and they are returned to the transfer panel with an error message.
- Replaced the vulnerable `JSON.parse(jsonString)` with a safe version that uses a reviver function. The reviver drops any keys matching `__proto__`, `constructor`, or `prototype`, eliminating the prototype pollution vector.

---
*PR created automatically by Jules for task [2137499740516814723](https://jules.google.com/task/2137499740516814723) started by @SjnExe*