### PR TITLE
🔒 Fix command injection vulnerability in runCommand

### DIFF
--- a/src/core/utils/sanitization.ts
+++ b/src/core/utils/sanitization.ts
@@ -34,12 +34,13 @@ export function validateInput(input: string, maxLength = 256): boolean {
 
 /**
  * Escapes a string to be safely used as an argument in a Minecraft command.
- * It escapes backslashes and double quotes, and replaces newlines with spaces.
+ * It replaces double quotes with single quotes, removes backslashes to prevent
+ * escaping the closing quote, and replaces newlines with spaces.
  * The resulting string should be wrapped in double quotes in the command.
  * @param input The string to escape.
  * @returns The escaped string.
  */
 export function escapeCommandArg(input: string): string {
     if (!input) return '';
-    return input.replaceAll('\\', '\\\\').replaceAll('"', '\\"').replaceAll('\n', ' ');
+    return input.replaceAll('\\', '').replaceAll('"', "'").replaceAll('\n', ' ');
 }


### PR DESCRIPTION
🎯 What: Fixed a command injection vulnerability where user-provided input with `\"` could escape command string quotes.
⚠️ Risk: If left unfixed, attackers could inject arbitrary commands via the reason string in ban/kick commands, potentially gaining operator access or crashing the server.
🛡️ Solution: Updated `escapeCommandArg` in `sanitization.ts` to replace double quotes with single quotes and strip backslashes entirely, making it impossible to escape the quote boundary and inject commands safely.

---
*PR created automatically by Jules for task [15383943045309066235](https://jules.google.com/task/15383943045309066235) started by @SjnExe*