### PR TITLE
🧪 Add tests for addCategory in shop adminManager

### DIFF
--- a/src/features/shop/__tests__/adminManager.test.ts
+++ b/src/features/shop/__tests__/adminManager.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+mock.module('@core/logger.js', () => ({
+    debugLog: mock()
+}));
+
+const mockConfig = {
+    categories: {} as Record<string, any>
+};
+
+mock.module('@core/configurations.js', () => ({
+    getShopConfig: mock(() => mockConfig),
+    saveShopConfig: mock()
+}));
+
+import { getShopConfig, saveShopConfig } from '@core/configurations.js';
+import { debugLog } from '@core/logger.js';
+import { addCategory } from '../adminManager.js';
+
+describe('Shop Admin Manager - addCategory', () => {
+    beforeEach(() => {
+        // Reset config state
+        mockConfig.categories = {};
+
+        // Clear mocks
+        (getShopConfig as any).mockClear();
+        (saveShopConfig as any).mockClear();
+        (debugLog as any).mockClear();
+    });
+
+    it('should successfully add a new category', () => {
+        const result = addCategory('Weapons', 'textures/items/diamond_sword');
+
+        expect(result.success).toBe(true);
+        expect(result.message).toBe("Successfully added category 'Weapons'.");
+
+        expect(mockConfig.categories['Weapons']).toBeDefined();
+        expect(mockConfig.categories['Weapons'].icon).toBe('textures/items/diamond_sword');
+        expect(mockConfig.categories['Weapons'].items).toEqual({});
+        expect(mockConfig.categories['Weapons'].subCategories).toEqual({});
+
+        expect(saveShopConfig).toHaveBeenCalledWith(mockConfig);
+        expect(debugLog).toHaveBeenCalledWith('[ShopAdminManager] Added new category: Weapons');
+    });
+
+    it('should fail when category name is too long', () => {
+        const longName = 'A'.repeat(33);
+        const result = addCategory(longName, 'textures/ui/folder_glyph');
+
+        expect(result.success).toBe(false);
+        expect(result.message).toBe('Category name is too long (max 32).');
+        expect(Object.keys(mockConfig.categories).length).toBe(0);
+        expect(saveShopConfig).not.toHaveBeenCalled();
+    });
+
+    it('should fail when category already exists', () => {
+        mockConfig.categories['Existing'] = {
+            icon: 'textures/ui/folder_glyph',
+            items: {},
+            subCategories: {}
+        };
+
+        const result = addCategory('Existing', 'some_icon');
+
+        expect(result.success).toBe(false);
+        expect(result.message).toBe("A category with the name 'Existing' already exists.");
+        expect(saveShopConfig).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to default icon when icon is empty', () => {
+        const result = addCategory('Blocks', '');
+
+        expect(result.success).toBe(true);
+        expect(mockConfig.categories['Blocks']).toBeDefined();
+        expect(mockConfig.categories['Blocks'].icon).toBe('textures/ui/folder_glyph');
+        expect(saveShopConfig).toHaveBeenCalledWith(mockConfig);
+    });
+
+    it('should keep color codes in category name as sanitizeString(allowColors=true) is used', () => {
+        // adminManager uses sanitizeString(categoryName, true) which means color codes ARE kept.
+        // It does trim the string however.
+        const result = addCategory(' §cColored ', 'some_icon');
+
+        expect(result.success).toBe(true);
+
+        // It should be trimmed, but keep the §c
+        expect(mockConfig.categories['§cColored']).toBeDefined();
+        expect(mockConfig.categories['§cColored'].icon).toBe('some_icon');
+    });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The exported `addCategory` function in `src/features/shop/adminManager.ts` lacked test coverage. As a public API surface, it requires unit testing to ensure reliability and catch regressions.

📊 **Coverage:** What scenarios are now tested
Tests have been added to cover:
- Successfully adding a new category
- Rejecting category names that exceed the maximum length (32 characters)
- Preventing the creation of duplicate categories
- Falling back to the default icon when an empty icon is provided
- Ensuring the category name undergoes proper sanitization (preserving color codes while trimming, per `sanitizeString(..., true)`)

✨ **Result:** The improvement in test coverage
The test coverage for the shop module has improved by explicitly validating the `addCategory` method's behavior. Five targeted unit tests now safeguard this core logic.

---
*PR created automatically by Jules for task [1311307542265499192](https://jules.google.com/task/1311307542265499192) started by @SjnExe*