### PR TITLE
feat: compress wordle word pool at build time

### DIFF
--- a/decompress_test.ts
+++ b/decompress_test.ts
@@ -1,0 +1,30 @@
+const compressedWordPool: Record<number, string> = {
+    4: 'abcd0efgh',
+    5: 'apple4y0zebra'
+};
+
+const plainWordPool: Record<number, string> = {};
+
+for (const [lenStr, compressed] of Object.entries(compressedWordPool)) {
+    const wordLen = parseInt(lenStr, 10);
+    if (!compressed) {
+        plainWordPool[wordLen] = '';
+        continue;
+    }
+
+    let decompressed = compressed.substring(0, wordLen);
+    let prevWord = decompressed;
+    let idx = wordLen;
+    while (idx < compressed.length) {
+        const shared = parseInt(compressed[idx], 36);
+        idx++;
+        const restLen = wordLen - shared;
+        const restStr = compressed.substring(idx, idx + restLen);
+        idx += restLen;
+        const currWord = prevWord.substring(0, shared) + restStr;
+        decompressed += currWord;
+        prevWord = currWord;
+    }
+    plainWordPool[wordLen] = decompressed;
+}
+console.log(plainWordPool);

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -281,6 +281,46 @@ async function compileScripts(versionArray: number[]) {
 
     const versionArrayStr = `[${versionArray.join(', ')}]`;
 
+    // Compress word pool plugin
+    const wordPoolCompressPlugin = {
+        name: 'wordpool-compress',
+        setup(build: import('bun').PluginBuilder) {
+            build.onLoad({ filter: /src[\\/]features[\\/]games[\\/]wordle[\\/]wordPool\.ts$/ }, async (args) => {
+                const content = await Bun.file(args.path).text();
+                const replaced = content.replace(/(\d+):\s*'([a-z]+)'/g, (match, lenStr, plainWords) => {
+                    const wordLen = parseInt(lenStr, 10);
+                    const words = [];
+                    for (let i = 0; i < plainWords.length; i += wordLen) {
+                        words.push(plainWords.substring(i, i + wordLen));
+                    }
+
+                    const SOLUTION_LIMIT = 500;
+                    const solutions = words.slice(0, SOLUTION_LIMIT).sort();
+                    const rest = words.slice(SOLUTION_LIMIT).sort();
+                    const combined = [...solutions, ...rest];
+
+                    if (combined.length === 0) return match;
+
+                    let compressed = combined[0];
+                    for (let i = 1; i < combined.length; i++) {
+                        const prev = combined[i - 1];
+                        const curr = combined[i];
+                        let shared = 0;
+                        while (shared < wordLen && prev[shared] === curr[shared]) {
+                            shared++;
+                        }
+                        compressed += shared.toString(36) + curr.substring(shared);
+                    }
+                    return `${lenStr}: '${compressed}'`;
+                });
+                return {
+                    contents: replaced,
+                    loader: 'ts'
+                };
+            });
+        }
+    };
+
     // Dynamic import interceptor
     const dynamicImportPlugin = {
         name: 'dynamic-import-resolver',
@@ -324,7 +364,7 @@ async function compileScripts(versionArray: number[]) {
         define: {
             __IS_NIGHTLY__: String(isNightly)
         },
-        plugins: [commandIndexPlugin, dynamicImportPlugin],
+        plugins: [commandIndexPlugin, dynamicImportPlugin, wordPoolCompressPlugin],
         external: ['@minecraft/server', '@minecraft/server-ui', '@minecraft/server-gametest', '@minecraft/debug-utilities', '@minecraft/common', ...externalConfigs]
     });
 

--- a/src/features/games/wordle/wordPool.ts
+++ b/src/features/games/wordle/wordPool.ts
@@ -11,18 +11,59 @@ export const compressedWordPool: Record<number, string> = {
 // N = 500 means the first 500 words (including Minecraft words + top english words) are possible solutions.
 const SOLUTION_LIMIT = 500;
 
+const decompressedWordPool: Record<number, string> = {};
+
+function getPool(length: number): string {
+    if (decompressedWordPool[length] !== undefined) {
+        return decompressedWordPool[length] as string;
+    }
+
+    const compressed = compressedWordPool[length];
+    if (!compressed) {
+        decompressedWordPool[length] = '';
+        return '';
+    }
+
+    // Try to see if it's compressed or plain. The compression logic replaces
+    // letters with digits or relies on the first word being fully intact.
+    // By definition of our prefix compression, the very first character of the second block is a base36 digit.
+    // If it's the raw original format (during dev/tests before build), it'll just be all alphabetical.
+    // We can just check if there are any numbers.
+    if (!/\d/.test(compressed) && !compressed.includes('0')) {
+        decompressedWordPool[length] = compressed;
+        return compressed;
+    }
+
+    let decompressed = compressed.substring(0, length);
+    let prevWord = decompressed;
+    let idx = length;
+    while (idx < compressed.length) {
+        const shared = parseInt(compressed[idx] as string, 36);
+        idx++;
+        const restLen = length - shared;
+        const restStr = compressed.substring(idx, idx + restLen);
+        idx += restLen;
+        const currWord = prevWord.substring(0, shared) + restStr;
+        decompressed += currWord;
+        prevWord = currWord;
+    }
+
+    decompressedWordPool[length] = decompressed;
+    return decompressed;
+}
+
 export function isValidWord(word: string): boolean {
     const len = word.length;
-    const pool = compressedWordPool[len];
+    const pool = getPool(len);
     if (!pool) return false;
 
-    // In a compressed string of fixed-length words, check if it's a multiple of length
+    // In a continuous string of fixed-length words, check if it's a multiple of length
     const idx = pool.indexOf(word.toLowerCase());
     return idx !== -1 && idx % len === 0;
 }
 
 export function getRandomSolution(length: number): string | undefined {
-    const pool = compressedWordPool[length];
+    const pool = getPool(length);
     if (!pool) return undefined;
 
     const maxWordsInPool = pool.length / length;

--- a/update-plan.md
+++ b/update-plan.md
@@ -1,22 +1,22 @@
 1. **Create an inline plugin to compress the wordPool during build**
-   - Add a new esbuild plugin in `scripts/build.ts` that intercepts the loading of `src/features/games/wordle/wordPool.ts`.
-   - The plugin will parse the plain string representation of words.
-   - It will slice it into words of length `L`.
-   - It will sort the first `SOLUTION_LIMIT` words separately from the rest of the pool.
-   - It will compress the combined sorted array using prefix compression (where each word is stored as a single base36 digit representing how many starting characters it shares with the previous word, followed by the rest of the word).
-   - The plugin returns the modified content to the bundler.
+    - Add a new esbuild plugin in `scripts/build.ts` that intercepts the loading of `src/features/games/wordle/wordPool.ts`.
+    - The plugin will parse the plain string representation of words.
+    - It will slice it into words of length `L`.
+    - It will sort the first `SOLUTION_LIMIT` words separately from the rest of the pool.
+    - It will compress the combined sorted array using prefix compression (where each word is stored as a single base36 digit representing how many starting characters it shares with the previous word, followed by the rest of the word).
+    - The plugin returns the modified content to the bundler.
 
 2. **Update `src/features/games/wordle/wordPool.ts`**
-   - Change `compressedWordPool` to plain strings (uncompressed, just continuous strings of length `N` characters per word). The name of the variable can stay `compressedWordPool` for less breakage, or we can change it to `wordPool` and handle the decompression at runtime. Let's rename it to `wordPool` inside this file but keep the export if needed. Let's rename the constant to `compressedWordPool` inside `wordPool.ts`, wait, the prompt says "the wordpool should be plain(can be in the format where every 5 letter words are one string with no divider), and the build step will compress it".
-   - It's already in that format right now! Currently `compressedWordPool` just holds plain strings of words. Wait, no, `compressedWordPool` IS currently a plain string of words! "compressedWordPool" is a misnomer in the existing code.
-   - We will rename `compressedWordPool` to `wordPool` in `wordPool.ts` to be accurate. But wait, we'll keep `compressedWordPool` but add decompression logic.
-   - Actually, let's create a new `decompressedWordPool` variable initialized lazily.
-   - The string inside `compressedWordPool` will be prefix-compressed by the build step.
-   - In `wordPool.ts`, we write a decompression function that takes the compressed string and returns the plain string or an array of strings, or just modifies `isValidWord` to work with the decompressed version.
-   - Since memory is a bit of a concern, we should decompress it into a single long string or array of strings at runtime.
-   - Update `isValidWord` and `getRandomSolution` to use the decompressed pool.
+    - Change `compressedWordPool` to plain strings (uncompressed, just continuous strings of length `N` characters per word). The name of the variable can stay `compressedWordPool` for less breakage, or we can change it to `wordPool` and handle the decompression at runtime. Let's rename it to `wordPool` inside this file but keep the export if needed. Let's rename the constant to `compressedWordPool` inside `wordPool.ts`, wait, the prompt says "the wordpool should be plain(can be in the format where every 5 letter words are one string with no divider), and the build step will compress it".
+    - It's already in that format right now! Currently `compressedWordPool` just holds plain strings of words. Wait, no, `compressedWordPool` IS currently a plain string of words! "compressedWordPool" is a misnomer in the existing code.
+    - We will rename `compressedWordPool` to `wordPool` in `wordPool.ts` to be accurate. But wait, we'll keep `compressedWordPool` but add decompression logic.
+    - Actually, let's create a new `decompressedWordPool` variable initialized lazily.
+    - The string inside `compressedWordPool` will be prefix-compressed by the build step.
+    - In `wordPool.ts`, we write a decompression function that takes the compressed string and returns the plain string or an array of strings, or just modifies `isValidWord` to work with the decompressed version.
+    - Since memory is a bit of a concern, we should decompress it into a single long string or array of strings at runtime.
+    - Update `isValidWord` and `getRandomSolution` to use the decompressed pool.
 
 3. **Complete pre commit steps**
-   - Complete pre commit steps to make sure proper testing, verifications, reviews and reflections are done.
+    - Complete pre commit steps to make sure proper testing, verifications, reviews and reflections are done.
 
 4. **Submit**

--- a/update-plan.md
+++ b/update-plan.md
@@ -1,0 +1,22 @@
+1. **Create an inline plugin to compress the wordPool during build**
+   - Add a new esbuild plugin in `scripts/build.ts` that intercepts the loading of `src/features/games/wordle/wordPool.ts`.
+   - The plugin will parse the plain string representation of words.
+   - It will slice it into words of length `L`.
+   - It will sort the first `SOLUTION_LIMIT` words separately from the rest of the pool.
+   - It will compress the combined sorted array using prefix compression (where each word is stored as a single base36 digit representing how many starting characters it shares with the previous word, followed by the rest of the word).
+   - The plugin returns the modified content to the bundler.
+
+2. **Update `src/features/games/wordle/wordPool.ts`**
+   - Change `compressedWordPool` to plain strings (uncompressed, just continuous strings of length `N` characters per word). The name of the variable can stay `compressedWordPool` for less breakage, or we can change it to `wordPool` and handle the decompression at runtime. Let's rename it to `wordPool` inside this file but keep the export if needed. Let's rename the constant to `compressedWordPool` inside `wordPool.ts`, wait, the prompt says "the wordpool should be plain(can be in the format where every 5 letter words are one string with no divider), and the build step will compress it".
+   - It's already in that format right now! Currently `compressedWordPool` just holds plain strings of words. Wait, no, `compressedWordPool` IS currently a plain string of words! "compressedWordPool" is a misnomer in the existing code.
+   - We will rename `compressedWordPool` to `wordPool` in `wordPool.ts` to be accurate. But wait, we'll keep `compressedWordPool` but add decompression logic.
+   - Actually, let's create a new `decompressedWordPool` variable initialized lazily.
+   - The string inside `compressedWordPool` will be prefix-compressed by the build step.
+   - In `wordPool.ts`, we write a decompression function that takes the compressed string and returns the plain string or an array of strings, or just modifies `isValidWord` to work with the decompressed version.
+   - Since memory is a bit of a concern, we should decompress it into a single long string or array of strings at runtime.
+   - Update `isValidWord` and `getRandomSolution` to use the decompressed pool.
+
+3. **Complete pre commit steps**
+   - Complete pre commit steps to make sure proper testing, verifications, reviews and reflections are done.
+
+4. **Submit**


### PR DESCRIPTION
This PR implements build-time prefix compression for the Wordle word pool. The source file remains plain text for easy modification, but the build script compresses consecutive alphabetical words sharing identical prefixes. A lazy decompression function unpacks this at runtime to supply a continuous plain text pool to `isValidWord` and `getRandomSolution`. This significantly cuts down bundle size without sacrificing performance or changing functionality.

---
*PR created automatically by Jules for task [12928611038211339346](https://jules.google.com/task/12928611038211339346) started by @SjnExe*