### PR TITLE
fix: improve subcategory title generation from camelCase ids

### DIFF
--- a/src/core/ui/panels/configPanel.ts
+++ b/src/core/ui/panels/configPanel.ts
@@ -327,7 +327,8 @@ export class ConfigPanelHandler implements IPanelHandler {
                     const catId = item.actionValue.replace('configSubCategoryPanel_', '');
                     const title =
                         catId
-                            .replace(/([A-Z])/g, ' $1')
+                            .replace(/([a-z])([A-Z])/g, '$1 $2')
+                            .replace(/([A-Z])([A-Z][a-z])/g, '$1 $2')
                             .trim()
                             .replace(/^./, (str) => str.toUpperCase()) + ' Configuration';
                     return showPanel(player, item.actionValue, { ...context, page: 1, customTitle: title });


### PR DESCRIPTION
Fixed the title generation logic for subcategories in the configuration panel.

Previously, `configPanel.ts` used `.replace(/([A-Z])/g, ' $1')` to separate camelCase subcategory IDs into titles, which failed for consecutive capital letters (e.g., changing `URLConfig` to `U R L Config`).

Replaced the simple regex with `.replace(/([a-z])([A-Z])/g, '$1 $2').replace(/([A-Z])([A-Z][a-z])/g, '$1 $2')` to properly handle standard camelCase as well as acronyms.

---
*PR created automatically by Jules for task [8335218200451332342](https://jules.google.com/task/8335218200451332342) started by @SjnExe*