### PR TITLE
🔒 Fix Command Injection in Kick Commands

### DIFF
--- a/src/core/utils/sanitization.ts
+++ b/src/core/utils/sanitization.ts
@@ -31,3 +31,15 @@ export function validateInput(input: string, maxLength = 256): boolean {
     if (input.length > maxLength) return false;
     return true;
 }
+
+/**
+ * Escapes a string to be safely used as an argument in a Minecraft command.
+ * It escapes backslashes and double quotes, and replaces newlines with spaces.
+ * The resulting string should be wrapped in double quotes in the command.
+ * @param input The string to escape.
+ * @returns The escaped string.
+ */
+export function escapeCommandArg(input: string): string {
+    if (!input) return '';
+    return input.replaceAll('\\', '\\\\').replaceAll('"', '\\"').replaceAll('\n', ' ');
+}

--- a/src/features/moderation/commands/ban.ts
+++ b/src/features/moderation/commands/ban.ts
@@ -8,6 +8,7 @@ import { sendMessage } from '@core/messaging.js';
 import { getPlayerIdByName, loadPlayerData } from '@core/playerDataManager.js';
 import { canTarget } from '@core/rankManager.js';
 import { parseDuration, playSoundFromConfig } from '@core/utils.js';
+import { escapeCommandArg } from '@core/utils/sanitization.js';
 import { isDefined } from '@lib/guards.js';
 
 import { addPunishment, removePunishment } from '@features/moderation/punishmentManager.js';
@@ -52,8 +53,9 @@ export function banPlayer(executor: CommandExecutor, targetPlayer: mc.Player, du
     }
 
     try {
-        const sanitizedReason = reason.replaceAll('"', String.raw`\"`).replaceAll('\n', ' ');
-        const command = `kick "${targetPlayer.name}" You have been banned ${durationText}. Reason: ${sanitizedReason}`;
+        const safeReason = escapeCommandArg(reason);
+        const safeTargetName = escapeCommandArg(targetPlayer.name);
+        const command = `kick "${safeTargetName}" "You have been banned ${durationText}. Reason: ${safeReason}"`;
         mc.world.getDimension('overworld').runCommand(command);
     } catch (error: unknown) {
         warnLog(`[Commands:Ban] Could not kick ${targetPlayer.name} after banning. They will be kicked on next join.`);
@@ -198,8 +200,9 @@ export function offlineBanPlayer(executor: CommandExecutor, targetId: string, ta
     }
 
     try {
-        const sanitizedReason = reason.replaceAll('"', String.raw`\"`).replaceAll('\n', ' ');
-        mc.world.getDimension('overworld').runCommand(`kick "${targetName}" You have been banned ${durationText}. Reason: ${sanitizedReason}`);
+        const safeReason = escapeCommandArg(reason);
+        const safeTargetName = escapeCommandArg(targetName);
+        mc.world.getDimension('overworld').runCommand(`kick "${safeTargetName}" "You have been banned ${durationText}. Reason: ${safeReason}"`);
     } catch {
         // Player is likely offline, which is fine.
     }

--- a/src/features/moderation/commands/kick.ts
+++ b/src/features/moderation/commands/kick.ts
@@ -8,6 +8,7 @@ import { sendMessage } from '@core/messaging.js';
 import { findPlayerByName } from '@core/playerCache.js';
 import { canTarget } from '@core/rankManager.js';
 import { playSound } from '@core/utils.js';
+import { escapeCommandArg } from '@core/utils/sanitization.js';
 import { isDefined } from '@lib/guards.js';
 
 export function kickPlayer(executor: CommandExecutor, targetPlayer: mc.Player | undefined, reason: string) {
@@ -38,8 +39,9 @@ export function kickPlayer(executor: CommandExecutor, targetPlayer: mc.Player | 
     }
 
     try {
-        const sanitizedReason = reason.replaceAll('"', String.raw`\"`).replaceAll('\n', ' ');
-        const commandToRun = `kick "${targetPlayer.name}" ${sanitizedReason}`;
+        const safeReason = escapeCommandArg(reason);
+        const safeTargetName = escapeCommandArg(targetPlayer.name);
+        const commandToRun = `kick "${safeTargetName}" "${safeReason}"`;
         mc.world.getDimension('overworld').runCommand(commandToRun);
         if (executor instanceof mc.Player) {
             sendMessage(`§aSuccessfully kicked ${targetPlayer.name}. Reason: ${reason}`, executor);

--- a/src/features/moderation/punishmentManager.ts
+++ b/src/features/moderation/punishmentManager.ts
@@ -4,6 +4,7 @@ import { getConfig } from '@core/configManager.js';
 import { debugLog, errorLog } from '@core/logger.js';
 import { serviceLocator } from '@core/services/serviceLocator.js';
 import { StorageManager } from '@core/storage/StorageManager.js';
+import { escapeCommandArg } from '@core/utils/sanitization.js';
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
 
 interface AnticheatLogsService {
@@ -184,8 +185,10 @@ export function checkAndKickBannedPlayer(player: mc.Player): boolean {
     const punishment = getPunishment(player.id, 'ban');
     if (isDefined(punishment)) {
         const banReason = isNonEmptyString(punishment.reason) ? punishment.reason : 'You are banned.';
+        const safeReason = escapeCommandArg(banReason);
+        const safePlayerName = escapeCommandArg(player.name);
         // Use a slight delay to ensure the kick command processes after join
-        mc.system.runTimeout(() => mc.world.getDimension('overworld').runCommand(`kick "${player.name}" ${banReason}`), 5);
+        mc.system.runTimeout(() => mc.world.getDimension('overworld').runCommand(`kick "${safePlayerName}" "${safeReason}"`), 5);
         return true;
     }
     return false;

--- a/src/features/moderation/ui/panel.ts
+++ b/src/features/moderation/ui/panel.ts
@@ -178,7 +178,10 @@ export class ModerationPanelHandler implements IPanelHandler {
         const safeReason = sanitizeString(reason, true).replaceAll('"', "'");
 
         try {
-            player.dimension.runCommand(`kick "${target.name}" ${safeReason}`);
+            const { escapeCommandArg } = await import('@core/utils/sanitization.js');
+            const escapedReason = escapeCommandArg(safeReason);
+            const escapedTargetName = escapeCommandArg(target.name);
+            player.dimension.runCommand(`kick "${escapedTargetName}" "${escapedReason}"`);
             player.sendMessage(`§2Kicked ${target.name}.`);
         } catch (error) {
             player.sendMessage(`§4Failed to kick player: ${String(error)}`);
@@ -311,7 +314,10 @@ export class ModerationPanelHandler implements IPanelHandler {
         const target = getPlayerFromCache(targetId);
         if (isDefined(target)) {
             try {
-                player.dimension.runCommand(`kick "${target.name}" §4You have been banned.\nReason: ${reason}\nExpires: ${new Date(expires).toLocaleString()}`);
+                const { escapeCommandArg } = await import('@core/utils/sanitization.js');
+                const escapedTargetName = escapeCommandArg(target.name);
+                const escapedReason = escapeCommandArg(`§4You have been banned.\nReason: ${reason}\nExpires: ${new Date(expires).toLocaleString()}`);
+                player.dimension.runCommand(`kick "${escapedTargetName}" "${escapedReason}"`);
             } catch {
                 // Ignore if kick fails
             }


### PR DESCRIPTION
🎯 **What:** Fixed a potential command injection vulnerability in commands that invoke `runCommand` (e.g. `kick`, `ban`, `offlineban` and UI panels).

⚠️ **Risk:** A malicious player with access to these commands could supply a crafted `reason` containing double quotes or newlines to break out of the string context and execute arbitrary server commands.

🛡️ **Solution:** Added a new sanitization utility `escapeCommandArg` in `src/core/utils/sanitization.ts` that escapes backslashes and double quotes, and strips newlines. The arguments are then securely wrapped in double quotes inside `runCommand` templates.

---
*PR created automatically by Jules for task [6061638212825591271](https://jules.google.com/task/6061638212825591271) started by @SjnExe*