### PR TITLE
🔒 Fix command injection vulnerability in kick/ban commands

### DIFF
--- a/src/features/moderation/commands/ban.ts
+++ b/src/features/moderation/commands/ban.ts
@@ -52,7 +52,7 @@ export function banPlayer(executor: CommandExecutor, targetPlayer: mc.Player, du
     }
 
     try {
-        const sanitizedReason = reason.replaceAll('"', String.raw`\"`).replaceAll('\n', ' ');
+        const sanitizedReason = reason.replaceAll('\\', '\\\\').replaceAll('"', '\\"').replaceAll('\n', ' ');
         const command = `kick "${targetPlayer.name}" You have been banned ${durationText}. Reason: ${sanitizedReason}`;
         mc.world.getDimension('overworld').runCommand(command);
     } catch (error: unknown) {
@@ -198,7 +198,7 @@ export function offlineBanPlayer(executor: CommandExecutor, targetId: string, ta
     }
 
     try {
-        const sanitizedReason = reason.replaceAll('"', String.raw`\"`).replaceAll('\n', ' ');
+        const sanitizedReason = reason.replaceAll('\\', '\\\\').replaceAll('"', '\\"').replaceAll('\n', ' ');
         mc.world.getDimension('overworld').runCommand(`kick "${targetName}" You have been banned ${durationText}. Reason: ${sanitizedReason}`);
     } catch {
         // Player is likely offline, which is fine.

--- a/src/features/moderation/commands/kick.ts
+++ b/src/features/moderation/commands/kick.ts
@@ -38,7 +38,7 @@ export function kickPlayer(executor: CommandExecutor, targetPlayer: mc.Player | 
     }
 
     try {
-        const sanitizedReason = reason.replaceAll('"', String.raw`\"`).replaceAll('\n', ' ');
+        const sanitizedReason = reason.replaceAll('\\', '\\\\').replaceAll('"', '\\"').replaceAll('\n', ' ');
         const commandToRun = `kick "${targetPlayer.name}" ${sanitizedReason}`;
         mc.world.getDimension('overworld').runCommand(commandToRun);
         if (executor instanceof mc.Player) {

--- a/src/features/moderation/punishmentManager.ts
+++ b/src/features/moderation/punishmentManager.ts
@@ -184,8 +184,9 @@ export function checkAndKickBannedPlayer(player: mc.Player): boolean {
     const punishment = getPunishment(player.id, 'ban');
     if (isDefined(punishment)) {
         const banReason = isNonEmptyString(punishment.reason) ? punishment.reason : 'You are banned.';
+        const safeBanReason = banReason.replaceAll('\\', '\\\\').replaceAll('"', '\\"').replaceAll('\n', ' ');
         // Use a slight delay to ensure the kick command processes after join
-        mc.system.runTimeout(() => mc.world.getDimension('overworld').runCommand(`kick "${player.name}" ${banReason}`), 5);
+        mc.system.runTimeout(() => mc.world.getDimension('overworld').runCommand(`kick "${player.name}" ${safeBanReason}`), 5);
         return true;
     }
     return false;

--- a/src/features/moderation/ui/panel.ts
+++ b/src/features/moderation/ui/panel.ts
@@ -175,7 +175,7 @@ export class ModerationPanelHandler implements IPanelHandler {
         const values = (res as import('@minecraft/server-ui').ModalFormResponse).formValues;
         if (!isDefined(values)) return showPanel(player, (context.returnPanel as string) || 'playerActionsPanel', context);
         const [reason] = values as [string];
-        const safeReason = sanitizeString(reason, true).replaceAll('"', "'");
+        const safeReason = sanitizeString(reason, true).replaceAll('\\', '\\\\').replaceAll('"', '\\"').replaceAll('\n', ' ');
 
         try {
             player.dimension.runCommand(`kick "${target.name}" ${safeReason}`);
@@ -311,7 +311,8 @@ export class ModerationPanelHandler implements IPanelHandler {
         const target = getPlayerFromCache(targetId);
         if (isDefined(target)) {
             try {
-                player.dimension.runCommand(`kick "${target.name}" §4You have been banned.\nReason: ${reason}\nExpires: ${new Date(expires).toLocaleString()}`);
+                const safeReason = reason.replaceAll('\\', '\\\\').replaceAll('"', '\\"').replaceAll('\n', ' ');
+                player.dimension.runCommand(`kick "${target.name}" §4You have been banned.\nReason: ${safeReason}\nExpires: ${new Date(expires).toLocaleString()}`);
             } catch {
                 // Ignore if kick fails
             }


### PR DESCRIPTION
🎯 **What:** Command injection vulnerability in the `/kick` command executions from the moderation features.
⚠️ **Risk:** An attacker could craft a reason string with an unescaped backslash (e.g. `\"`) which bypassed the double-quote sanitization, potentially allowing arbitrary shell-like command execution via `mc.world.getDimension('overworld').runCommand(...)`.
🛡️ **Solution:** Replaced simple quote replacement with a robust sanitization chain that first escapes all backslashes (`\`), then escapes double quotes (`"`), and replaces newlines (`\n`). This ensures that malicious command parameters cannot break out of the string boundary using backslash escapes. This was applied to `ban.ts`, `kick.ts`, `punishmentManager.ts`, and `ui/panel.ts`.

---
*PR created automatically by Jules for task [6580013024160824566](https://jules.google.com/task/6580013024160824566) started by @SjnExe*