### PR TITLE
🧹 [Code Health] Refactor parseRankOverrides duplicate code

### DIFF
--- a/src/features/shop/ui/adminPanel.ts
+++ b/src/features/shop/ui/adminPanel.ts
@@ -6,7 +6,7 @@ import { getShopConfig } from '@core/configurations.js';
 import { showPanel } from '@core/uiManager.js';
 import * as shopAdminManager from '@features/shop/adminManager.js';
 import { ShopCategory } from '@features/shop/shopConfig.js';
-import { ensureItemsConfig, getAllItems } from '@features/shop/utils.js';
+import { ensureItemsConfig, getAllItems, parseRankOverrides } from '@features/shop/utils.js';
 import { isDefined, isNonEmptyString, isNumber, isString } from '@lib/guards.js';
 import { showConfirmationDialog } from '@ui/components.js';
 import { IPanelHandler, MainConfig, PanelItem, ShopItem, UIContext } from '@ui/types.js';
@@ -627,29 +627,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
         const sellPrice = Number.parseInt(isNonEmptyString(sellPriceStr) ? sellPriceStr : '-1', 10);
         const permission = isNonEmptyString(permLevelStr) ? permLevelStr : 'ui.panel.member';
 
-        let parsedOverrides: Record<string, { buy: number; sell: number }> | undefined = undefined;
-
-        if (isNonEmptyString(overridesRaw)) {
-            parsedOverrides = {};
-            const pairs = overridesRaw.split(';');
-            for (const pair of pairs) {
-                const parts = pair.trim().split('=');
-                if (parts.length === 2 && isNonEmptyString(parts[0]) && isNonEmptyString(parts[1])) {
-                    const rankId = parts[0].trim();
-                    const multiParts = parts[1].split(',');
-                    if (multiParts.length === 2) {
-                        const buyM = Number.parseFloat(multiParts[0]!);
-                        const sellM = Number.parseFloat(multiParts[1]!);
-                        if (!Number.isNaN(buyM) && !Number.isNaN(sellM)) {
-                            parsedOverrides[rankId] = { buy: buyM, sell: sellM };
-                        }
-                    }
-                }
-            }
-            if (Object.keys(parsedOverrides).length === 0) {
-                parsedOverrides = undefined;
-            }
-        }
+        const parsedOverrides = parseRankOverrides(overridesRaw);
 
         if (isNonEmptyString(customId) && isNonEmptyString(displayName) && isNonEmptyString(mcId) && !Number.isNaN(buyPrice)) {
             shopAdminManager.addCustomItemToConfig(customId, {
@@ -697,29 +675,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
         const sellPrice = Number.parseInt(isNonEmptyString(sellPriceStr) ? sellPriceStr : '-1', 10);
         const permission = isNonEmptyString(permLevelStr) ? permLevelStr : 'ui.panel.member';
 
-        let parsedOverrides: Record<string, { buy: number; sell: number }> | undefined = undefined;
-
-        if (isNonEmptyString(overridesRaw)) {
-            parsedOverrides = {};
-            const pairs = overridesRaw.split(';');
-            for (const pair of pairs) {
-                const parts = pair.trim().split('=');
-                if (parts.length === 2 && isNonEmptyString(parts[0]) && isNonEmptyString(parts[1])) {
-                    const rankId = parts[0].trim();
-                    const multiParts = parts[1].split(',');
-                    if (multiParts.length === 2) {
-                        const buyM = Number.parseFloat(multiParts[0]!);
-                        const sellM = Number.parseFloat(multiParts[1]!);
-                        if (!Number.isNaN(buyM) && !Number.isNaN(sellM)) {
-                            parsedOverrides[rankId] = { buy: buyM, sell: sellM };
-                        }
-                    }
-                }
-            }
-            if (Object.keys(parsedOverrides).length === 0) {
-                parsedOverrides = undefined;
-            }
-        }
+        const parsedOverrides = parseRankOverrides(overridesRaw);
 
         if (!Number.isNaN(buyPrice) && isDefined(masterItem)) {
             shopAdminManager.setItem(context.categoryName as string, (context.subCategoryName as string) || undefined, itemId, {
@@ -758,29 +714,7 @@ export class ShopAdminPanelHandler implements IPanelHandler {
         const pLevel = vals[5];
         const overridesRaw = vals[6] ?? '';
 
-        let parsedOverrides: Record<string, { buy: number; sell: number }> | undefined = undefined;
-
-        if (isNonEmptyString(overridesRaw)) {
-            parsedOverrides = {};
-            const pairs = overridesRaw.split(';');
-            for (const pair of pairs) {
-                const parts = pair.trim().split('=');
-                if (parts.length === 2 && isNonEmptyString(parts[0]) && isNonEmptyString(parts[1])) {
-                    const rankId = parts[0].trim();
-                    const multiParts = parts[1].split(',');
-                    if (multiParts.length === 2) {
-                        const buyM = Number.parseFloat(multiParts[0]!);
-                        const sellM = Number.parseFloat(multiParts[1]!);
-                        if (!Number.isNaN(buyM) && !Number.isNaN(sellM)) {
-                            parsedOverrides[rankId] = { buy: buyM, sell: sellM };
-                        }
-                    }
-                }
-            }
-            if (Object.keys(parsedOverrides).length === 0) {
-                parsedOverrides = undefined;
-            }
-        }
+        const parsedOverrides = parseRankOverrides(overridesRaw);
 
         shopAdminManager.updateShopItem(categoryName, subCategoryName ?? undefined, itemId, {
             buyPrice: isDefined(bPrice) ? Number(bPrice) : -1,

--- a/src/features/shop/utils.ts
+++ b/src/features/shop/utils.ts
@@ -1,4 +1,5 @@
 import { loadConfig } from '@core/configLoader.js';
+import { isNonEmptyString } from '@lib/guards.js';
 
 export interface Item {
     displayName?: string;
@@ -34,4 +35,36 @@ export async function ensureItemsConfig() {
  */
 export function getAllItems(): Record<string, Item> {
     return allItems;
+}
+
+/**
+ * Parses rank override string into a record of multipliers.
+ * @param overridesRaw String format "rank1=buy,sell;rank2=buy,sell"
+ */
+export function parseRankOverrides(overridesRaw: string | undefined): Record<string, { buy: number; sell: number }> | undefined {
+    let parsedOverrides: Record<string, { buy: number; sell: number }> | undefined = undefined;
+
+    if (isNonEmptyString(overridesRaw)) {
+        parsedOverrides = {};
+        const pairs = overridesRaw.split(';');
+        for (const pair of pairs) {
+            const parts = pair.trim().split('=');
+            if (parts.length === 2 && isNonEmptyString(parts[0]) && isNonEmptyString(parts[1])) {
+                const rankId = parts[0].trim();
+                const multiParts = parts[1].split(',');
+                if (multiParts.length === 2) {
+                    const buyM = Number.parseFloat(multiParts[0]!);
+                    const sellM = Number.parseFloat(multiParts[1]!);
+                    if (!Number.isNaN(buyM) && !Number.isNaN(sellM)) {
+                        parsedOverrides[rankId] = { buy: buyM, sell: sellM };
+                    }
+                }
+            }
+        }
+        if (Object.keys(parsedOverrides).length === 0) {
+            parsedOverrides = undefined;
+        }
+    }
+
+    return parsedOverrides;
 }


### PR DESCRIPTION
🎯 **What:** The duplicated logic to parse `overridesRaw` rank multiplier overrides into a `Record<string, { buy: number; sell: number }>` was extracted to a utility function and the redundant inline implementations were replaced with function calls.
💡 **Why:** This drastically reduces the size of the `ShopAdminPanelHandler` functions handling shop item modifications, reducing code duplication and centralizing the parsing logic to one reusable utility in `src/features/shop/utils.ts`.
✅ **Verification:** Re-ran unit tests and ensured that there are no regressions. Code review marked as #Correct#.
✨ **Result:** A more maintainable and readable `adminPanel.ts` without repeated inline code.

---
*PR created automatically by Jules for task [8966949973453318892](https://jules.google.com/task/8966949973453318892) started by @SjnExe*