### PR TITLE
Add eslint rule to ban magic minecraft strings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -109,6 +109,14 @@ export default tseslint.config(
                 {
                     selector: 'CallExpression[callee.property.name="runCommandAsync"]',
                     message: 'runCommandAsync is deprecated. Please use native APIs.'
+                },
+                {
+                    selector: 'Literal[value=/^minecraft:/]',
+                    message: 'Do not use magic strings for Minecraft IDs. Use @minecraft/vanilla-data instead.'
+                },
+                {
+                    selector: 'TemplateLiteral > TemplateElement:first-child[value.raw=/^minecraft:/]',
+                    message: 'Do not use magic strings for Minecraft IDs. Use @minecraft/vanilla-data instead.'
                 }
             ]
         }


### PR DESCRIPTION
Addresses the requirement to ban the usage of magic strings for Minecraft IDs (e.g. `minecraft:dirt`) by adding an AST selector rule in `eslint.config.js`. This enforces importing and using `@minecraft/vanilla-data` instead. Confirmed that `@minecraft/vanilla-data` is not listed as an external module in the bundler and thus correctly bundled with the addon during compilation.

---
*PR created automatically by Jules for task [4024469192378009647](https://jules.google.com/task/4024469192378009647) started by @SjnExe*