### PR TITLE
Refactor Core Panels (Session 2)

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -75,14 +75,21 @@ The core builder classes (`ActionFormBuilder`, `ModalFormBuilder`, `MessageFormB
 
 ### Session 2: Refactor Core Panels
 
-- [ ] Migrate `mainPanel` to the new functional builder pattern in `src/core/ui/panels/`.
-- [ ] Migrate `adminPanel` to the new functional builder pattern.
-- [ ] Migrate `playerPanel` to the new functional builder pattern.
-- [ ] Migrate `configPanel` to the new functional builder pattern.
+- [x] Migrate `mainPanel` to the new functional builder pattern in `src/core/ui/panels/`.
+- [x] Migrate `adminPanel` to the new functional builder pattern.
+- [x] Migrate `playerPanel` to the new functional builder pattern.
+- [x] Migrate `configPanel` to the new functional builder pattern.
 
 #### Session 2 Handover Context
 
-_(To be written by future sessions of Jules)_
+In Session 2, we completely refactored the core system panels (`mainPanel`, `adminPanel`, `playerPanel`, and `configPanel`) using the fluent builder patterns (`ActionFormBuilder`, `ModalFormBuilder`).
+
+- Replaced class-based `IPanelHandler` implementations with direct async functional exports (e.g., `showMainPanel`, `showStaffDashboardPanel`).
+- Set up interceptors in `src/core/uiManager.ts` inside `showPanel` to intercept legacy string-based panel IDs and route them directly to the new async functional UI builders.
+- Updated `src/core/ui/panels/index.ts` to stop registering the refactored handlers.
+- The build, format, test, and type-check steps passed successfully.
+
+When migrating future panels (Session 3 and beyond), continue adding interceptor routes in `src/core/uiManager.ts` to maintain fallback compatibility with unmigrated panels that might still be referencing string identifiers to trigger these.
 
 ### Session 3: Refactor Feature Panels (Part 1)
 

--- a/src/core/ui/panels/adminPanel.ts
+++ b/src/core/ui/panels/adminPanel.ts
@@ -1,276 +1,197 @@
-import { MinecraftDimensionTypes } from '@minecraft/vanilla-data';
-
-import * as mc from '@minecraft/server';
-import { ActionFormResponse, ModalFormData, ModalFormResponse } from '@minecraft/server-ui';
-
+import { hasPermission } from '@core/permissionEngine.js';
 import { showPanel } from '@core/uiManager.js';
-import { formatLocation } from '@core/utils.js';
-import * as floatingTextManager from '@features/essentials/floatingTextManager.js';
+import { createText, getAllTexts, getTextById, updateText } from '@features/essentials/floatingTextManager.js';
 import { isDefined, isNonEmptyString, isNumber } from '@lib/guards.js';
+import * as mc from '@minecraft/server';
+import { ActionFormBuilder } from '@ui/builders/ActionFormBuilder.js';
+import { ModalFormBuilder } from '@ui/builders/ModalFormBuilder.js';
+
 import { getStaticMenuItems } from '@ui/panelBuilder.js';
-import { panelDefinitions, PanelItem, UIContext } from '@ui/panelRegistry.js';
-import { IPanelHandler } from '@ui/types.js';
-import { addBackButton } from '@ui/uiUtils.js';
+import { panelDefinitions } from '@ui/panelRegistry.js';
 
-export class AdminPanelHandler implements IPanelHandler {
-    canHandle(panelId: string): boolean {
-        return panelId === 'staffDashboardPanel' || panelId.startsWith('floatingText');
-    }
+export async function showStaffDashboardPanel(player: mc.Player): Promise<void> {
+    const form = new ActionFormBuilder().title('Staff Dashboard');
+    const def = panelDefinitions['staffDashboardPanel'];
 
-    getItems(player: mc.Player, panelId: string, _context: UIContext): Promise<PanelItem[]> {
-        const items: PanelItem[] = [];
-        // Admin Panel uses static items (delegates to sub-panels)
-        if (panelId === 'staffDashboardPanel') {
-            const def = panelDefinitions[panelId];
-            if (isDefined(def)) {
-                const staticItems = getStaticMenuItems(player, def);
-                items.push(...staticItems);
-            }
-            return Promise.resolve(items);
-        }
-
-        if (panelId === 'floatingTextListPanel') {
-            addBackButton(items, 'staffDashboardPanel');
-            items.push(
-                {
-                    id: 'placeholderList',
-                    text: '§l§6View Placeholders',
-                    icon: 'textures/ui/icon_sign',
-                    permission: 'ui.panel.admin',
-                    actionType: 'openPanel',
-                    actionValue: 'placeholderListPanel'
-                },
-                {
-                    id: 'create',
-                    text: '§l§2+ Create New',
-                    icon: 'textures/ui/color_plus',
-                    permission: 'ui.panel.admin',
-                    actionType: 'openPanel',
-                    actionValue: 'floatingTextCreatePanel'
-                }
-            );
-
-            const texts = floatingTextManager.getAllTexts();
-            for (const text of texts) {
-                items.push({
-                    id: text.id,
-                    text: `§6${text.id}§r\n${formatLocation(text.location)}`,
-                    permission: 'ui.panel.admin',
-                    actionType: 'openPanel',
-                    actionValue: 'floatingTextActionPanel'
-                });
-            }
-            return Promise.resolve(items);
-        }
-
-        if (panelId === 'floatingTextActionPanel') {
-            addBackButton(items, 'floatingTextListPanel');
-            items.push(
-                {
-                    id: 'edit',
-                    text: 'Edit Settings',
-                    icon: 'textures/ui/icon_setting',
-                    permission: 'ui.panel.admin',
-                    actionType: 'openPanel',
-                    actionValue: 'floatingTextEditPanel'
-                },
-                {
-                    id: 'respawn',
-                    text: 'Respawn Entity',
-                    icon: 'textures/ui/refresh_light',
-                    permission: 'ui.panel.admin',
-                    actionType: 'functionCall',
-                    actionValue: 'respawnText'
-                },
-                {
-                    id: 'despawn',
-                    text: 'Despawn Entity',
-                    icon: 'textures/ui/cancel',
-                    permission: 'ui.panel.admin',
-                    actionType: 'functionCall',
-                    actionValue: 'despawnText'
-                },
-                {
-                    id: 'delete',
-                    text: '§4Delete Text',
-                    icon: 'textures/ui/trash',
-                    permission: 'ui.panel.admin',
-                    actionType: 'functionCall',
-                    actionValue: 'deleteText'
-                }
-            );
-            return Promise.resolve(items);
-        }
-
-        return Promise.resolve(items);
-    }
-
-    buildModal(_player: mc.Player, panelId: string, context: UIContext): Promise<ModalFormData | undefined | void> {
-        if (panelId === 'floatingTextCreatePanel') {
-            return Promise.resolve(
-                new ModalFormData().title('Create New Floating Text').textField('Unique ID (no spaces)', 'e.g., "welcome_message"').textField('Text Content', 'Enter text to display')
-            );
-        }
-
-        if (panelId === 'floatingTextEditPanel') {
-            const id = (context.id ?? context.selectedItemId) as string;
-            if (!isNonEmptyString(id)) return Promise.resolve();
-            const text = floatingTextManager.getTextById(id);
-            if (!isDefined(text)) return Promise.resolve();
-            const expiresAt = text.expiresAt;
-            const updateInterval = text.updateInterval ?? 0;
-            const dimensionOptions = ['Overworld', 'Nether', 'The End'];
-            const dimensionIds = [MinecraftDimensionTypes.Overworld, MinecraftDimensionTypes.Nether, MinecraftDimensionTypes.TheEnd];
-            const defaultDimensionIndex = Math.max(0, dimensionIds.indexOf(text.dimension as MinecraftDimensionTypes));
-            return Promise.resolve(
-                new ModalFormData()
-                    .title(`Edit: ${id}`)
-                    .textField('Text Content', 'Enter the text to display', { defaultValue: text.text })
-                    .textField('X', 'X', { defaultValue: String(text.location.x.toFixed(2)) })
-                    .textField('Y', 'Y', { defaultValue: String(text.location.y.toFixed(2)) })
-                    .textField('Z', 'Z', { defaultValue: String(text.location.z.toFixed(2)) })
-                    .dropdown('Dimension', dimensionOptions, { defaultValueIndex: defaultDimensionIndex })
-                    .textField('Update Interval', '0 to disable', { defaultValue: String(updateInterval) })
-                    .toggle('Expiration', { defaultValue: isNumber(expiresAt) })
-                    .textField('Expiration (mins)', 'mins', {
-                        defaultValue: isNumber(expiresAt) ? String(Math.round((expiresAt - Date.now()) / 60_000)) : '0'
-                    })
-            );
-        }
-        return Promise.resolve();
-    }
-
-    async handleResponse(player: mc.Player, panelId: string, response: ActionFormResponse | ModalFormResponse, context: UIContext): Promise<void> {
-        const selection = (response as ActionFormResponse).selection;
-        const values = (response as ModalFormResponse).formValues;
-
-        if (panelId === 'floatingTextCreatePanel') {
-            if ((response as ModalFormResponse).canceled) return showPanel(player, 'floatingTextListPanel');
-            const rawValues = (values ?? []) as (string | undefined)[];
-            const id = rawValues[0];
-            const text = rawValues[1];
-
-            if (!isNonEmptyString(id) || id.includes(' ')) {
-                player.sendMessage('§4Invalid ID.');
-                return showPanel(player, 'floatingTextCreatePanel');
-            }
-            if (floatingTextManager.createText(player, id, isNonEmptyString(text) ? text : '')) {
-                // Success msg in manager
-            }
-            return showPanel(player, 'floatingTextListPanel');
-        }
-
-        if (panelId === 'floatingTextEditPanel') {
-            if ((response as ModalFormResponse).canceled) return showPanel(player, 'floatingTextActionPanel', context);
-            const id = context.id as string;
-            const rawValues = values ?? [];
-
-            const textContent = rawValues[0] as string;
-            const x = rawValues[1] as string;
-            const y = rawValues[2] as string;
-            const z = rawValues[3] as string;
-            const dimensionIndex = rawValues[4] as number;
-            const updateIntervalStr = rawValues[5] as string;
-            const useExpiration = rawValues[6] as boolean;
-            const expirationMinutes = rawValues[7] as string;
-
-            const dimensionIds = [MinecraftDimensionTypes.Overworld, MinecraftDimensionTypes.Nether, MinecraftDimensionTypes.TheEnd];
-            const selectedDimension = (isDefined(dimensionIndex) ? dimensionIds[dimensionIndex] : undefined) ?? MinecraftDimensionTypes.Overworld;
-
-            const updatedConfig = {
-                text: textContent,
-                location: { x: Number.parseFloat(x), y: Number.parseFloat(y), z: Number.parseFloat(z) },
-                dimension: selectedDimension,
-                updateInterval: Number.parseInt(updateIntervalStr) || 0,
-                expiresAt: useExpiration === true && Number(expirationMinutes) > 0 ? Date.now() + Number(expirationMinutes) * 60_000 : undefined
-            };
-            floatingTextManager.updateText(id, updatedConfig);
-            player.sendMessage(`§2Successfully updated floating text: ${id}`);
-            return showPanel(player, 'floatingTextActionPanel', context);
-        }
-
-        if (typeof selection === 'number') {
-            const items = await this.getItems(player, panelId, context);
-            if (selection >= 0 && selection < items.length) {
-                const item = items[selection];
-                if (!isDefined(item)) return;
+    if (def) {
+        const items = getStaticMenuItems(player, def);
+        for (const item of items) {
+            if (item.id === '__back__') continue;
+            form.button(item.text, item.icon, async () => {
                 if (item.actionType === 'openPanel') {
-                    const newContext = {
-                        ...context,
-                        page: 1,
-                        selectedItemId: item.id,
-                        id: item.id
-                    };
-
-                    // Fix: Preserve the floating text ID when navigating to the edit panel
-                    if (panelId === 'floatingTextActionPanel' && item.actionValue === 'floatingTextEditPanel') {
-                        newContext.id = context.id as string;
-                    }
-
-                    return showPanel(player, item.actionValue, newContext);
+                    await showPanel(player, item.actionValue, { page: 1 });
+                } else {
+                    const { uiActionFunctions } = await import('@core/ui/actionRegistry.js');
+                    const action = uiActionFunctions[item.actionValue];
+                    if (action) await action(player, {}, 'staffDashboardPanel');
                 }
-                const actionContext = {
-                    ...context,
-                    selectedItemId: item.id,
-                    id: item.id
-                };
-
-                if (panelId === 'floatingTextActionPanel') {
-                    actionContext.id = context.id as string;
-                }
-
-                if (item.actionValue === 'showRules') {
-                    return showPanel(player, 'rulesManagementPanel', actionContext);
-                }
-                if (item.actionValue === 'showHelpfulLinks') {
-                    return showPanel(player, 'helpfulLinksManagementPanel', actionContext);
-                }
-                if (item.actionValue === 'respawnText') {
-                    const { respawnText } = await import('@features/essentials/floatingTextManager.js');
-                    if (isNonEmptyString(actionContext.id)) {
-                        try {
-                            respawnText(actionContext.id);
-                            player.sendMessage(`§2Respawned text: ${actionContext.id}`);
-                        } catch (error) {
-                            player.sendMessage(`§4Error respawning text: ${String(error)}`);
-                        }
-                    }
-                    return showPanel(player, 'floatingTextActionPanel', actionContext);
-                }
-                if (item.actionValue === 'despawnText') {
-                    const { despawnText } = await import('@features/essentials/floatingTextManager.js');
-                    if (isNonEmptyString(actionContext.id)) {
-                        try {
-                            despawnText(actionContext.id);
-                            player.sendMessage(`§2Despawned text: ${actionContext.id}`);
-                        } catch (error) {
-                            player.sendMessage(`§4Error despawning text: ${String(error)}`);
-                        }
-                    }
-                    return showPanel(player, 'floatingTextActionPanel', actionContext);
-                }
-                if (item.actionValue === 'deleteText') {
-                    const { deleteText } = await import('@features/essentials/floatingTextManager.js');
-                    if (isNonEmptyString(actionContext.id)) {
-                        try {
-                            deleteText(player, actionContext.id);
-                        } catch (error) {
-                            player.sendMessage(`§4Error deleting text: ${String(error)}`);
-                        }
-                    }
-                    return showPanel(player, 'floatingTextListPanel', actionContext);
-                }
-
-                const { uiActionFunctions } = await import('@core/ui/actionRegistry.js');
-                const action = uiActionFunctions[item.actionValue];
-                if (isDefined(action)) {
-                    await action(player, context, panelId);
-                    return;
-                }
-
-                player.sendMessage(`§cAction ${item.actionValue} not mapped.`);
-                return;
-            }
+            });
         }
     }
+
+    form.addBackButton(async () => {
+        await showPanel(player, 'mainPanel');
+    });
+
+    await form.show(player);
+}
+
+export async function showFloatingTextListPanel(player: mc.Player): Promise<void> {
+    const form = new ActionFormBuilder().title('Floating Text');
+
+    if (hasPermission(player, 'ui.panel.admin')) {
+        form.button('Create New Text', 'textures/ui/color_plus', async () => {
+            await showFloatingTextCreatePanel(player);
+        });
+
+        const texts = getAllTexts();
+        for (const textConfig of texts) {
+            const id = textConfig.id;
+            form.button(id, 'textures/ui/text_color_paintbrush', async () => {
+                await showFloatingTextActionPanel(player, id);
+            });
+        }
+
+        form.button('§bView Placeholders', 'textures/ui/infobulb', async () => {
+            await showPanel(player, 'placeholderListPanel', { returnPanel: 'floatingTextListPanel' });
+        });
+    }
+
+    form.addBackButton(async () => {
+        await showStaffDashboardPanel(player);
+    });
+
+    await form.show(player);
+}
+
+export async function showFloatingTextCreatePanel(player: mc.Player): Promise<void> {
+    const form = new ModalFormBuilder()
+        .title('Create New Floating Text')
+        .textField('id', 'Unique ID (no spaces)', 'e.g., "welcome_message"')
+        .textField('text', 'Text Content', 'Enter text to display');
+
+    const result = await form.show(player);
+
+    if (result.canceled) {
+        return showFloatingTextListPanel(player);
+    }
+
+    const id = result.formValues?.id as string;
+    const text = result.formValues?.text as string;
+
+    if (!isNonEmptyString(id) || id.includes(' ')) {
+        player.sendMessage('§4Invalid ID.');
+        return showFloatingTextCreatePanel(player);
+    }
+
+    if (createText(player, id, isNonEmptyString(text) ? text : '')) {
+        // Success handled
+    }
+
+    await showFloatingTextListPanel(player);
+}
+
+export async function showFloatingTextActionPanel(player: mc.Player, textId: string): Promise<void> {
+    const form = new ActionFormBuilder().title('Floating Text Actions');
+
+    if (hasPermission(player, 'ui.panel.admin')) {
+        form.button('Edit Config', 'textures/ui/edit', async () => {
+            await showFloatingTextEditPanel(player, textId);
+        });
+
+        form.button('Respawn Entity', 'textures/ui/refresh_light', async () => {
+            const { respawnText } = await import('@features/essentials/floatingTextManager.js');
+            try {
+                respawnText(textId);
+                player.sendMessage(`§2Respawned text: ${textId}`);
+            } catch (error) {
+                player.sendMessage(`§4Error respawning text: ${String(error)}`);
+            }
+            await showFloatingTextActionPanel(player, textId);
+        });
+
+        form.button('Despawn Entity', 'textures/ui/cancel', async () => {
+            const { despawnText } = await import('@features/essentials/floatingTextManager.js');
+            try {
+                despawnText(textId);
+                player.sendMessage(`§2Despawned text: ${textId}`);
+            } catch (error) {
+                player.sendMessage(`§4Error despawning text: ${String(error)}`);
+            }
+            await showFloatingTextActionPanel(player, textId);
+        });
+
+        form.button('§4Delete Text', 'textures/ui/trash', async () => {
+            const { deleteText } = await import('@features/essentials/floatingTextManager.js');
+            try {
+                deleteText(player, textId);
+            } catch (error) {
+                player.sendMessage(`§4Error deleting text: ${String(error)}`);
+            }
+            await showFloatingTextListPanel(player);
+        });
+    }
+
+    form.addBackButton(async () => {
+        await showFloatingTextListPanel(player);
+    });
+
+    await form.show(player);
+}
+
+export async function showFloatingTextEditPanel(player: mc.Player, textId: string): Promise<void> {
+    const text = getTextById(textId);
+    if (!isDefined(text)) {
+        return showFloatingTextListPanel(player);
+    }
+
+    const expiresAt = text.expiresAt;
+    const updateInterval = text.updateInterval ?? 0;
+    const dimensionOptions = ['Overworld', 'Nether', 'The End'];
+    const dimensionIds = ['minecraft:overworld', 'minecraft:nether', 'minecraft:the_end'];
+    const defaultDimensionIndex = Math.max(0, dimensionIds.indexOf(text.dimension));
+
+    const form = new ModalFormBuilder()
+        .title(`Edit: ${textId}`)
+        .textField('text', 'Text Content', 'Enter the text to display', text.text)
+        .textField('x', 'X', 'X', String(text.location.x.toFixed(2)))
+        .textField('y', 'Y', 'Y', String(text.location.y.toFixed(2)))
+        .textField('z', 'Z', 'Z', String(text.location.z.toFixed(2)))
+        .dropdown('dimensionIndex', 'Dimension', dimensionOptions, defaultDimensionIndex)
+        .textField('updateInterval', 'Update Interval', '0 to disable', String(updateInterval))
+        .toggle('useExpiration', 'Expiration', isNumber(expiresAt))
+        .textField('expirationMinutes', 'Expiration (mins)', 'mins', isNumber(expiresAt) ? String(Math.round((expiresAt - Date.now()) / 60_000)) : '0');
+
+    const result = await form.show(player);
+
+    if (result.canceled) {
+        return showFloatingTextActionPanel(player, textId);
+    }
+
+    const values = result.formValues;
+    if (!values) return showFloatingTextActionPanel(player, textId);
+
+    const textContent = values.text as string;
+    const xStr = values.x as string;
+    const yStr = values.y as string;
+    const zStr = values.z as string;
+    const dimIdx = values.dimensionIndex as number;
+    const intStr = values.updateInterval as string;
+    const useExp = values.useExpiration as boolean;
+    const expMins = values.expirationMinutes as string;
+
+    const selectedDimension = (isDefined(dimIdx) ? dimensionIds[dimIdx] : undefined) ?? 'minecraft:overworld';
+
+    const updatedConfig = {
+        text: textContent,
+        location: { x: Number.parseFloat(xStr), y: Number.parseFloat(yStr), z: Number.parseFloat(zStr) },
+        dimension: selectedDimension,
+        updateInterval: Number.parseInt(intStr) || 0,
+        expiresAt: useExp === true && Number(expMins) > 0 ? Date.now() + Number(expMins) * 60_000 : undefined
+    };
+
+    updateText(textId, updatedConfig);
+    player.sendMessage(`§2Successfully updated floating text: ${textId}`);
+
+    await showFloatingTextActionPanel(player, textId);
 }

--- a/src/core/ui/panels/configPanel.ts
+++ b/src/core/ui/panels/configPanel.ts
@@ -1,673 +1,372 @@
-import { hasPermission } from '@core/permissionEngine.js';
-import * as mc from '@minecraft/server';
-import { ActionFormResponse, ModalFormData, ModalFormResponse } from '@minecraft/server-ui';
-
-import { refreshXrayCache } from '@features/anticheat/xrayDetection.js';
-
-import { resetConfigSection } from '@core/configManager.js';
 import { errorLog } from '@core/logger.js';
 import { getValueFromPath, setValueByPath } from '@core/objectUtils.js';
+import { hasPermission } from '@core/permissionEngine.js';
 import { showPanel } from '@core/uiManager.js';
-import * as utils from '@core/utils.js';
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
-import { showConfirmationDialog } from '@ui/components.js';
+import * as mc from '@minecraft/server';
+import { ActionFormBuilder } from '@ui/builders/ActionFormBuilder.js';
+import { ModalFormBuilder } from '@ui/builders/ModalFormBuilder.js';
+
 import { configPanelSchema } from '@ui/configPanelRegistry.js';
-import { PanelItem, UIContext } from '@ui/panelRegistry.js';
-import { IPanelHandler } from '@ui/types.js';
-import { addBackButton, addPaginationItems, getPaginatedItems, getSystemsByCategory, getVisibleCategories, configHandlers as uiConfigHandlers } from '@ui/uiUtils.js';
-
-const uiConfigHandlerKeys = Object.keys(uiConfigHandlers);
+import { configHandlers as uiConfigHandlers } from '@ui/uiUtils.js';
 const uiConfigHandlerEntries = Object.entries(uiConfigHandlers);
-const systemOptionsCache = ['All Systems', ...uiConfigHandlerKeys];
 
-interface ConfigSetting {
-    key: string;
-    type: string;
-    label: string;
-    description?: string;
-    options?: string[];
-    [key: string]: unknown;
+import { getSystemRegistry } from '@ui/systemRegistry.js';
+
+let systemOptionsCache: string[] = [];
+
+function getSystemOptions(): string[] {
+    if (systemOptionsCache.length > 0) return systemOptionsCache;
+    systemOptionsCache = ['All Systems', ...Object.keys(uiConfigHandlers)];
+    return systemOptionsCache;
 }
 
-export class ConfigPanelHandler implements IPanelHandler {
-    canHandle(panelId: string): boolean {
-        return (
-            panelId === 'configCategoryPanel' ||
-            panelId.startsWith('configSubCategoryPanel_') ||
-            panelId === 'configResetPanel' ||
-            panelId.startsWith('configResetCategoryPanel_') ||
-            panelId.startsWith('config_') ||
-            panelId === 'configTransferPanel' ||
-            panelId === 'configExportPanel' ||
-            panelId === 'configImportPanel'
-        );
+export async function showConfigCategoryPanel(player: mc.Player, context: any = {}): Promise<void> {
+    const form = new ActionFormBuilder().title('Configuration');
+
+    if (!hasPermission(player, 'ui.panel.admin')) {
+        player.sendMessage('§cYou do not have permission to view configurations.');
+        return;
     }
 
-    getItems(player: mc.Player, panelId: string, context: UIContext): Promise<PanelItem[]> {
-        if (panelId === 'configCategoryPanel') {
-            return Promise.resolve(this.getCategoryPanelItems(player, context));
+    const systems = getSystemRegistry();
+    const categories = new Set<string>();
+
+    systems.forEach((system) => {
+        if (!system.hidden) {
+            categories.add(system.category ?? 'Uncategorized');
         }
+    });
 
-        if (panelId.startsWith('configSubCategoryPanel_')) {
-            const category = panelId.replace('configSubCategoryPanel_', '');
-            return Promise.resolve(this.getSubCategoryPanelItems(player, category, context));
-        }
+    const categoryList = Array.from(categories).sort();
 
-        if (panelId === 'configResetPanel') {
-            return Promise.resolve(this.getResetPanelItems(player, context));
-        }
-
-        if (panelId.startsWith('configResetCategoryPanel_')) {
-            const category = panelId.replace('configResetCategoryPanel_', '');
-            return Promise.resolve(this.getResetCategoryPanelItems(player, category, context));
-        }
-
-        if (panelId === 'configTransferPanel') {
-            return Promise.resolve(this.getTransferPanelItems(player, context));
-        }
-
-        return Promise.resolve([]);
-    }
-
-    private getTransferPanelItems(_player: mc.Player, _context: UIContext): PanelItem[] {
-        const items: PanelItem[] = [];
-        addBackButton(items, 'configCategoryPanel');
-        items.push({
-            id: 'exportConfig',
-            text: 'Export Configurations',
-            icon: 'textures/ui/arrow_right',
-            permission: 'ui.panel.owner',
-            actionType: 'openPanel',
-            actionValue: 'configExportPanel'
+    for (const cat of categoryList) {
+        form.button(cat, 'textures/ui/settings_glyph_color_2x', async () => {
+            await showConfigSubCategoryPanel(player, cat, context);
         });
-        items.push({
-            id: 'importConfig',
-            text: 'Import Configurations',
-            icon: 'textures/ui/arrow_left',
-            permission: 'ui.panel.owner',
-            actionType: 'openPanel',
-            actionValue: 'configImportPanel'
+    }
+
+    form.button('§4Reset Configurations', 'textures/ui/refresh', async () => {
+        await showConfigResetPanel(player, context);
+    });
+
+    if (hasPermission(player, 'ui.panel.owner')) {
+        form.button('Export/Import Configs', 'textures/ui/refresh', async () => {
+            await showConfigTransferPanel(player, context);
         });
-        return items;
     }
 
-    private getCategoryPanelItems(player: mc.Player, context: UIContext): PanelItem[] {
-        const items: PanelItem[] = [];
-        addBackButton(items, 'staffDashboardPanel');
-        const categories = getVisibleCategories(player);
+    form.addBackButton(async () => {
+        await showPanel(player, 'staffDashboardPanel');
+    });
 
-        const paginated = getPaginatedItems(categories, (context.page as number) || 1);
-        for (const cat of paginated) {
-            if (!isDefined(cat)) continue;
+    await form.show(player);
+}
 
-            items.push({
-                id: cat.id,
-                text: cat.title,
-                icon: cat.icon,
-                permission: 'ui.panel.admin',
-                actionType: 'openPanel',
-                actionValue: `configSubCategoryPanel_${cat.id}`
-            });
-        }
-
-        addPaginationItems(items, (context.page as number) || 1, categories.length, 'ui.panel.admin');
-
-        if (hasPermission(player, 'ui.panel.owner')) {
-            items.push({
-                id: 'resetSettings',
-                text: '§l§4Reset Settings§r',
-                icon: 'textures/ui/wysiwyg_reset',
-                permission: 'ui.panel.owner',
-                actionType: 'openPanel',
-                actionValue: 'configResetPanel'
-            });
-        }
-
-        return items;
+export async function showConfigSubCategoryPanel(player: mc.Player, category: string, context: any = {}): Promise<void> {
+    if (!hasPermission(player, 'ui.panel.admin')) {
+        player.sendMessage('§cYou do not have permission to view configurations.');
+        return;
     }
+    const form = new ActionFormBuilder().title(`Config: ${category}`);
+    const systems = getSystemRegistry();
+    const matchingSystems = systems.filter((s) => (s.category ?? 'Uncategorized') === category && !s.hidden).sort((a, b) => a.title.localeCompare(b.title));
 
-    private getSubCategoryPanelItems(player: mc.Player, category: string, context: UIContext): PanelItem[] {
-        const items: PanelItem[] = [];
-        addBackButton(items, 'configCategoryPanel');
-        const systems = getSystemsByCategory(player, category);
-        const paginated = getPaginatedItems(systems, (context.page as number) || 1);
-        for (const sys of paginated) {
-            if (!isDefined(sys)) continue;
-            items.push({
-                id: sys.id,
-                text: sys.title,
-                icon: sys.icon,
-                permission: 'ui.panel.admin',
-                actionType: 'openPanel',
-                actionValue: sys.id
-            });
-        }
-        addPaginationItems(items, (context.page as number) || 1, systems.length, 'ui.panel.admin');
-        return items;
-    }
-
-    private getResetPanelItems(player: mc.Player, context: UIContext): PanelItem[] {
-        const items: PanelItem[] = [];
-        addBackButton(items, 'configCategoryPanel');
-        const categories = getVisibleCategories(player);
-
-        categories.push({
-            id: 'resetAll',
-            title: '§l§cReset All Systems',
-            icon: 'textures/ui/trash'
-        });
-
-        const paginated = getPaginatedItems(categories, (context.page as number) || 1);
-        for (const cat of paginated) {
-            if (!isDefined(cat)) continue;
-
-            if (cat.id === 'resetAll') {
-                items.push({
-                    id: 'resetAll',
-                    text: '§l§4Reset All Systems',
-                    icon: 'textures/ui/trash',
-                    permission: 'ui.panel.owner',
-                    actionType: 'functionCall',
-                    actionValue: 'resetAllConfig'
-                });
+    for (const sys of matchingSystems) {
+        form.button(sys.title, sys.icon, async () => {
+            if (sys.isSimpleConfig) {
+                await showSimpleConfigPanel(player, sys.id, category, context);
             } else {
-                items.push({
-                    id: cat.id,
-                    text: `Reset ${cat.title}`,
-                    icon: cat.icon,
-                    permission: 'ui.panel.owner',
-                    actionType: 'openPanel',
-                    actionValue: `configResetCategoryPanel_${cat.id}`
-                });
+                await showPanel(player, sys.configPanelId, context);
+            }
+        });
+    }
+
+    form.addBackButton(async () => {
+        await showConfigCategoryPanel(player, context);
+    });
+
+    await form.show(player);
+}
+
+export async function showSimpleConfigPanel(player: mc.Player, systemId: string, parentCategory: string, context: any = {}): Promise<void> {
+    const schema = configPanelSchema.find((s) => s.id === systemId);
+    if (!schema) {
+        player.sendMessage(`§cNo config schema found for ${systemId}.`);
+        return showConfigSubCategoryPanel(player, parentCategory, context);
+    }
+
+    const configSource = schema.configSource ?? 'main';
+    const handlers = uiConfigHandlers as Record<string, { get: () => unknown; save: (cfg: unknown) => void }>;
+    const handler = handlers[configSource];
+    if (!handler) {
+        player.sendMessage(`§cNo config handler found for source ${configSource}.`);
+        return showConfigSubCategoryPanel(player, parentCategory, context);
+    }
+
+    const config = handler.get() as Record<string, any>;
+    const form = new ModalFormBuilder().title(`Edit: ${schema.title}`);
+
+    for (const setting of schema.settings) {
+        const currentValue = getValueFromPath(config, setting.key);
+
+        if (setting.type === 'toggle') {
+            form.toggle(setting.key, setting.label, !!currentValue);
+        } else if (setting.type === 'dropdown') {
+            const options = setting.options ?? [];
+            let defaultIndex = 0;
+            if (setting.key === 'logLevel' && typeof currentValue === 'number') {
+                defaultIndex = currentValue;
+            } else if (typeof currentValue === 'string') {
+                defaultIndex = Math.max(0, options.indexOf(currentValue));
+            }
+            form.dropdown(setting.key, setting.label, options, defaultIndex);
+        } else if (setting.type === 'textField') {
+            const currentStr = currentValue !== undefined ? String(currentValue) : '';
+            form.textField(setting.key, setting.label, setting.description ?? '', currentStr);
+        }
+    }
+
+    const result = await form.show(player);
+    if (result.canceled) {
+        return showConfigSubCategoryPanel(player, parentCategory, context);
+    }
+
+    const updates: Record<string, any> = {};
+    const validSettings = schema.settings.filter((s) => ['toggle', 'textField', 'dropdown'].includes(s.type));
+    for (const setting of validSettings) {
+        if (!result.formValues) continue;
+        let value = result.formValues[setting.key];
+
+        if (setting.type === 'dropdown') {
+            const options = setting.options ?? [];
+            const selectedIndex = value as number;
+            value = setting.key === 'logLevel' ? selectedIndex : options[selectedIndex];
+        } else if (setting.type === 'textField') {
+            const strVal = value as string;
+            const current = getValueFromPath(config, setting.key);
+            if (
+                typeof current === 'number' ||
+                setting.key.includes('.x') ||
+                setting.key.includes('.y') ||
+                setting.key.includes('.z') ||
+                setting.key.includes('Radius') ||
+                setting.key.includes('Seconds') ||
+                setting.key.includes('Cost') ||
+                setting.key.includes('Length') ||
+                setting.key.includes('Percent') ||
+                setting.key.includes('Interval')
+            ) {
+                if (!Number.isNaN(Number(strVal)) && isNonEmptyString(strVal) && strVal.trim() !== '') {
+                    value = Number(strVal);
+                } else if (current === undefined && strVal.trim() === '') {
+                    value = undefined;
+                } else if (strVal.trim() !== '') {
+                    continue; // Skip invalid
+                }
             }
         }
-
-        addPaginationItems(items, (context.page as number) || 1, categories.length, 'ui.panel.admin');
-        return items;
+        updates[setting.key] = value;
     }
 
-    private getResetCategoryPanelItems(player: mc.Player, category: string, context: UIContext): PanelItem[] {
-        const items: PanelItem[] = [];
-        addBackButton(items, 'configResetPanel');
-        const systems = getSystemsByCategory(player, category);
-        const paginated = getPaginatedItems(systems, (context.page as number) || 1);
+    if (configSource === 'main') {
+        handler.save(updates);
+    } else {
+        const currentConfig = handler.get() as Record<string, any>;
+        for (const key in updates) {
+            setValueByPath(currentConfig, key, updates[key]);
+        }
+        handler.save(currentConfig);
+    }
 
-        items.push({
-            id: 'resetCategory',
-            text: `§l§4Reset All ${category}§r`,
-            icon: 'textures/ui/trash',
-            permission: 'ui.panel.owner',
-            actionType: 'functionCall',
-            actionValue: `resetCategory_${category}`
+    player.sendMessage('§2Configuration saved.');
+    if (systemId === 'data') {
+        await import('@core/dataManager.js').then(({ restartAutoSave }) => restartAutoSave());
+    }
+    if (configSource === 'xray') {
+        const { refreshXrayCache } = await import('@features/anticheat/xrayDetection.js');
+        refreshXrayCache();
+    }
+
+    await showConfigSubCategoryPanel(player, parentCategory, context);
+}
+
+export async function showConfigResetPanel(player: mc.Player, context: any = {}): Promise<void> {
+    if (!hasPermission(player, 'ui.panel.owner')) {
+        player.sendMessage('§cYou do not have permission to reset configurations.');
+        return;
+    }
+    const form = new ActionFormBuilder().title('Reset Configurations');
+
+    form.button('§4Reset ALL Systems', 'textures/ui/warning_alex', async () => {
+        await handleSystemReset(player, 'All Systems', context);
+    });
+
+    const systems = getSystemRegistry();
+    for (const sys of systems) {
+        form.button(`Reset ${sys.title}`, sys.icon, async () => {
+            await handleSystemReset(player, sys.id, context);
         });
-
-        for (const sys of paginated) {
-            if (!isDefined(sys)) continue;
-            items.push({
-                id: sys.id,
-                text: `§4Reset ${sys.title}`,
-                icon: sys.icon,
-                permission: 'ui.panel.owner',
-                actionType: 'functionCall',
-                actionValue: `resetSystem_${sys.id}`
-            });
-        }
-        addPaginationItems(items, (context.page as number) || 1, systems.length, 'ui.panel.admin');
-        return items;
     }
 
-    buildModal(_player: mc.Player, panelId: string, _context: UIContext): Promise<ModalFormData | undefined | void> {
-        if (panelId === 'configExportPanel' || panelId === 'configImportPanel') {
-            return this.buildTransferModal(panelId);
-        }
+    form.addBackButton(async () => {
+        await showConfigCategoryPanel(player, context);
+    });
 
-        if (!panelId.startsWith('config_')) return Promise.resolve();
+    await form.show(player);
+}
 
-        const categoryId = panelId.replace('config_', '');
-        const category = configPanelSchema.find((c) => c.id === categoryId);
-        if (!isDefined(category)) return Promise.resolve();
+import { resetConfigSection } from '@core/configManager.js';
 
-        const form = new ModalFormData().title(category.title);
-        const configSource = isNonEmptyString(category.configSource) ? category.configSource : 'main';
+async function handleSystemReset(player: mc.Player, systemId: string, context: any): Promise<void> {
+    const form = new ModalFormBuilder()
+        .title(`Confirm Reset`)
+        .textField('confirm', `Are you sure you want to reset ${systemId} to default settings?\nType 'confirm' to proceed.\n\n§4This action cannot be undone.`, 'Type confirm here');
 
-        const handlers = uiConfigHandlers as Record<string, { get: () => unknown; save: (cfg: unknown) => void }>;
-        const handler = handlers[configSource];
-
-        if (!isDefined(handler)) return Promise.resolve();
-
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const config = handler.get() as Record<string, any>;
-
-        // Cast settings to ConfigSetting array to avoid any errors
-        const settings = category.settings as unknown as ConfigSetting[];
-        this.addFormFields(form, settings, config);
-
-        return Promise.resolve(form);
+    const response = await form.show(player);
+    if (response.canceled || response.formValues?.confirm !== 'confirm') {
+        player.sendMessage('§cReset canceled or confirmation failed.');
+        return showConfigResetPanel(player, context);
     }
 
-    private buildTransferModal(panelId: string): Promise<ModalFormData> {
-        const form = new ModalFormData();
-        const systemOptions = systemOptionsCache;
-
-        if (panelId === 'configExportPanel') {
-            form.title('Export Configuration');
-            form.dropdown('Select System to Export', systemOptions, { defaultValueIndex: 0 });
-            form.textField('Action Information', 'The exported JSON data will appear in a new window after you submit.', { defaultValue: 'Submit to generate and receive export data.' });
+    if (systemId === 'All Systems') {
+        await resetConfigSection('all', player);
+        player.sendMessage('§aSuccessfully reset All Systems to default settings.');
+    } else {
+        const result = await resetConfigSection(systemId, player);
+        if (result.success) {
+            player.sendMessage(`§aSuccessfully reset ${systemId} to default settings.`);
         } else {
-            form.title('Import Configuration');
-            form.dropdown('Select Target System', systemOptions, { defaultValueIndex: 0 });
-            form.textField('Paste JSON Config Data', 'Paste the condensed JSON text here');
-        }
-
-        return Promise.resolve(form);
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private addFormFields(form: ModalFormData, settings: ConfigSetting[], config: Record<string, any>) {
-        // Filter settings to ensure consistent index mapping
-        const validSettings = settings.filter((s) => ['toggle', 'textField', 'dropdown'].includes(s.type));
-
-        for (const setting of validSettings) {
-            const currentValue = getValueFromPath(config, setting.key);
-            switch (setting.type) {
-                case 'toggle': {
-                    form.toggle(setting.label, { defaultValue: Boolean(currentValue) });
-                    break;
-                }
-                case 'textField': {
-                    const val = currentValue ?? '';
-                    const strVal = typeof val === 'string' || typeof val === 'number' || typeof val === 'boolean' ? String(val) : JSON.stringify(val);
-                    form.textField(setting.label, isNonEmptyString(setting.description) ? setting.description : '', {
-                        defaultValue: strVal
-                    });
-                    break;
-                }
-                case 'dropdown': {
-                    const options = setting.options ?? [];
-                    const index = setting.key === 'logLevel' && typeof currentValue === 'number' ? currentValue : options.indexOf(currentValue as string);
-                    form.dropdown(setting.label, options, { defaultValueIndex: Math.max(0, index) });
-                    break;
-                }
-            }
+            player.sendMessage(`§cCannot reset ${systemId}: ${result.message}`);
         }
     }
+    await showConfigResetPanel(player, context);
+    return;
+}
 
-    async handleResponse(player: mc.Player, panelId: string, response: ActionFormResponse | ModalFormResponse, context: UIContext): Promise<void> {
-        const selection = (response as ActionFormResponse).selection;
+export async function showConfigTransferPanel(player: mc.Player, context: any = {}): Promise<void> {
+    if (!hasPermission(player, 'ui.panel.owner')) {
+        player.sendMessage('§cYou do not have permission to manage configurations.');
+        return;
+    }
+    const form = new ActionFormBuilder().title('Config Transfer');
 
-        if (typeof selection === 'number') {
-            await this.handleSelection(player, panelId, selection, context);
-            return;
+    form.button('Export Config', 'textures/ui/arrow_right', async () => {
+        await showConfigExportPanel(player, context);
+    });
+
+    form.button('Import Config', 'textures/ui/arrow_left', async () => {
+        await showConfigImportPanel(player, context);
+    });
+
+    form.addBackButton(async () => {
+        await showConfigCategoryPanel(player, context);
+    });
+
+    await form.show(player);
+}
+
+export async function showConfigExportPanel(player: mc.Player, context: any = {}): Promise<void> {
+    if (!hasPermission(player, 'ui.panel.owner')) {
+        player.sendMessage('§cYou do not have permission to export configurations.');
+        return;
+    }
+    const options = getSystemOptions();
+    const form = new ModalFormBuilder().title('Export Config').dropdown('systemIndex', 'Select System to Export', options);
+
+    const result = await form.show(player);
+    if (result.canceled || !result.formValues) return showConfigTransferPanel(player, context);
+
+    const selectedSystem = options[result.formValues.systemIndex as number];
+    let exportData: unknown;
+
+    if (selectedSystem === 'All Systems') {
+        const allData: Record<string, unknown> = {};
+        for (const [key, handler] of uiConfigHandlerEntries) {
+            allData[key] = (handler as any).get();
         }
-
-        // Modal Handling
-        if (panelId.startsWith('config_')) {
-            await this.handleConfigModalSave(player, panelId, response, context);
-            return;
-        }
-
-        if (panelId === 'configExportPanel') {
-            return this.handleExportConfig(player, response, context);
-        }
-
-        if (panelId === 'configImportPanel') {
-            return this.handleImportConfig(player, response, context);
-        }
+        exportData = allData;
+    } else if (isDefined(selectedSystem) && isDefined(uiConfigHandlers[selectedSystem])) {
+        exportData = uiConfigHandlers[selectedSystem].get();
+    } else {
+        player.sendMessage('§4Invalid system selected.');
+        return showConfigTransferPanel(player, context);
     }
 
-    private async handleSelection(player: mc.Player, panelId: string, selection: number, context: UIContext): Promise<void> {
-        const items = await this.getItems(player, panelId, context);
-        if (selection >= 0 && selection < items.length) {
-            const item = items[selection];
-            if (!isDefined(item)) return;
-
-            if (item.actionType === 'openPanel') {
-                // Title Fix for SubCategories
-                if (item.actionValue.startsWith('configSubCategoryPanel_')) {
-                    const catId = item.actionValue.replace('configSubCategoryPanel_', '');
-                    const title =
-                        catId
-                            .replace(/([a-z])([A-Z])/g, '$1 $2')
-                            .replace(/([A-Z])([A-Z][a-z])/g, '$1 $2')
-                            .trim()
-                            .replace(/^./, (str) => str.toUpperCase()) + ' Configuration';
-                    return showPanel(player, item.actionValue, { ...context, page: 1, customTitle: title });
-                }
-                return showPanel(player, item.actionValue, { ...context, page: 1 });
-            }
-            if (item.actionValue === 'prevPage') {
-                return showPanel(player, panelId, {
-                    ...context,
-                    page: Math.max(1, ((context.page as number) || 1) - 1)
-                });
-            }
-            if (item.actionValue === 'nextPage') {
-                return showPanel(player, panelId, { ...context, page: ((context.page as number) || 1) + 1 });
-            }
-
-            if (item.actionValue === 'resetAllConfig' || item.actionValue.startsWith('resetCategory_') || item.actionValue.startsWith('resetSystem_')) {
-                await this.handleResetAction(player, item.actionValue, panelId, context);
-                return;
-            }
-
-            const { uiActionFunctions } = await import('@core/ui/actionRegistry.js');
-            const action = uiActionFunctions[item.actionValue];
-            if (isDefined(action)) {
-                await action(player, context, panelId);
-                return;
-            }
-
-            // Removed redundant functionCall check
-            player.sendMessage(`§cAction ${item.actionValue} not mapped.`);
-        }
+    try {
+        const jsonString = JSON.stringify(exportData);
+        const copyForm = new ModalFormBuilder().title('Exported Data').textField('data', 'Copy the data below:', 'JSON Data', jsonString);
+        await copyForm.show(player);
+    } catch (error) {
+        player.sendMessage(`§4Failed to generate export data. Check console for errors.`);
+        errorLog(`[UIManager] Failed to export config: ${String(error)}`);
     }
 
-    private async handleResetAction(player: mc.Player, actionValue: string, panelId: string, context: UIContext): Promise<void> {
-        if (actionValue === 'resetAllConfig') {
-            await this.handleResetAll(player, panelId, context);
-            return;
-        }
+    await showConfigTransferPanel(player, context);
+}
 
-        if (actionValue.startsWith('resetCategory_')) {
-            const category = actionValue.replace('resetCategory_', '');
-            await this.handleResetCategory(player, category, panelId, context);
-            return;
-        }
+export async function showConfigImportPanel(player: mc.Player, context: any = {}): Promise<void> {
+    if (!hasPermission(player, 'ui.panel.owner')) {
+        player.sendMessage('§cYou do not have permission to import configurations.');
+        return;
+    }
+    const options = getSystemOptions();
+    const form = new ModalFormBuilder().title('Import Config').dropdown('systemIndex', 'Select System to Import', options).textField('data', 'JSON Data', 'Paste JSON here');
 
-        if (actionValue.startsWith('resetSystem_')) {
-            const sysId = actionValue.replace('resetSystem_', '');
-            await this.handleResetSystem(player, sysId, panelId, context);
-        }
+    const result = await form.show(player);
+    if (result.canceled || !result.formValues) return showConfigTransferPanel(player, context);
+
+    const selectedSystem = options[result.formValues.systemIndex as number];
+    const jsonString = result.formValues.data as string;
+
+    if (!isNonEmptyString(jsonString) || jsonString.trim() === '') {
+        player.sendMessage('§4You must provide JSON data to import.');
+        return showConfigTransferPanel(player, context);
     }
 
-    private async handleResetAll(player: mc.Player, panelId: string, context: UIContext): Promise<void> {
-        await showConfirmationDialog(player, {
-            title: 'Confirm Reset All',
-            body: 'This action cannot be undone. Are you sure you want to reset ALL system configurations to their default values?',
-            confirmButtonText: '§4Yes, Reset All',
-            cancelButtonText: '§2No, Cancel',
-            onConfirm: async () => {
-                const finalConfirmForm = new ModalFormData().title('Final Confirmation').textField('Type "confirm" to reset ALL systems.', 'Case-insensitive', {
-                    defaultValue: ''
-                });
-                const finalConfirmResponse = await utils.uiWait(player, finalConfirmForm);
-                if (finalConfirmResponse.canceled) return showPanel(player, panelId, context);
-                const confirmModal = finalConfirmResponse as ModalFormResponse;
-                const confirmationValue = isDefined(confirmModal.formValues) && isDefined(confirmModal.formValues[0]) ? String(confirmModal.formValues[0]) : '';
-                if (confirmationValue.trim().toLowerCase() !== 'confirm') {
-                    player.sendMessage('§4Final confirmation failed. Reset canceled.');
-                    return showPanel(player, panelId, context);
-                }
-                const result = await resetConfigSection('all', player);
-                if (result.success) {
-                    player.sendMessage(`§2${result.message}`);
-                    refreshXrayCache();
-                } else {
-                    player.sendMessage('§4Failed to reset all configurations. Please check the console.');
-                    errorLog(`[UIManager] Failed to reset all: ${result.message}`);
-                }
-                return showPanel(player, panelId, { ...context, page: 1 });
-            },
-            onCancel: () => showPanel(player, panelId, context)
+    let importData: unknown;
+    try {
+        importData = JSON.parse(jsonString, (key, value) => {
+            if (key === '__proto__' || key === 'constructor' || key === 'prototype') return undefined;
+            return value;
         });
+    } catch {
+        player.sendMessage('§4Invalid JSON format. Please ensure you copied the entire exported string correctly.');
+        return showConfigTransferPanel(player, context);
     }
 
-    private async handleResetCategory(player: mc.Player, category: string, panelId: string, context: UIContext): Promise<void> {
-        // Removed dynamic import of getSystemsByCategory as it caused shadowing
-        const systems = getSystemsByCategory(player, category);
-
-        await showConfirmationDialog(player, {
-            title: `Reset ${category}`,
-            body: `Are you sure you want to reset all systems in the ${category} category?`,
-            confirmButtonText: '§4Yes, Reset Category',
-            cancelButtonText: '§2No, Cancel',
-            onConfirm: async () => {
-                let successCount = 0;
-                for (const sys of systems) {
-                    const res = await resetConfigSection(sys.id, player);
-                    if (res.success) successCount++;
-                }
-                player.sendMessage(`§2Reset ${successCount} systems in ${category}.`);
-                if (category === 'Moderation') refreshXrayCache();
-                return showPanel(player, panelId, context);
-            },
-            onCancel: () => showPanel(player, panelId, context)
-        });
-    }
-
-    private async handleResetSystem(player: mc.Player, sysId: string, panelId: string, context: UIContext): Promise<void> {
-        await showConfirmationDialog(player, {
-            title: `Reset System`,
-            body: `Reset this system to defaults?`,
-            confirmButtonText: '§4Yes, Reset',
-            cancelButtonText: '§2No, Cancel',
-            onConfirm: async () => {
-                const result = await resetConfigSection(sysId, player);
-                if (result.success) {
-                    player.sendMessage(`§2${result.message}`);
-                    if (sysId === 'xray') refreshXrayCache();
-                } else {
-                    player.sendMessage('§4Failed to reset.');
-                }
-                return showPanel(player, panelId, context);
-            },
-            onCancel: () => showPanel(player, panelId, context)
-        });
-    }
-
-    private async handleConfigModalSave(player: mc.Player, panelId: string, response: ModalFormResponse, context: UIContext): Promise<void> {
-        const categoryId = panelId.replace('config_', '');
-        const category = configPanelSchema.find((c) => c.id === categoryId);
-        const values = response.formValues;
-
-        if (response.canceled) {
-            if (isDefined(category) && isNonEmptyString(category.category)) {
-                return showPanel(player, `configSubCategoryPanel_${category.category}`, { ...context, page: 1 });
-            }
-            return showPanel(player, 'configCategoryPanel', { ...context, page: 1 });
-        }
-
-        if (isDefined(category) && isDefined(values)) {
-            const configSource = isNonEmptyString(category.configSource) ? category.configSource : 'main';
-            const handlers = uiConfigHandlers as Record<string, { get: () => unknown; save: (cfg: unknown) => void }>;
-            const handler = handlers[configSource];
-
-            if (isDefined(handler)) {
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                const config = handler.get() as Record<string, any>;
-                // Cast settings to ConfigSetting[] to match the type
-                const updates = this.processFormValues(category.settings as unknown as ConfigSetting[], values, config);
-
-                this.saveConfigUpdates(handler, configSource, updates);
-                player.sendMessage('§2Configuration saved.');
-
-                if (categoryId === 'data') {
-                    await import('@core/dataManager.js').then(({ restartAutoSave }) => restartAutoSave());
-                }
-
-                if (configSource === 'xray') {
-                    refreshXrayCache();
-                }
-            }
-        }
-        if (isDefined(category) && isNonEmptyString(category.category)) {
-            return showPanel(player, `configSubCategoryPanel_${category.category}`, { ...context, page: 1 });
-        }
-        return showPanel(player, 'configCategoryPanel', { ...context, page: 1 });
-    }
-
-    private handleExportConfig(player: mc.Player, response: ModalFormResponse, context: UIContext): Promise<void> | void {
-        if (!hasPermission(player, 'ui.panel.owner')) {
-            player.sendMessage('§4You do not have permission to export configurations.');
-            return showPanel(player, 'configTransferPanel', context);
-        }
-
-        if (response.canceled) return showPanel(player, 'configTransferPanel', context);
-
-        const values = response.formValues;
-        if (!isDefined(values) || !isDefined(values[0])) return showPanel(player, 'configTransferPanel', context);
-
-        const systemOptions = systemOptionsCache;
-        const selectedIndex = values[0] as number;
-        const selectedSystem = systemOptions[selectedIndex];
-
-        let exportData: unknown;
-
+    try {
         if (selectedSystem === 'All Systems') {
-            const allData: Record<string, unknown> = {};
+            const parsedData = importData as Record<string, unknown>;
             for (const [key, handler] of uiConfigHandlerEntries) {
-                allData[key] = handler.get();
+                if (isDefined(parsedData[key])) {
+                    (handler as any).save(parsedData[key]);
+                }
             }
-            exportData = allData;
+            player.sendMessage('§aSuccessfully imported All Systems configurations.');
         } else if (isDefined(selectedSystem) && isDefined(uiConfigHandlers[selectedSystem])) {
-            exportData = uiConfigHandlers[selectedSystem].get();
+            uiConfigHandlers[selectedSystem].save(importData);
+            player.sendMessage(`§aSuccessfully imported configuration for ${selectedSystem}.`);
         } else {
             player.sendMessage('§4Invalid system selected.');
-            return showPanel(player, 'configTransferPanel', context);
+            return showConfigTransferPanel(player, context);
         }
 
-        try {
-            const jsonString = JSON.stringify(exportData);
-            // Instead of putting it in chat, open a new read-only modal with the data
-            const form = new ModalFormData();
-            form.title('Exported Data');
-            form.textField('Copy the data below:', 'JSON Data', { defaultValue: jsonString });
-
-            void utils.uiWait(player, form).then(() => {
-                void showPanel(player, 'configTransferPanel', context);
-            });
-        } catch (error) {
-            player.sendMessage(`§4Failed to generate export data. Check console for errors.`);
-            errorLog(`[UIManager] Failed to export config: ${String(error)}`);
-            return showPanel(player, 'configTransferPanel', context);
+        // Trigger reloads
+        if (selectedSystem === 'All Systems' || selectedSystem === 'xray') {
+            const { refreshXrayCache } = await import('@features/anticheat/xrayDetection.js');
+            refreshXrayCache();
         }
+        if (selectedSystem === 'All Systems' || selectedSystem === 'ranks') {
+            await import('@core/rankManager.js').then(({ reloadRanks }) => reloadRanks());
+        }
+        if (selectedSystem === 'All Systems' || selectedSystem === 'spawn') {
+            await import('@features/essentials/spawnProtection.js').then(({ initializeSpawnProtection }) => initializeSpawnProtection());
+        }
+    } catch (error) {
+        player.sendMessage(`§4Failed to apply imported configuration. Check console for errors.`);
+        errorLog(`[UIManager] Failed to import config: ${String(error)}`);
     }
 
-    private handleImportConfig(player: mc.Player, response: ModalFormResponse, context: UIContext): Promise<void> | void {
-        if (!hasPermission(player, 'ui.panel.owner')) {
-            player.sendMessage('§4You do not have permission to import configurations.');
-            return showPanel(player, 'configTransferPanel', context);
-        }
-
-        if (response.canceled) return showPanel(player, 'configTransferPanel', context);
-
-        const values = response.formValues;
-        if (!isDefined(values) || !isDefined(values[0]) || !isDefined(values[1])) {
-            return showPanel(player, 'configTransferPanel', context);
-        }
-
-        const systemOptions = systemOptionsCache;
-        const selectedIndex = values[0] as number;
-        const selectedSystem = systemOptions[selectedIndex];
-        const jsonString = values[1] as string;
-
-        if (!isNonEmptyString(jsonString) || jsonString.trim() === '') {
-            player.sendMessage('§4You must provide JSON data to import.');
-            return showPanel(player, 'configTransferPanel', context);
-        }
-
-        let importData: unknown;
-        try {
-            importData = JSON.parse(jsonString, (key, value) => {
-                if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
-                    return undefined;
-                }
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-                return value;
-            });
-        } catch {
-            player.sendMessage('§4Invalid JSON format. Please ensure you copied the entire exported string correctly.');
-            return showPanel(player, 'configTransferPanel', context);
-        }
-
-        try {
-            if (selectedSystem === 'All Systems') {
-                const parsedData = importData as Record<string, unknown>;
-                for (const [key, handler] of uiConfigHandlerEntries) {
-                    if (isDefined(parsedData[key])) {
-                        handler.save(parsedData[key]);
-                    }
-                }
-                player.sendMessage('§aSuccessfully imported All Systems configurations.');
-            } else if (isDefined(selectedSystem) && isDefined(uiConfigHandlers[selectedSystem])) {
-                uiConfigHandlers[selectedSystem].save(importData);
-                player.sendMessage(`§aSuccessfully imported configuration for ${selectedSystem}.`);
-            } else {
-                player.sendMessage('§4Invalid system selected.');
-                return showPanel(player, 'configTransferPanel', context);
-            }
-
-            // Trigger reloads where necessary
-            if (selectedSystem === 'All Systems' || selectedSystem === 'xray') {
-                refreshXrayCache();
-            }
-            if (selectedSystem === 'All Systems' || selectedSystem === 'ranks') {
-                void import('@core/rankManager.js').then(({ reloadRanks }) => reloadRanks());
-            }
-            if (selectedSystem === 'All Systems' || selectedSystem === 'spawn') {
-                void import('@features/essentials/spawnProtection.js').then(({ initializeSpawnProtection }) => initializeSpawnProtection());
-            }
-        } catch (error) {
-            player.sendMessage(`§4Failed to apply imported configuration. Check console for errors.`);
-            errorLog(`[UIManager] Failed to import config: ${String(error)}`);
-        }
-
-        return showPanel(player, 'configTransferPanel', context);
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private processFormValues(settings: ConfigSetting[], values: unknown[], config: Record<string, any>): Record<string, unknown> {
-        const updates: Record<string, unknown> = {};
-        // Filter settings to match buildModal logic
-        const validSettings = settings.filter((s) => ['toggle', 'textField', 'dropdown'].includes(s.type));
-
-        for (const [index, setting] of validSettings.entries()) {
-            let value = values[index];
-            if (setting.type === 'dropdown') {
-                const options = setting.options ?? [];
-                const selectedIndex = value as number;
-                value = setting.key === 'logLevel' ? selectedIndex : options[selectedIndex];
-            } else if (setting.type === 'textField') {
-                const strVal = value as string;
-                const current = getValueFromPath(config, setting.key);
-                if (
-                    typeof current === 'number' ||
-                    setting.key.includes('.x') ||
-                    setting.key.includes('.y') ||
-                    setting.key.includes('.z') ||
-                    setting.key.includes('Radius') ||
-                    setting.key.includes('Seconds') ||
-                    setting.key.includes('Cost') ||
-                    setting.key.includes('Length') ||
-                    setting.key.includes('Percent') ||
-                    setting.key.includes('Interval')
-                ) {
-                    if (!Number.isNaN(Number(strVal)) && isNonEmptyString(strVal) && strVal.trim() !== '') {
-                        value = Number(strVal);
-                    } else if (current === undefined && strVal.trim() === '') {
-                        // Allow resetting to undefined
-                        value = undefined;
-                    } else if (strVal.trim() !== '') {
-                        // Skip update if input is invalid for a number field, but allow empty strings if current is undefined
-                        continue;
-                    }
-                }
-            }
-            updates[setting.key] = value;
-        }
-        return updates;
-    }
-
-    private saveConfigUpdates(handler: { get: () => unknown; save: (cfg: unknown) => void }, configSource: string, updates: Record<string, unknown>) {
-        if (configSource === 'main') {
-            handler.save(updates);
-        } else {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const currentConfig = handler.get() as Record<string, any>;
-            for (const key in updates) {
-                setValueByPath(currentConfig, key, updates[key]);
-            }
-            handler.save(currentConfig);
-        }
-    }
+    await showConfigTransferPanel(player, context);
 }

--- a/src/core/ui/panels/generalPanel.ts
+++ b/src/core/ui/panels/generalPanel.ts
@@ -1,44 +1,107 @@
-import * as mc from '@minecraft/server';
-import { ActionFormResponse } from '@minecraft/server-ui';
-
+import { hasPermission } from '@core/permissionEngine.js';
 import { showPanel } from '@core/uiManager.js';
-import { isDefined } from '@lib/guards.js';
+import * as mc from '@minecraft/server';
+import { ActionFormBuilder } from '@ui/builders/ActionFormBuilder.js';
+
 import { getStaticMenuItems } from '@ui/panelBuilder.js';
-import { panelDefinitions, PanelItem, UIContext } from '@ui/panelRegistry.js';
-import { IPanelHandler } from '@ui/types.js';
+import { panelDefinitions } from '@ui/panelRegistry.js';
 
-export class GeneralPanelHandler implements IPanelHandler {
-    canHandle(panelId: string): boolean {
-        return panelId === 'mainPanel' || panelId === 'profileMainPanel' || panelId === 'bountyActionsPanel' || panelId === 'bountyListPanel';
-    }
+export async function showMainPanel(player: mc.Player): Promise<void> {
+    const form = new ActionFormBuilder().title('Main Menu');
+    const def = panelDefinitions['mainPanel'];
 
-    getItems(player: mc.Player, panelId: string, _context: UIContext): Promise<PanelItem[]> {
-        const items: PanelItem[] = [];
-        const def = panelDefinitions[panelId];
-        if (isDefined(def)) {
-            const staticItems = getStaticMenuItems(player, def);
-            items.push(...staticItems);
+    if (def) {
+        const items = getStaticMenuItems(player, def);
+        for (const item of items) {
+            if (item.id === '__back__') continue;
+            form.button(item.text, item.icon, async () => {
+                if (item.actionType === 'openPanel') {
+                    await showPanel(player, item.actionValue, { page: 1 });
+                } else {
+                    const { uiActionFunctions } = await import('@core/ui/actionRegistry.js');
+                    const action = uiActionFunctions[item.actionValue];
+                    if (action) await action(player, {}, 'mainPanel');
+                }
+            });
         }
-        return Promise.resolve(items);
     }
 
-    async handleResponse(player: mc.Player, panelId: string, response: ActionFormResponse, context: UIContext): Promise<void> {
-        if (response.canceled || response.selection === undefined) return;
+    form.addCloseButton();
 
-        const items = await this.getItems(player, panelId, context);
-        if (response.selection >= 0 && response.selection < items.length) {
-            const item = items[response.selection];
-            if (!isDefined(item)) return;
-            if (item.actionType === 'openPanel') {
-                return showPanel(player, item.actionValue, { ...context, page: 1 });
-            }
+    await form.show(player);
+}
+
+export async function showProfileMainPanel(player: mc.Player): Promise<void> {
+    const form = new ActionFormBuilder().title('Profile');
+
+    if (hasPermission(player, 'ui.panel.member')) {
+        form.button('My Stats', 'textures/ui/profile_glyph_color.png', async () => {
+            await showPanel(player, 'myStatsPanel');
+        });
+        form.button('TPA Settings', 'textures/items/ender_pearl', async () => {
+            await showPanel(player, 'tpaSettingsPanel');
+        });
+    }
+
+    form.addBackButton(async () => {
+        await showMainPanel(player);
+    });
+
+    await form.show(player);
+}
+
+export async function showBountyListPanel(player: mc.Player): Promise<void> {
+    const form = new ActionFormBuilder().title('Bounty List');
+    const { getAllBounties } = await import('@features/economy/bountyManager.js');
+    const { formatCurrency } = await import('@core/utils/economy.js');
+
+    const bountiesMap = getAllBounties();
+    const bounties = Array.from(bountiesMap.values());
+
+    if (bounties.length === 0) {
+        form.body('There are currently no active bounties.');
+    } else {
+        for (const bounty of bounties) {
+            form.button(`${bounty.name}\n§6${formatCurrency(bounty.amount)}`, 'textures/items/netherite_sword', async () => {
+                await showPanel(player, 'bountyActionsPanel', {
+                    targetPlayerId: bounty.playerId,
+                    targetPlayerName: bounty.name,
+                    returnPanel: 'bountyListPanel',
+                    customTitle: bounty.name
+                });
+            });
+        }
+    }
+
+    form.addBackButton(async () => {
+        await showMainPanel(player);
+    });
+
+    await form.show(player);
+}
+
+export async function showBountyActionsPanel(player: mc.Player, targetPlayerId: string, targetPlayerName: string): Promise<void> {
+    const form = new ActionFormBuilder().title(targetPlayerName);
+
+    if (hasPermission(player, 'ui.panel.member')) {
+        form.button('Add Bounty', 'textures/items/netherite_sword', async () => {
             const { uiActionFunctions } = await import('@core/ui/actionRegistry.js');
-            const action = uiActionFunctions[item.actionValue];
-            if (isDefined(action)) {
-                await action(player, context, panelId);
-                return;
-            }
-            player.sendMessage(`§cAction ${item.actionValue} not mapped.`);
-        }
+            const action = uiActionFunctions['bountyPlayer'];
+            if (action) await action(player, { targetPlayerId, targetPlayerName }, 'bountyActionsPanel');
+        });
     }
+
+    if (hasPermission(player, 'ui.panel.mod')) {
+        form.button('Remove Bounty', 'textures/ui/cancel', async () => {
+            const { uiActionFunctions } = await import('@core/ui/actionRegistry.js');
+            const action = uiActionFunctions['removePlayerBounty'];
+            if (action) await action(player, { targetPlayerId, targetPlayerName }, 'bountyActionsPanel');
+        });
+    }
+
+    form.addBackButton(async () => {
+        await showBountyListPanel(player);
+    });
+
+    await form.show(player);
 }

--- a/src/core/ui/panels/index.ts
+++ b/src/core/ui/panels/index.ts
@@ -1,19 +1,11 @@
 import { panelRouter } from '@ui/PanelRouter.js';
 import { SidebarPanelHandler } from '@ui/panels/sidebarPanel.js';
-import { AdminPanelHandler } from './adminPanel.js';
-import { ConfigPanelHandler } from './configPanel.js';
-import { GeneralPanelHandler } from './generalPanel.js';
 import { InfoPanelHandler } from './infoPanel.js';
-import { PlayerPanelHandler } from './playerPanel.js';
 import { RankPanelHandler } from './rankPanel.js';
 
 export function initialize() {
     // Core Handlers
-    panelRouter.register(new AdminPanelHandler());
-    panelRouter.register(new ConfigPanelHandler());
-    panelRouter.register(new GeneralPanelHandler());
     panelRouter.register(new InfoPanelHandler());
-    panelRouter.register(new PlayerPanelHandler());
     panelRouter.register(new RankPanelHandler());
     panelRouter.register(new SidebarPanelHandler());
 }

--- a/src/core/ui/panels/playerPanel.ts
+++ b/src/core/ui/panels/playerPanel.ts
@@ -1,158 +1,11 @@
-import * as mc from '@minecraft/server';
-import { ActionFormData, ActionFormResponse, ModalFormData } from '@minecraft/server-ui';
-
 import { getConfig } from '@core/configManager.js';
 import { getVisiblePlayers, loadPlayerData } from '@core/playerDataManager.js';
 import { getPlayerRank } from '@core/rankManager.js';
-import { getStaticMenuItems } from '@core/ui/panelBuilder.js';
-import { panelDefinitions } from '@core/ui/panelRegistry.js';
-import { IPanelHandler, PanelItem, UIContext } from '@core/ui/types.js';
 import { showPanel } from '@core/uiManager.js';
 import { formatCurrency } from '@core/utils/economy.js';
 import { getPlayerIcon } from '@core/utils/ui.js';
-import { isDefined } from '@lib/guards.js';
-
-export class PlayerPanelHandler implements IPanelHandler {
-    canHandle(panelId: string): boolean {
-        return panelId.startsWith('player') || panelId === 'myStatsPanel' || panelId === 'playerManagementPanel';
-    }
-
-    getItems(player: mc.Player, panelId: string, _context: UIContext): Promise<PanelItem[] | undefined> {
-        const config = getConfig();
-        const def = panelDefinitions[panelId];
-        const baseItems = isDefined(def) ? getStaticMenuItems(player, def, _context) : [];
-
-        if (panelId === 'playerListPanel' || panelId === 'playerManagementPanel') {
-            const players = getVisiblePlayers(player);
-            const playerItems: PanelItem[] = players.map((p) => {
-                const targetRank = getPlayerRank(p, config);
-                const rankText = targetRank.chatFormatting?.prefixText ? `[${targetRank.chatFormatting.prefixText}]` : `[${targetRank.name}]`;
-                return {
-                    id: `player_${p.id}`,
-                    text: `${p.name}\n§r${rankText}`,
-                    icon: getPlayerIcon(p),
-                    actionType: 'openPanel',
-                    actionValue: 'playerActionsPanel',
-                    permission: 'ui.panel.member'
-                };
-            });
-            // Append player items to static items (which includes back button at start)
-            return Promise.resolve([...baseItems, ...playerItems]);
-        }
-
-        if (panelId === 'myStatsPanel') {
-            const data = loadPlayerData(player.id);
-            if (!data) return Promise.resolve(baseItems);
-
-            const stats: PanelItem[] = [
-                {
-                    id: 'stat_money',
-                    text: `§2Balance: §r${formatCurrency(data.balance)}`,
-                    icon: 'textures/items/emerald',
-                    permission: 'ui.panel.member',
-                    actionType: 'functionCall',
-                    actionValue: 'noop'
-                },
-                {
-                    id: 'stat_rank',
-                    text: `§6Rank: §r${data.rankId}`,
-                    icon: 'textures/ui/icon_rank',
-                    permission: 'ui.panel.member',
-                    actionType: 'functionCall',
-                    actionValue: 'noop'
-                },
-                {
-                    id: 'stat_playtime',
-                    text: `§3Playtime: §r${formatDuration(data.totalPlayTime)}`,
-                    icon: 'textures/items/clock_item',
-                    permission: 'ui.panel.member',
-                    actionType: 'functionCall',
-                    actionValue: 'noop'
-                },
-                {
-                    id: 'stat_kills',
-                    text: `§4Kills: §r${data.kills}`,
-                    icon: 'textures/items/iron_sword',
-                    permission: 'ui.panel.member',
-                    actionType: 'functionCall',
-                    actionValue: 'noop'
-                },
-                {
-                    id: 'stat_deaths',
-                    text: `§4Deaths: §r${data.deaths}`,
-                    icon: 'textures/ui/skull_face',
-                    permission: 'ui.panel.member',
-                    actionType: 'functionCall',
-                    actionValue: 'noop'
-                }
-            ];
-            return Promise.resolve([...baseItems, ...stats]);
-        }
-
-        // Return undefined for panels handled by static logic or other means
-        // But for 'playerActionsPanel', getItems should probably return static items?
-        // Actually, if we return undefined, panelBuilder falls back to static items.
-        // But since we implement handleResponse, we need to be consistent.
-        // Let's rely on fallback if not handled here.
-
-        return Promise.resolve(undefined);
-    }
-
-    async handleResponse(player: mc.Player, panelId: string, response: ActionFormResponse, context: UIContext): Promise<void> {
-        if (response.canceled || response.selection === undefined) return;
-
-        // Re-generate items to match selection index
-        // Use getItems first
-        let items = await this.getItems(player, panelId, context);
-
-        // If getItems returned undefined, use static items (fallback logic from panelBuilder)
-        if (!isDefined(items)) {
-            const def = panelDefinitions[panelId];
-            if (isDefined(def)) {
-                items = getStaticMenuItems(player, def, context);
-            } else {
-                return;
-            }
-        }
-
-        const selectedItem = items[response.selection];
-        if (!isDefined(selectedItem)) return;
-
-        if (selectedItem.id === '__back__') {
-            // Handled by actionValue usually
-            if (isDefined(context) && isDefined(context.returnPanel)) {
-                delete context.returnPanel;
-            }
-        }
-
-        if (selectedItem.actionType === 'openPanel') {
-            const newContext = { ...context };
-            // Pass target player ID if selecting a player
-            if (selectedItem.id.startsWith('player_')) {
-                const targetId = selectedItem.id.replace('player_', '');
-                newContext.targetPlayerId = targetId;
-                newContext.customTitle = selectedItem.text; // Use player name as title for actions panel
-                newContext.returnPanel = panelId; // Return to current panel on back/cancel
-            }
-            return showPanel(player, selectedItem.actionValue, newContext);
-        } else {
-            if (selectedItem.actionValue === 'noop') return;
-            const { uiActionFunctions } = await import('@core/ui/actionRegistry.js');
-            const action = uiActionFunctions[selectedItem.actionValue];
-            if (isDefined(action)) {
-                await action(player, context, panelId);
-                return;
-            }
-            player.sendMessage(`§cAction ${selectedItem.actionValue} not mapped.`);
-        }
-    }
-
-    // eslint-disable-next-line @typescript-eslint/require-await
-    async buildModal(_player: mc.Player, _panelId: string, _context: UIContext): Promise<ActionFormData | ModalFormData | undefined> {
-        // No modals handled here currently
-        return undefined;
-    }
-}
+import * as mc from '@minecraft/server';
+import { ActionFormBuilder } from '@ui/builders/ActionFormBuilder.js';
 
 function formatDuration(ms: number): string {
     const seconds = Math.floor(ms / 1000);
@@ -162,4 +15,100 @@ function formatDuration(ms: number): string {
 
     if (h > 0) return `${h}h ${m}m`;
     return `${m}m ${s}s`;
+}
+
+export async function showPlayerListPanel(player: mc.Player): Promise<void> {
+    const form = new ActionFormBuilder().title('Player List');
+    const config = getConfig();
+    const players = getVisiblePlayers(player);
+
+    for (const p of players) {
+        const targetRank = getPlayerRank(p, config);
+        const rankText = targetRank.chatFormatting?.prefixText ? `[${targetRank.chatFormatting.prefixText}]` : `[${targetRank.name}]`;
+        form.button(`${p.name}\n§r${rankText}`, getPlayerIcon(p), async () => {
+            await showPlayerActionsPanel(player, p.id, p.name, 'playerListPanel');
+        });
+    }
+
+    form.addBackButton(async () => {
+        await showPanel(player, 'mainPanel');
+    });
+
+    await form.show(player);
+}
+
+export async function showPlayerManagementPanel(player: mc.Player): Promise<void> {
+    const form = new ActionFormBuilder().title('Player Management');
+    const config = getConfig();
+    const players = getVisiblePlayers(player);
+
+    for (const p of players) {
+        const targetRank = getPlayerRank(p, config);
+        const rankText = targetRank.chatFormatting?.prefixText ? `[${targetRank.chatFormatting.prefixText}]` : `[${targetRank.name}]`;
+        form.button(`${p.name}\n§r${rankText}`, getPlayerIcon(p), async () => {
+            await showPlayerActionsPanel(player, p.id, p.name, 'playerManagementPanel');
+        });
+    }
+
+    form.addBackButton(async () => {
+        await showPanel(player, 'staffDashboardPanel');
+    });
+
+    await form.show(player);
+}
+
+export async function showMyStatsPanel(player: mc.Player): Promise<void> {
+    const form = new ActionFormBuilder().title('My Stats');
+    const data = loadPlayerData(player.id);
+
+    if (data) {
+        form.button(`§2Balance: §r${formatCurrency(data.balance)}`, 'textures/items/emerald');
+        form.button(`§6Rank: §r${data.rankId}`, 'textures/ui/icon_rank');
+        form.button(`§3Playtime: §r${formatDuration(data.totalPlayTime)}`, 'textures/items/clock_item');
+        form.button(`§4Kills: §r${data.kills}`, 'textures/items/iron_sword');
+        form.button(`§4Deaths: §r${data.deaths}`, 'textures/ui/skull_face');
+    } else {
+        form.body('Could not load player data.');
+    }
+
+    form.addBackButton(async () => {
+        await showPanel(player, 'profileMainPanel');
+    });
+
+    await form.show(player);
+}
+
+import { getStaticMenuItems } from '@ui/panelBuilder.js';
+import { panelDefinitions } from '@ui/panelRegistry.js';
+
+export async function showPlayerActionsPanel(player: mc.Player, targetPlayerId: string, targetPlayerName: string, returnPanelId: string): Promise<void> {
+    const form = new ActionFormBuilder().title(targetPlayerName);
+    const def = panelDefinitions['playerActionsPanel'];
+
+    if (def) {
+        const context = { targetPlayerId, targetPlayerName, customTitle: targetPlayerName };
+        const items = getStaticMenuItems(player, def, context);
+        for (const item of items) {
+            if (item.id === '__back__') continue;
+            form.button(item.text, item.icon, async () => {
+                if (item.actionType === 'openPanel') {
+                    await showPanel(player, item.actionValue, context);
+                } else {
+                    const { uiActionFunctions } = await import('@core/ui/actionRegistry.js');
+                    const action = uiActionFunctions[item.actionValue];
+                    if (action) await action(player, context, 'playerActionsPanel');
+                }
+            });
+        }
+    }
+
+    form.addBackButton(async () => {
+        if (returnPanelId === 'playerManagementPanel') {
+            await showPlayerManagementPanel(player);
+        } else {
+            await showPlayerListPanel(player);
+        }
+    });
+
+    await form.show(player);
 }

--- a/src/core/uiManager.ts
+++ b/src/core/uiManager.ts
@@ -29,6 +29,92 @@ export async function showPanel(player: mc.Player, panelId: string, context: UIC
 
         context.history = context.history || [];
 
+        // Intercept functionally migrated panels (Session 2)
+        if (panelId === 'mainPanel') {
+            const { showMainPanel } = await import('@ui/panels/generalPanel.js');
+            return showMainPanel(player);
+        }
+        if (panelId === 'profileMainPanel') {
+            const { showProfileMainPanel } = await import('@ui/panels/generalPanel.js');
+            return showProfileMainPanel(player);
+        }
+        if (panelId === 'bountyListPanel') {
+            const { showBountyListPanel } = await import('@ui/panels/generalPanel.js');
+            return showBountyListPanel(player);
+        }
+        if (panelId === 'bountyActionsPanel') {
+            const { showBountyActionsPanel } = await import('@ui/panels/generalPanel.js');
+            return showBountyActionsPanel(player, context.targetPlayerId as string, context.targetPlayerName as string);
+        }
+        if (panelId === 'staffDashboardPanel') {
+            const { showStaffDashboardPanel } = await import('@ui/panels/adminPanel.js');
+            return showStaffDashboardPanel(player);
+        }
+        if (panelId === 'floatingTextListPanel') {
+            const { showFloatingTextListPanel } = await import('@ui/panels/adminPanel.js');
+            return showFloatingTextListPanel(player);
+        }
+        if (panelId === 'floatingTextCreatePanel') {
+            const { showFloatingTextCreatePanel } = await import('@ui/panels/adminPanel.js');
+            return showFloatingTextCreatePanel(player);
+        }
+        if (panelId === 'floatingTextEditPanel') {
+            const { showFloatingTextEditPanel } = await import('@ui/panels/adminPanel.js');
+            return showFloatingTextEditPanel(player, context.id as string);
+        }
+        if (panelId === 'floatingTextActionPanel') {
+            const { showFloatingTextActionPanel } = await import('@ui/panels/adminPanel.js');
+            return showFloatingTextActionPanel(player, context.id as string);
+        }
+        if (panelId === 'playerListPanel') {
+            const { showPlayerListPanel } = await import('@ui/panels/playerPanel.js');
+            return showPlayerListPanel(player);
+        }
+        if (panelId === 'playerManagementPanel') {
+            const { showPlayerManagementPanel } = await import('@ui/panels/playerPanel.js');
+            return showPlayerManagementPanel(player);
+        }
+        if (panelId === 'myStatsPanel') {
+            const { showMyStatsPanel } = await import('@ui/panels/playerPanel.js');
+            return showMyStatsPanel(player);
+        }
+        if (panelId === 'playerActionsPanel') {
+            const { showPlayerActionsPanel } = await import('@ui/panels/playerPanel.js');
+            return showPlayerActionsPanel(player, context.targetPlayerId as string, context.customTitle as string, context.returnPanel as string);
+        }
+        if (panelId.startsWith('config_')) {
+            const { showSimpleConfigPanel } = await import('@ui/panels/configPanel.js');
+            const systemId = panelId.replace('config_', '');
+            // For simple configs triggered directly, we fallback the category to 'Uncategorized' or retrieve it from system registry
+            const { getSystemRegistry } = await import('@ui/systemRegistry.js');
+            const sys = getSystemRegistry().find((s) => s.id === systemId);
+            return showSimpleConfigPanel(player, systemId, sys?.category ?? 'Uncategorized', context);
+        }
+        if (panelId === 'configCategoryPanel') {
+            const { showConfigCategoryPanel } = await import('@ui/panels/configPanel.js');
+            return showConfigCategoryPanel(player, context);
+        }
+        if (panelId.startsWith('configSubCategoryPanel_')) {
+            const { showConfigSubCategoryPanel } = await import('@ui/panels/configPanel.js');
+            return showConfigSubCategoryPanel(player, panelId.replace('configSubCategoryPanel_', ''), context);
+        }
+        if (panelId === 'configResetPanel') {
+            const { showConfigResetPanel } = await import('@ui/panels/configPanel.js');
+            return showConfigResetPanel(player, context);
+        }
+        if (panelId === 'configTransferPanel') {
+            const { showConfigTransferPanel } = await import('@ui/panels/configPanel.js');
+            return showConfigTransferPanel(player, context);
+        }
+        if (panelId === 'configExportPanel') {
+            const { showConfigExportPanel } = await import('@ui/panels/configPanel.js');
+            return showConfigExportPanel(player, context);
+        }
+        if (panelId === 'configImportPanel') {
+            const { showConfigImportPanel } = await import('@ui/panels/configPanel.js');
+            return showConfigImportPanel(player, context);
+        }
+
         const form = await buildPanelForm(player, panelId, context);
         if (!isDefined(form)) {
             debugLog(`[UIManager] buildPanelForm returned undefined for panel '${panelId}'. Aborting.`);


### PR DESCRIPTION
Completes Session 2 of the UI Refactoring Plan:

- Refactored `generalPanel.ts` & `mainPanel` to use functional builder patterns.
- Refactored `adminPanel.ts` (Staff Dashboard, Floating Text tools).
- Refactored `playerPanel.ts` (Player List, Management, Stats, Actions).
- Refactored `configPanel.ts` (Categories, Import/Export, Settings).
- Removed legacy handlers from `index.ts`.
- Hooked functional entries into `uiManager.ts` to allow backward compatibility.
- Updated `plan.md` checkboxes and added Handover Context for Session 3.
- Tests, typechecks, formatting, and build pipelines all verified successfully.

---
*PR created automatically by Jules for task [3860001120461750275](https://jules.google.com/task/3860001120461750275) started by @SjnExe*