### PR TITLE
fix(ui): correct title formatting for configuration subcategories

### DIFF
--- a/src/core/ui/panels/configPanel.ts
+++ b/src/core/ui/panels/configPanel.ts
@@ -321,7 +321,10 @@ export class ConfigPanelHandler implements IPanelHandler {
                 // Title Fix for SubCategories
                 if (item.actionValue.startsWith('configSubCategoryPanel_')) {
                     const catId = item.actionValue.replace('configSubCategoryPanel_', '');
-                    const title = catId.charAt(0).toUpperCase() + catId.slice(1) + ' Configuration';
+                    const title = catId
+                        .replace(/([A-Z])/g, ' $1')
+                        .trim()
+                        .replace(/^./, (str) => str.toUpperCase()) + ' Configuration';
                     return showPanel(player, item.actionValue, { ...context, page: 1, customTitle: title });
                 }
                 return showPanel(player, item.actionValue, { ...context, page: 1 });

--- a/src/core/ui/panels/configPanel.ts
+++ b/src/core/ui/panels/configPanel.ts
@@ -321,10 +321,11 @@ export class ConfigPanelHandler implements IPanelHandler {
                 // Title Fix for SubCategories
                 if (item.actionValue.startsWith('configSubCategoryPanel_')) {
                     const catId = item.actionValue.replace('configSubCategoryPanel_', '');
-                    const title = catId
-                        .replace(/([A-Z])/g, ' $1')
-                        .trim()
-                        .replace(/^./, (str) => str.toUpperCase()) + ' Configuration';
+                    const title =
+                        catId
+                            .replace(/([A-Z])/g, ' $1')
+                            .trim()
+                            .replace(/^./, (str) => str.toUpperCase()) + ' Configuration';
                     return showPanel(player, item.actionValue, { ...context, page: 1, customTitle: title });
                 }
                 return showPanel(player, item.actionValue, { ...context, page: 1 });


### PR DESCRIPTION
Fixes the title formatting for configuration subcategories in `configPanel.ts`. Previously, the logic only capitalized the first letter of the category string (e.g., `staffHosted` -> `StaffHosted Configuration`). The updated code adds spaces before uppercase letters and capitalizes the first letter, generating the desired title format (e.g., `Staff Hosted Configuration`).

---
*PR created automatically by Jules for task [5141477105103585342](https://jules.google.com/task/5141477105103585342) started by @SjnExe*