### PR TITLE
🧹 Consolidate duplicate home/warp teleport logic

### DIFF
--- a/src/features/teleport/commands/home.ts
+++ b/src/features/teleport/commands/home.ts
@@ -3,15 +3,13 @@ import { ActionFormData, ActionFormResponse } from '@minecraft/server-ui';
 
 import { CommandExecutor, CustomCommand } from '@commands/commandManager.js';
 import { getConfig } from '@core/configManager.js';
-import { setCooldown } from '@core/cooldownManager.js';
 import { errorLog } from '@core/logger.js';
 import { sendMessage } from '@core/messaging.js';
-import { startTeleportWarmup } from '@core/teleportLogic.js';
 import { uiWait } from '@core/utils.js';
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
 
 import * as homesManager from '@features/teleport/homesManager.js';
-import { saveLastLocation } from '@features/teleport/utils.js';
+import { executeTeleport } from '@features/teleport/utils.js';
 
 interface HomeCommandArgs {
     homeName?: string;
@@ -41,26 +39,15 @@ const homeCommand: CustomCommand = {
                 return;
             }
 
-            const warmupSeconds = config.homes.teleportWarmupSeconds;
-            const teleportLogic = () => {
-                try {
-                    saveLastLocation(executor);
-                    const dimension = mc.world.getDimension(homeLocation.dimensionId);
-                    if (isDefined(dimension)) {
-                        executor.teleport(homeLocation, { dimension });
-                        sendMessage(`§aTeleported to home '${homeName}'.`, executor);
-                        setCooldown(executor.id, 'homes', config.homes.cooldownSeconds);
-                    } else {
-                        sendMessage(`§cError: Dimension '${homeLocation.dimensionId}' not found.`, executor);
-                    }
-                } catch (error: unknown) {
-                    const message = error instanceof Error ? error.message : String(error);
-                    const stack = error instanceof Error ? error.stack : String(error);
-                    sendMessage(`§cFailed to teleport. Error: ${message}`, executor);
-                    errorLog(`[/home] Failed to teleport: ${stack}`);
-                }
-            };
-            startTeleportWarmup(executor, warmupSeconds, teleportLogic, `home '${homeName}'`);
+            executeTeleport({
+                executor,
+                location: homeLocation,
+                destinationName: homeName,
+                teleportType: 'home',
+                warmupSeconds: config.homes.teleportWarmupSeconds,
+                cooldownSeconds: config.homes.cooldownSeconds,
+                cooldownKey: 'homes'
+            });
         };
 
         const homeNameArg = args.homeName;

--- a/src/features/teleport/commands/warp.ts
+++ b/src/features/teleport/commands/warp.ts
@@ -3,14 +3,12 @@ import { ActionFormData, ActionFormResponse } from '@minecraft/server-ui';
 
 import { CommandExecutor, CustomCommand } from '@commands/commandManager.js';
 import { getConfig } from '@core/configManager.js';
-import { setCooldown } from '@core/cooldownManager.js';
 import { errorLog } from '@core/logger.js';
 import { sendMessage } from '@core/messaging.js';
-import { startTeleportWarmup } from '@core/teleportLogic.js';
 import { uiWait } from '@core/utils.js';
 import { isDefined, isNonEmptyString, isNumber } from '@lib/guards.js';
 
-import { saveLastLocation } from '@features/teleport/utils.js';
+import { executeTeleport } from '@features/teleport/utils.js';
 import * as warpsManager from '@features/teleport/warpsManager.js';
 
 interface WarpCommandArgs {
@@ -54,26 +52,15 @@ const warpCommand: CustomCommand = {
                 return;
             }
 
-            const warmupSeconds = config.warps.teleportWarmupSeconds;
-            const teleportLogic = () => {
-                try {
-                    saveLastLocation(executor);
-                    const dimension = mc.world.getDimension(warpLocation.dimensionId);
-                    if (isDefined(dimension)) {
-                        executor.teleport(warpLocation, { dimension });
-                        sendMessage(`§aTeleported to warp '${warpName}'.`, executor);
-                        setCooldown(executor.id, 'warp', config.warps.cooldownSeconds);
-                    } else {
-                        sendMessage(`§cError: Dimension '${warpLocation.dimensionId}' not found.`, executor);
-                    }
-                } catch (error: unknown) {
-                    if (error instanceof Error) {
-                        sendMessage(`§cFailed to teleport. Error: ${error.message}`, executor);
-                        errorLog(`[/warp] Failed to teleport: ${error.stack}`);
-                    }
-                }
-            };
-            startTeleportWarmup(executor, warmupSeconds, teleportLogic, `warp '${warpName}'`);
+            executeTeleport({
+                executor,
+                location: warpLocation,
+                destinationName: warpName,
+                teleportType: 'warp',
+                warmupSeconds: config.warps.teleportWarmupSeconds,
+                cooldownSeconds: config.warps.cooldownSeconds,
+                cooldownKey: 'warp'
+            });
         };
 
         const warpNameArg = (args as unknown as WarpCommandArgs).warpName;

--- a/src/features/teleport/utils.ts
+++ b/src/features/teleport/utils.ts
@@ -1,7 +1,11 @@
 import * as mc from '@minecraft/server';
 
 import { getConfig } from '@core/configManager.js';
+import { setCooldown } from '@core/cooldownManager.js';
+import { errorLog } from '@core/logger.js';
+import { sendMessage } from '@core/messaging.js';
 import { setPlayerLastLocation } from '@core/playerDataManager.js';
+import { startTeleportWarmup } from '@core/teleportLogic.js';
 import { isDefined } from '@lib/guards.js';
 
 /**
@@ -81,4 +85,42 @@ export function findSafeLocation(dimension: mc.Dimension, location: mc.Vector3):
         }
     }
     return undefined;
+}
+
+export interface ExecuteTeleportParams {
+    executor: mc.Player;
+    location: mc.Vector3 & { dimensionId: string };
+    destinationName: string;
+    teleportType: string;
+    warmupSeconds: number;
+    cooldownSeconds: number;
+    cooldownKey: string;
+}
+
+/**
+ * Consolidates the common teleport logic including warmup, dimension resolving, cooldown setting, and error logging.
+ */
+export function executeTeleport(params: ExecuteTeleportParams): void {
+    const { executor, location, destinationName, teleportType, warmupSeconds, cooldownSeconds, cooldownKey } = params;
+
+    const teleportLogic = () => {
+        try {
+            saveLastLocation(executor);
+            const dimension = mc.world.getDimension(location.dimensionId);
+            if (isDefined(dimension)) {
+                executor.teleport(location, { dimension });
+                sendMessage(`§aTeleported to ${teleportType} '${destinationName}'.`, executor);
+                setCooldown(executor.id, cooldownKey, cooldownSeconds);
+            } else {
+                sendMessage(`§cError: Dimension '${location.dimensionId}' not found.`, executor);
+            }
+        } catch (error: unknown) {
+            const message = error instanceof Error ? error.message : String(error);
+            const stack = error instanceof Error ? error.stack : String(error);
+            sendMessage(`§cFailed to teleport. Error: ${message}`, executor);
+            errorLog(`[/${teleportType}] Failed to teleport: ${stack}`);
+        }
+    };
+
+    startTeleportWarmup(executor, warmupSeconds, teleportLogic, `${teleportType} '${destinationName}'`);
 }


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the duplication of nearly identical teleportation setup and execution logic across the `/home` and `/warp` commands.
💡 **Why:** Consolidating this pattern into a shared `executeTeleport` helper improves maintainability. Any future changes to the teleport logic (e.g., how warmup delays or error logging operate) can now be applied consistently from one place instead of patching multiple command files.
✅ **Verification:** Verified by checking types with `bun run build` and checking file modifications with `bun run lint`. The automated test suite (`bun test`) passed safely (the existing pre-related failures were unrelated to this teleportation utility).
✨ **Result:** A cleaner structure in the command files with the core sequence neatly encapsulated into a parameterizable utility function, cutting redundant boilerplate.

---
*PR created automatically by Jules for task [17428304466106139780](https://jules.google.com/task/17428304466106139780) started by @SjnExe*