### PR TITLE
fix: Use dynamic config for rank evaluation and update bun documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -90,7 +90,7 @@ Key points:
 
 - **TypeScript:** The project is migrating to TypeScript. All new code should be written in TypeScript (`.ts`) in the `src/` directory. Legacy JavaScript code should be preserved or migrated with care.
 - **Naming Conventions:** Pay close attention to naming conventions (typically `camelCase` for variables and functions), formatting, and documentation standards.
-- **Formatting & Linting:** Run `npm run format` and `npm run lint` before submitting your changes.
+- **Formatting & Linting:** Run `bun run format` and `bun run lint` before submitting your changes.
 
 ### Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,17 +55,17 @@ Before implementing changes, strive to understand the relevant parts of the code
 
 - **Adherence to Guidelines:** Strictly follow `Docs/Development/CodingStyle.md` and `Docs/Development/StandardizationGuidelines.md`.
 - **TypeScript:** All Behavior Pack scripts are written in TypeScript (or JavaScript migrating to TypeScript) in the `src/` directory.
-- **Build Artifacts:** Do not edit files in `packs/behavior/scripts/` directly. Always edit the source in `src/` and run `npm run build`.
+- **Build Artifacts:** Do not edit files in `packs/behavior/scripts/` directly. Always edit the source in `src/` and run `bun run build`.
 - **Error Handling:** Implement robust error handling (e.g., `try...catch` blocks for risky operations, validation of inputs). Refer to `Docs/Development/StandardizationGuidelines.md` (Section 6) for detailed error logging standards.
 - **Logging:** Utilize the `debugLog()` function from `core/logger.ts` for development messages. This is conditional on `config.debug` being true.
     - **User-Facing Text:** Most user-facing text is hardcoded directly in the command or UI files where it is used. Configurable messages (like the welcome message or rules) are in `config.js`. Button texts for dynamically generated panels are defined in `src/core/panelLayoutConfig.js`.
 - **Linting & Formatting:**
-    - Run `npm run lint` to check for linting issues (ESLint).
-    - Run `npm run format` to format code (Prettier).
-    - Please ensure your changes pass linting and build (`npm run build`) before submitting.
+    - Run `bun run lint` to check for linting issues (ESLint).
+    - Run `bun run format` to format code (Prettier).
+    - Please ensure your changes pass linting and build (`bun run build`) before submitting.
     - **No Log Files:** Do not create `.txt` or other log files to store lint or build output (e.g., `lint_errors.txt`, `build.log`).
     - **Check Console:** Always read errors and warnings directly from the terminal/console output.
-    - **Fixing Workflow:** When fixing issues, run the command (e.g., `npm run lint`), check the console for remaining errors, fix them, and repeat.
+    - **Fixing Workflow:** When fixing issues, run the command (e.g., `bun run lint`), check the console for remaining errors, fix them, and repeat.
 
 ## 7. Planning and Communication
 
@@ -109,8 +109,8 @@ The following patterns must be verified and adhered to when working on the codeb
     - `eslint.config.js` now enables strict type-checking rules (e.g., `no-unsafe-assignment`) as **warnings**. Strive to resolve these when working on files.
     - Use `@minecraft/vanilla-data` for strict typing of Block, Item, and Entity IDs (e.g., `MinecraftItemTypes.Diamond`) instead of string literals.
     - Use `@minecraft/math` for vector math operations (e.g., `Vector3Utils.distance`) instead of manual calculations.
-    - Run `npm run check-deps` to verify that `package.json` dependencies match `manifest.json` dependencies. This is integrated into `npm run validate`.
-    - Run `npm run project-info` to view project details via `@minecraft/creator-tools`.
-    - Run `npm run fix-project` to apply automated fixes via `@minecraft/creator-tools`.
+    - Run `bun run check-deps` to verify that `package.json` dependencies match `manifest.json` dependencies. This is integrated into `bun run validate`.
+    - Run `bun run project-info` to view project details via `@minecraft/creator-tools`.
+    - Run `bun run fix-project` to apply automated fixes via `@minecraft/creator-tools`.
 
 By following these guidelines, you will help ensure the continued quality, consistency, and maintainability of the AddonExe. Thank you!

--- a/Dev/README.md
+++ b/Dev/README.md
@@ -40,7 +40,7 @@ The project uses a structured versioning system where `package.json` is the sing
 - **Source of Truth:** The version in `package.json` controls the version of the generated addon.
 - **Manifest Templates:** The `manifest.json` files in `packs/` are generated from `manifest.template.json` during the build. Do not edit `manifest.json` directly as it is git-ignored and will be overwritten.
 - **Build Modes:**
-    - **Local Build:** `npm run build` uses the exact version from `package.json`.
+    - **Local Build:** `bun run build` uses the exact version from `package.json`.
     - **Public Release:** Triggered by tagging a commit with `vX.Y.Z`. Enforces `Patch = 0` (e.g., `1.2.0`).
     - **Nightly Build:** Triggered by pushes to the `Dev` branch. Uses `Major.Minor` from `package.json` + GitHub Run Number as the patch (e.g., `0.7.124`).
 
@@ -49,7 +49,7 @@ The project uses a structured versioning system where `package.json` is the sing
 The codebase uses **TypeScript** for robustness and maintainability.
 
 - **Source Directory:** All behavior pack scripts are located in `src/`.
-- **Compilation:** Run `npm run build` to compile the TypeScript source into JavaScript in `packs/behavior/scripts/`. This command also auto-generates the `manifest.json` files.
+- **Compilation:** Run `bun run build` to compile the TypeScript source into JavaScript in `packs/behavior/scripts/`. This command also auto-generates the `manifest.json` files.
 - **Local Configuration:**
     - The repository contains `src/config.default.ts` as the template.
     - **Action:** Create a copy named `src/config.ts`. This file is git-ignored.

--- a/Docs/F.A.Q.md
+++ b/Docs/F.A.Q.md
@@ -102,7 +102,7 @@ If you are developing the addon or building it from source:
 
 - **Config Files:** The repository contains the primary configuration files in the `src/` directory, ending in `.ts` (e.g., `src/config.ts`).
 - **Customization:** You can simply open and edit these configuration files directly to adjust your settings before building.
-- **Build Process:** When you run `npm run build`, the system will compile these configuration files directly into the build output alongside the rest of your scripts.
+- **Build Process:** When you run `bun run build`, the system will compile these configuration files directly into the build output alongside the rest of your scripts.
 
 ### 2. For Users (Installed Addon)
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ This method is ideal for those who fork the repository to make their own custom 
 1.  **Fork the Repository:** Start by forking the [AddonExe repository](https://github.com/SjnExe/AddonExe).
 2.  **Locate Configs:** Inside the `src/` and `src/features/` directories, you will find several configuration files ending in `.ts` (e.g., `config.ts`, `economyConfig.ts`). These are the primary settings files.
 3.  **Customize:** Open the `config.ts` file (or any feature configuration file) and make any changes you desire.
-4.  **Build:** Run `npm run build` to compile your changes into the `packs/behavior` folder.
+4.  **Build:** Run `bun run build` to compile your changes into the `packs/behavior` folder.
 
 **How it Works:**
 

--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -72,21 +72,6 @@ async function postinstallTask() {
         }
     }
 
-    const bashrcPath = path.join(homeDir, '.bashrc');
-    if (existsSync(bashrcPath)) {
-        console.log('🧹 Cleaning up old shell profile configuration wrappers if present...');
-        let bashrcContent = await Bun.file(bashrcPath).text();
-
-        const startMarker = '# >>> ADDONEXE PROFILE START >>>';
-        const endMarker = '# <<< ADDONEXE PROFILE END <<<';
-
-        const blockRegex = new RegExp(`${startMarker}[\\s\\S]*?${endMarker}\\n?`, 'g');
-        if (blockRegex.test(bashrcContent)) {
-            bashrcContent = bashrcContent.replace(blockRegex, '');
-            await Bun.write(bashrcPath, bashrcContent);
-            console.log('✨ Cleaned up old shell profile synchronization.');
-        }
-    }
 }
 
 postinstallTask().catch(console.error);

--- a/src/core/__tests__/permissionEngine.test.ts
+++ b/src/core/__tests__/permissionEngine.test.ts
@@ -33,6 +33,12 @@ mock.module('../../config.js', () => ({
     }
 }));
 
+import { config as Config } from '../../config.js';
+
+mock.module('@core/configManager.js', () => ({
+    getConfig: () => Config
+}));
+
 mock.module('../playerCache.js', () => ({
     getAllPlayersFromCache: () => [{ id: 'player1' }, { id: 'player2' }]
 }));

--- a/src/core/permissionEngine.ts
+++ b/src/core/permissionEngine.ts
@@ -1,4 +1,4 @@
-import { config } from '@core/../config.js';
+import { getConfig } from '@core/configManager.js';
 import { getRanksConfig } from '@core/configurations.js';
 import { getAllPlayersFromCache } from '@core/playerCache.js';
 import { getPlayer } from '@core/playerDataManager.js';
@@ -73,11 +73,11 @@ function getRankMap(rankId: string): Record<string, boolean> {
 export function getPlayerRanks(player: mc.Player): RankDefinition[] {
     const pData = getPlayer(player.id);
 
-    // Fallback logic, ensuring we match `config.playerDefaults.rankId` or the hardcoded default 'member' if all else fails
+    // Fallback logic, ensuring we match `getConfig().playerDefaults.rankId` or the hardcoded default 'member' if all else fails
     let rankIds = pData?.ranks;
     if (!rankIds || rankIds.length === 0) {
-        if (config.playerDefaults.rankId) {
-            rankIds = [config.playerDefaults.rankId];
+        if (getConfig().playerDefaults.rankId) {
+            rankIds = [getConfig().playerDefaults.rankId];
         } else {
             rankIds = ['member'];
         }
@@ -101,7 +101,7 @@ export function getPlayerRanks(player: mc.Player): RankDefinition[] {
 
     // If absolutely no rank was assigned or conditions met, explicitly grant the configured default rank
     if (ranks.length === 0) {
-        const defaultRank = getRankById(config.playerDefaults.rankId);
+        const defaultRank = getRankById(getConfig().playerDefaults.rankId);
         if (defaultRank) {
             ranks.push(defaultRank);
         }
@@ -116,7 +116,7 @@ function evaluateRankConditions(player: mc.Player, rank: RankDefinition, assigne
 
     for (const condition of rank.conditions) {
         if (condition.type === 'isOwner') {
-            const ownerNames = config.ownerPlayerNames.map((name: string) => name.trim().toLowerCase());
+            const ownerNames = getConfig().ownerPlayerNames.map((name: string) => name.trim().toLowerCase());
             const playerName = player.name.trim().toLowerCase();
             if (!ownerNames.includes(playerName)) return false;
         } else if (condition.type === 'hasTag') {


### PR DESCRIPTION
This PR addresses an issue where setting a custom username as the owner in the configuration did not grant the owner rank due to a static import of the configuration object. It fixes this by using the dynamic `getConfig()` method in the permission engine. 

Additionally, following a user request, it completes the project's migration to Bun by updating all mentions of `npm` in documentation to `bun`, and cleans up unused profile cleanup code in the postinstall script.

---
*PR created automatically by Jules for task [3759408241022785370](https://jules.google.com/task/3759408241022785370) started by @SjnExe*