### PR TITLE
Fix invalid export syntax in compiled configuration files

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -257,7 +257,7 @@ async function compileScripts(versionArray: number[], outDirSuffix: string = '')
                 compilerOptions: {
                     target: ts.ScriptTarget.ESNext,
                     module: ts.ModuleKind.ESNext,
-                    removeComments: false,
+                    removeComments: false
                 }
             }).outputText;
             content = content.replace(/import\s*\{[^}]*\}\s*from\s*['"]@minecraft\/vanilla-data['"]\s*;?\n?/g, '');

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -252,7 +252,14 @@ async function compileScripts(versionArray: number[], outDirSuffix: string = '')
             });
 
             // Strip out strict TypeScript compilation types cleanly
-            content = content.replace(/\s+as\s+number\s*\|\s*undefined/g, '');
+            const ts = await import('typescript');
+            content = ts.transpileModule(content, {
+                compilerOptions: {
+                    target: ts.ScriptTarget.ESNext,
+                    module: ts.ModuleKind.ESNext,
+                    removeComments: false,
+                }
+            }).outputText;
             content = content.replace(/import\s*\{[^}]*\}\s*from\s*['"]@minecraft\/vanilla-data['"]\s*;?\n?/g, '');
 
             await fs.mkdir(path.dirname(conf.dest), { recursive: true });


### PR DESCRIPTION
The project's build script previously used regular expressions to strip out some type casting (`as number | undefined`) from user configuration files like `shopConfig.ts`. However, it left behind full TypeScript blocks, like `export interface`, which threw an "invalid export syntax" error in the Javascript runtime (Bedrock's QuickJS environment).

This PR fixes this by using the `typescript` module directly inside `build.ts` to cleanly `transpileModule` the configuration files down to `ESNext` JavaScript before writing them to the output directory. It preserves comments so users can still read and edit their configs, but completely guarantees that all TypeScript artifacts (types, interfaces, casts) are stripped out securely.

---
*PR created automatically by Jules for task [14788876645454296560](https://jules.google.com/task/14788876645454296560) started by @SjnExe*