### PR TITLE
🔒 Fix command injection via player name in AntiCheat punishment

### DIFF
--- a/src/features/anticheat/__tests__/FlagManager.test.ts
+++ b/src/features/anticheat/__tests__/FlagManager.test.ts
@@ -1,0 +1,105 @@
+import * as mc from '@minecraft/server';
+import { describe, expect, it, mock } from 'bun:test';
+
+import { MockConstructable } from '@core/__tests__/__mocks__/utils.js';
+import { escapeCommandArg } from '@core/utils.js';
+
+// Mock formatString and escapeCommandArg
+const mockFormatString = mock((template: string, context: any) => {
+    let result = template;
+    for (const key in context) {
+        result = result.replaceAll(`{${key}}`, context[key]);
+    }
+    return result;
+});
+
+mock.module('@core/utils.js', () => ({
+    formatString: mockFormatString,
+    escapeCommandArg: escapeCommandArg,
+    sanitizeString: (str: string) => str // Need this just in case as utils imports a lot of things
+}));
+
+mock.module('@core/logger.js', () => ({
+    debugLog: mock(),
+    errorLog: mock()
+}));
+
+// Mock minimal dependencies of flagManager
+mock.module('@core/playerCache.js', () => ({
+    getAllPlayersFromCache: mock()
+}));
+
+mock.module('@core/playerDataManager.js', () => ({
+    getPlayer: mock()
+}));
+
+mock.module('@core/storage/StorageManager.js', () => ({
+    StorageManager: class {
+        load() {
+            return undefined;
+        }
+        save() {}
+    }
+}));
+
+mock.module('@lib/guards.js', () => ({
+    isDefined: (val: any) => val !== undefined && val !== null
+}));
+
+mock.module('@features/anticheat/anticheatConfig.js', () => ({}));
+mock.module('@features/anticheat/configLoader.js', () => ({
+    getAnticheatConfig: mock()
+}));
+mock.module('@features/anticheat/logManager.js', () => ({
+    addFlagLog: mock()
+}));
+
+// Import after mocking
+const { executePunishment } = await import('../flagManager.js');
+
+describe('FlagManager', () => {
+    it('executePunishment should sanitize player names to prevent command injection', () => {
+        const PlayerMock = mc.Player as unknown as MockConstructable<mc.Player>;
+        // Create a malicious player name containing quotes
+        const maliciousName = 'Hacker" ] } ; kill @a ; #';
+        const player = new PlayerMock('p1', maliciousName);
+
+        const mockRunCommand = mock();
+        Object.defineProperty(player, 'dimension', {
+            value: { runCommand: mockRunCommand },
+            writable: true
+        });
+
+        // The config defines punishments like "kick {player} Illegal Items"
+        const commandTemplate = 'kick {player} Illegal Items';
+
+        // Run the punishment
+        executePunishment(player, commandTemplate);
+
+        const expectedSafeName = maliciousName.replaceAll('"', "'");
+        const expectedCmd = `kick "${expectedSafeName}" Illegal Items`;
+
+        expect(mockRunCommand).toHaveBeenCalledWith(expectedCmd);
+    });
+
+    it('executePunishment should handle template with manual quotes', () => {
+        const PlayerMock = mc.Player as unknown as MockConstructable<mc.Player>;
+        const maliciousName = 'Hacker" ] } ; kill @a ; #';
+        const player = new PlayerMock('p1', maliciousName);
+
+        const mockRunCommand = mock();
+        Object.defineProperty(player, 'dimension', {
+            value: { runCommand: mockRunCommand },
+            writable: true
+        });
+
+        const commandTemplate = 'kick "{player}" Illegal Items';
+
+        executePunishment(player, commandTemplate);
+
+        const expectedSafeName = maliciousName.replaceAll('"', "'");
+        const expectedCmd = `kick "${expectedSafeName}" Illegal Items`;
+
+        expect(mockRunCommand).toHaveBeenCalledWith(expectedCmd);
+    });
+});

--- a/src/features/anticheat/flagManager.ts
+++ b/src/features/anticheat/flagManager.ts
@@ -4,7 +4,7 @@ import { debugLog, errorLog, warnLog } from '@core/logger.js';
 import { getAllPlayersFromCache } from '@core/playerCache.js';
 import { getPlayer } from '@core/playerDataManager.js';
 import { StorageManager } from '@core/storage/StorageManager.js';
-import { formatString } from '@core/utils.js';
+import { escapeCommandArg, formatString } from '@core/utils.js';
 import { isDefined } from '@lib/guards.js';
 
 import { BaseCheckConfig } from '@features/anticheat/anticheatConfig.js';
@@ -101,8 +101,10 @@ function notifyAdmins(suspect: mc.Player, check: string, vl: number, info: strin
     }
 }
 
-function executePunishment(player: mc.Player, commandTemplate: string) {
-    const cmd = formatString(commandTemplate, { player: player.name });
+export function executePunishment(player: mc.Player, commandTemplate: string) {
+    const safePlayerName = escapeCommandArg(player.name);
+    const normalizedTemplate = commandTemplate.replaceAll('"{player}"', '{player}').replaceAll("'{player}'", '{player}');
+    const cmd = formatString(normalizedTemplate, { player: `"${safePlayerName}"` });
     try {
         player.dimension.runCommand(cmd);
         debugLog(`[AntiCheat] Executed: ${cmd}`);


### PR DESCRIPTION
🎯 **What:** Command injection vulnerability via the `{player}` placeholder in AntiCheat punishment templates.
⚠️ **Risk:** A player with quotes in their name could escape the string and append arbitrary commands, achieving unauthorized command execution.
🛡️ **Solution:** Used `escapeCommandArg` from core utilities to sanitize the player's name and ensure it is safely wrapped in double quotes when injecting into the command template. Normalized the command template first to prevent double-quoting issues. Added unit tests to verify the fix.

---
*PR created automatically by Jules for task [6366751562515747990](https://jules.google.com/task/6366751562515747990) started by @SjnExe*