### PR TITLE
Fix Disabled Indicator and Games Panel UI Bugs

### DIFF
--- a/src/core/ui/panelBuilder.ts
+++ b/src/core/ui/panelBuilder.ts
@@ -33,7 +33,7 @@ export function getStaticMenuItems(player: mc.Player, panelDef: PanelDefinition,
             }
 
             if (isDisabled) {
-                newItem.text += '\n[§4Disabled]';
+                newItem.text += '\n§4[Disabled]';
             }
             return newItem;
         })

--- a/src/core/ui/panelRegistry.ts
+++ b/src/core/ui/panelRegistry.ts
@@ -36,10 +36,11 @@ export const panelDefinitions: Record<string, PanelDefinition> = {
             {
                 id: 'games',
                 text: 'Games',
-                icon: 'textures/ui/controller_icon',
+                icon: 'textures/ui/controller_icon.png',
                 permission: 'ui.panel.member',
                 actionType: 'openPanel',
                 actionValue: 'gamesMainPanel',
+                requiresFeature: 'games.enabled',
                 sortId: 15
             },
             {


### PR DESCRIPTION
Fixes user-reported bugs in the UI where the disabled indicator had incorrectly colored brackets, the Games menu button failed to show a disabled state despite backend logs, and the Games icon was missing.

---
*PR created automatically by Jules for task [15105499905832182137](https://jules.google.com/task/15105499905832182137) started by @SjnExe*