### PR TITLE
Fix Ranks Config Merging & Permission Group Nodes

### DIFF
--- a/src/core/configManagerFactory.ts
+++ b/src/core/configManagerFactory.ts
@@ -79,12 +79,13 @@ export default function createConfigManager<T>(key: string, defaultConfig: T, na
                         break;
                     }
                     case 'Ranks': {
+                        const baseConfig = reconcileConfig(newDefaultConfig as unknown as Record<string, unknown>, lastLoadedConfigForMerge, userSavedConfig);
                         const mergedRanks = mergeRanks(
-                            userSavedConfig.rankDefinitions as Record<string, unknown>[],
+                            (userSavedConfig.rankDefinitions as Record<string, unknown>[]) || [],
                             (newDefaultConfig as unknown as { rankDefinitions: Record<string, unknown>[] }).rankDefinitions,
-                            lastLoadedConfigForMerge.rankDefinitions as Record<string, unknown>[]
+                            (lastLoadedConfigForMerge.rankDefinitions as Record<string, unknown>[]) || []
                         );
-                        currentConfig = { ...userSavedConfig, rankDefinitions: mergedRanks } as unknown as T;
+                        currentConfig = { ...baseConfig, rankDefinitions: mergedRanks } as unknown as T;
 
                         break;
                     }

--- a/src/core/configManagerFactory.ts
+++ b/src/core/configManagerFactory.ts
@@ -81,9 +81,9 @@ export default function createConfigManager<T>(key: string, defaultConfig: T, na
                     case 'Ranks': {
                         const baseConfig = reconcileConfig(newDefaultConfig as unknown as Record<string, unknown>, lastLoadedConfigForMerge, userSavedConfig);
                         const mergedRanks = mergeRanks(
-                            (userSavedConfig.rankDefinitions as Record<string, unknown>[]) || [],
+                            (userSavedConfig.rankDefinitions || []) as Record<string, unknown>[],
                             (newDefaultConfig as unknown as { rankDefinitions: Record<string, unknown>[] }).rankDefinitions,
-                            (lastLoadedConfigForMerge.rankDefinitions as Record<string, unknown>[]) || []
+                            (lastLoadedConfigForMerge.rankDefinitions || []) as Record<string, unknown>[]
                         );
                         currentConfig = { ...baseConfig, rankDefinitions: mergedRanks } as unknown as T;
 

--- a/src/features/ranks/ranksConfig.ts
+++ b/src/features/ranks/ranksConfig.ts
@@ -34,10 +34,10 @@ export const defaultChatFormatting: Required<ChatFormatting> = {
 };
 
 export const permissionGroups: Record<string, string[]> = {
-    default: ['cmd.**.member', 'ui.**.member', 'command.member'],
-    mod: ['cmd.**.mod', 'ui.**.mod'],
-    admin: ['cmd.**.admin', 'ui.**.admin'],
-    owner: ['cmd.**.owner', 'ui.**.owner']
+    default: ['**.member'],
+    mod: ['**.mod'],
+    admin: ['**.admin'],
+    owner: ['**.owner']
 };
 
 export const rankDefinitions: RankDefinition[] = [


### PR DESCRIPTION
Fixes a crash when generating rank maps where `permissionGroups` could become undefined due to improper config merging. Also updates default permission nodes to a cleaner format as requested.

---
*PR created automatically by Jules for task [13241507204324521116](https://jules.google.com/task/13241507204324521116) started by @SjnExe*