### PR TITLE
docs: update plan.md with context and handover sections

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,5 +1,12 @@
 # UI Panel Refactoring Plan
 
+
+## Context
+
+This project is a Minecraft Bedrock scripting/addon project written in TypeScript. We use Bun for tooling (`bun format`, `bun run build`, `bun run test`). The UI architecture aims to rely on a programmatic, type-safe fluent builder pattern wrapping the `@minecraft/server-ui` API, avoiding legacy string-based registries.
+
+During this refactoring, we will make full use of available tooling and all relevant Minecraft dependencies (`@minecraft/server`, `@minecraft/server-ui`, `@minecraft/math`, `@minecraft/vanilla-data`) to ensure robust architecture, type safety, and optimal native integration.
+
 ## Overview
 
 The current UI system in the addon relies on a centralized string-based registry (`panelRegistry.ts`), a centralized action registry (`actionRegistry.ts`), and a routing system (`PanelRouter.ts`) that matches string IDs to handlers. This design has several drawbacks:
@@ -30,6 +37,9 @@ Panels will become async functions that take a player and strongly typed argumen
 **Example Refactored Panel:**
 
 ```typescript
+import * as mc from '@minecraft/server';
+import { ActionFormBuilder } from '../builders/ActionFormBuilder';
+
 export async function showAdminPanel(player: mc.Player): Promise<void> {
     const form = new ActionFormBuilder().title('Admin Panel').body('Manage the server.');
 
@@ -60,6 +70,10 @@ export async function showAdminPanel(player: mc.Player): Promise<void> {
 - [ ] Implement and test `ModalFormBuilder`.
 - [ ] Implement and test `MessageFormBuilder`.
 
+
+#### Session 1 Handover Context
+*(To be written by future sessions of Jules)*
+
 ### Session 2: Refactor Core Panels
 
 - [ ] Migrate `mainPanel` to the new functional builder pattern in `src/core/ui/panels/`.
@@ -67,12 +81,20 @@ export async function showAdminPanel(player: mc.Player): Promise<void> {
 - [ ] Migrate `playerPanel` to the new functional builder pattern.
 - [ ] Migrate `configPanel` to the new functional builder pattern.
 
+
+#### Session 2 Handover Context
+*(To be written by future sessions of Jules)*
+
 ### Session 3: Refactor Feature Panels (Part 1)
 
 - [ ] Migrate UI panels in `src/features/auction/ui/`.
 - [ ] Migrate UI panels in `src/features/economy/ui/`.
 - [ ] Migrate UI panels in `src/features/essentials/ui/`.
 - [ ] Migrate UI panels in `src/features/games/ui/`.
+
+
+#### Session 3 Handover Context
+*(To be written by future sessions of Jules)*
 
 ### Session 4: Refactor Feature Panels (Part 2)
 
@@ -84,6 +106,10 @@ export async function showAdminPanel(player: mc.Player): Promise<void> {
 - [ ] Migrate UI panels in `src/features/teleport/ui/`.
 - [ ] Migrate UI panels in `src/features/vote/ui/`.
 
+
+#### Session 4 Handover Context
+*(To be written by future sessions of Jules)*
+
 ### Session 5: Update Systems Registry and Remove Legacy Code
 
 - [ ] Modify `systemRegistry.ts` to accept functional callbacks for settings panels instead of mapping to string-based config schemas.
@@ -92,6 +118,10 @@ export async function showAdminPanel(player: mc.Player): Promise<void> {
 - [ ] Delete `actionRegistry.ts`.
 - [ ] Delete `PanelRouter.ts`.
 - [ ] Remove legacy UI context types in `src/core/ui/types.ts`.
+
+
+#### Session 5 Handover Context
+*(To be written by future sessions of Jules)*
 
 ## Benefits
 

--- a/plan.md
+++ b/plan.md
@@ -1,6 +1,5 @@
 # UI Panel Refactoring Plan
 
-
 ## Context
 
 This project is a Minecraft Bedrock scripting/addon project written in TypeScript. We use Bun for tooling (`bun format`, `bun run build`, `bun run test`). The UI architecture aims to rely on a programmatic, type-safe fluent builder pattern wrapping the `@minecraft/server-ui` API, avoiding legacy string-based registries.
@@ -70,9 +69,9 @@ export async function showAdminPanel(player: mc.Player): Promise<void> {
 - [ ] Implement and test `ModalFormBuilder`.
 - [ ] Implement and test `MessageFormBuilder`.
 
-
 #### Session 1 Handover Context
-*(To be written by future sessions of Jules)*
+
+_(To be written by future sessions of Jules)_
 
 ### Session 2: Refactor Core Panels
 
@@ -81,9 +80,9 @@ export async function showAdminPanel(player: mc.Player): Promise<void> {
 - [ ] Migrate `playerPanel` to the new functional builder pattern.
 - [ ] Migrate `configPanel` to the new functional builder pattern.
 
-
 #### Session 2 Handover Context
-*(To be written by future sessions of Jules)*
+
+_(To be written by future sessions of Jules)_
 
 ### Session 3: Refactor Feature Panels (Part 1)
 
@@ -92,9 +91,9 @@ export async function showAdminPanel(player: mc.Player): Promise<void> {
 - [ ] Migrate UI panels in `src/features/essentials/ui/`.
 - [ ] Migrate UI panels in `src/features/games/ui/`.
 
-
 #### Session 3 Handover Context
-*(To be written by future sessions of Jules)*
+
+_(To be written by future sessions of Jules)_
 
 ### Session 4: Refactor Feature Panels (Part 2)
 
@@ -106,9 +105,9 @@ export async function showAdminPanel(player: mc.Player): Promise<void> {
 - [ ] Migrate UI panels in `src/features/teleport/ui/`.
 - [ ] Migrate UI panels in `src/features/vote/ui/`.
 
-
 #### Session 4 Handover Context
-*(To be written by future sessions of Jules)*
+
+_(To be written by future sessions of Jules)_
 
 ### Session 5: Update Systems Registry and Remove Legacy Code
 
@@ -119,9 +118,9 @@ export async function showAdminPanel(player: mc.Player): Promise<void> {
 - [ ] Delete `PanelRouter.ts`.
 - [ ] Remove legacy UI context types in `src/core/ui/types.ts`.
 
-
 #### Session 5 Handover Context
-*(To be written by future sessions of Jules)*
+
+_(To be written by future sessions of Jules)_
 
 ## Benefits
 


### PR DESCRIPTION
Updates the migration plan `plan.md` to include required tooling/dependency context and handover sections for multi-session development as requested by the user.

---
*PR created automatically by Jules for task [17652185298407328963](https://jules.google.com/task/17652185298407328963) started by @SjnExe*