### PR TITLE
Fix build configurations to separate nightly vs release debug artifacts and clean directories

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
             - name: Build TypeScript (Nightly)
               if: steps.build_type.outputs.type == 'nightly'
               run: |
-                  bun run build -- --nightly --build-number ${{ github.run_number }}
+                  bun run build:nightly -- --build-number ${{ github.run_number }}
               env:
                   IS_BETA_RELEASE: ${{ env.IS_BETA_RELEASE }}
 

--- a/package.json
+++ b/package.json
@@ -17,8 +17,9 @@
     "type": "module",
     "main": "index.js",
     "scripts": {
-        "build": "bun scripts/build.ts",
-        "build:release": "bun scripts/build.ts --release --minify",
+        "build": "bun clean && bun scripts/build.ts",
+        "build:nightly": "bun clean && bun scripts/build.ts --nightly",
+        "build:release": "bun clean && bun scripts/build.ts --release --minify",
         "check-deps": "bun scripts/check-dependencies.ts",
         "check-types": "bun tsc --noEmit --incremental",
         "clean": "rm -rf out packs/behavior/scripts",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -210,7 +210,8 @@ async function compileScripts(versionArray: number[], outDirSuffix: string = '')
         target: 'browser',
         format: 'esm',
         minify: isMinify,
-        sourcemap: 'external',
+        sourcemap: isRelease ? 'none' : 'external',
+        drop: isRelease ? ['debugger'] : [],
         splitting: false,
         naming: '[dir]/[name].[ext]',
         define: {


### PR DESCRIPTION
This change addresses the issue where differences between nightly and release builds were unclear, and build scripts were not starting from a clean state.

- A cleanup prefix `bun clean &&` was added to all build scripts in `package.json`. 
- `scripts/build.ts` was updated to properly clear `debugger` calls and exclude sourcemaps during `--release` mode. `console` was intentionally kept to maintain compatibility with `logger.ts`.
- The github workflow was updated to use the new `build:nightly` task.

---
*PR created automatically by Jules for task [14644257405707155832](https://jules.google.com/task/14644257405707155832) started by @SjnExe*