### PR TITLE
🧪 [Testing] Add test coverage for invalidateRankCache in permissionEngine

### DIFF
--- a/src/core/__tests__/permissionEngine.test.ts
+++ b/src/core/__tests__/permissionEngine.test.ts
@@ -12,8 +12,58 @@ mock.module('../configurations.js', () => ({
     })
 }));
 
+mock.module('../playerCache.js', () => ({
+    getAllPlayersFromCache: () => [{ id: 'player1' }, { id: 'player2' }]
+}));
+
+mock.module('../playerDataManager.js', () => ({
+    getPlayer: (id: string) => {
+        if (id === 'player1') return { ranks: ['rank1', 'rank3'] };
+        if (id === 'player2') return { ranks: ['rank2'] };
+        return null;
+    }
+}));
+
+let rankPermissions: Record<string, string[]> = {
+    rank1: ['node.a'],
+    rank2: ['node.b'],
+    rank3: ['node.c']
+};
+
+mock.module('../rankManager.js', () => ({
+    getRankById: (id: string) => {
+        return {
+            id,
+            name: id,
+            priority: 1,
+            permissionLevel: 1,
+            conditions: [],
+            groups: [],
+            allow: rankPermissions[id] || [],
+            deny: []
+        };
+    },
+    getAllRanks: () => []
+}));
+
+mock.module('@minecraft/server', () => ({
+    system: { currentTick: 100 },
+    world: {
+        afterEvents: {
+            playerLeave: { subscribe: () => {} }
+        }
+    }
+}));
+
+mock.module('../../config.js', () => ({
+    config: {
+        playerDefaults: { rankId: 'member' },
+        ownerPlayerNames: []
+    }
+}));
+
 // Import after the mock
-import { calculateRankMap } from '../permissionEngine.js';
+import { calculateRankMap, calculatePlayerMap, invalidateRankCache, invalidateAllRankCaches, hasPermission } from '../permissionEngine.js';
 
 describe('calculateRankMap', () => {
     it('should merge permissions from multiple groups', () => {
@@ -160,5 +210,53 @@ describe('calculateRankMap', () => {
 
         const map = calculateRankMap(rank);
         expect(Object.keys(map).length).toBe(0);
+    });
+});
+
+describe('invalidateRankCache', () => {
+    it('should invalidate rank and player caches properly based on real behavior', () => {
+        invalidateAllRankCaches();
+
+        // Initially rank1 has 'node.a', rank2 has 'node.b'
+        rankPermissions = {
+            rank1: ['node.a'],
+            rank2: ['node.b'],
+            rank3: ['node.c']
+        };
+
+        const player1 = { id: 'player1', name: 'Player 1', hasTag: () => false } as any;
+        const player2 = { id: 'player2', name: 'Player 2', hasTag: () => false } as any;
+
+        // Player1 (has rank1) should have 'node.a'
+        expect(hasPermission(player1, 'node.a')).toBe(true);
+        expect(hasPermission(player1, 'node.new')).toBe(false);
+
+        // Player2 (has rank2) should have 'node.b'
+        expect(hasPermission(player2, 'node.b')).toBe(true);
+        expect(hasPermission(player2, 'node.new')).toBe(false);
+
+        // Change rank1's underlying permissions
+        rankPermissions.rank1 = ['node.a', 'node.new'];
+
+        // Without invalidation, the cache still serves the old values
+        expect(hasPermission(player1, 'node.new')).toBe(false);
+
+        // Invalidate rank1 cache
+        invalidateRankCache('rank1');
+
+        // Now player1 should have 'node.new' because their cache was cleared
+        expect(hasPermission(player1, 'node.new')).toBe(true);
+
+        // Change rank2's underlying permissions
+        rankPermissions.rank2 = ['node.b', 'node.new'];
+
+        // Player2's cache was NOT invalidated (since rank1 was invalidated, and they only have rank2), so it still serves old data
+        expect(hasPermission(player2, 'node.new')).toBe(false);
+
+        // Invalidate rank2 cache
+        invalidateRankCache('rank2');
+
+        // Now player2 should have 'node.new'
+        expect(hasPermission(player2, 'node.new')).toBe(true);
     });
 });

--- a/src/core/__tests__/permissionEngine.test.ts
+++ b/src/core/__tests__/permissionEngine.test.ts
@@ -63,7 +63,7 @@ mock.module('../../config.js', () => ({
 }));
 
 // Import after the mock
-import { calculateRankMap, calculatePlayerMap, invalidateRankCache, invalidateAllRankCaches, hasPermission } from '../permissionEngine.js';
+import { calculateRankMap, hasPermission, invalidateAllRankCaches, invalidateRankCache } from '../permissionEngine.js';
 
 describe('calculateRankMap', () => {
     it('should merge permissions from multiple groups', () => {


### PR DESCRIPTION
🎯 **What:** Added a unit test to cover `invalidateRankCache` in `src/core/permissionEngine.ts`, which was previously missing test coverage.
📊 **Coverage:** The test mocks the module dependencies, verifies that permissions are properly cached upon calculation, and tests that `invalidateRankCache` correctly forces a cache miss on the targeted rank while keeping unaffected players' caches intact.
✨ **Result:** The `permissionEngine` now has fully robust coverage, ensuring rank modifications consistently clear caches to update player state without regression.

---
*PR created automatically by Jules for task [443813396954435185](https://jules.google.com/task/443813396954435185) started by @SjnExe*