### PR TITLE
Ensure team ID uniqueness to prevent race conditions

### DIFF
--- a/src/features/team/manager.ts
+++ b/src/features/team/manager.ts
@@ -194,7 +194,7 @@ export function createTeam(player: mc.Player, name: string): ActionResult {
     };
 
     // Ensure ID uniqueness (Race Condition Fix)
-    if (activeTeam.has(newTeamId)) {
+    while (activeTeam.has(newTeamId)) {
         let maxId = 0;
         for (const id of activeTeam.keys()) {
             if (id > maxId) maxId = id;


### PR DESCRIPTION
Replaced `if` with `while` loop in `src/features/team/manager.ts` at line 197 to ensure strict uniqueness of team IDs when creating new teams, acting as a robust race condition fix.

---
*PR created automatically by Jules for task [12811906225163563175](https://jules.google.com/task/12811906225163563175) started by @SjnExe*