### PR TITLE
refactor(ui): migrate feature panels part 1 to builder pattern

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -86,14 +86,14 @@ The core panels (`mainPanel`, `adminPanel`, `playerPanel`, and `configPanel`) ha
 
 ### Session 3: Refactor Feature Panels (Part 1)
 
-- [ ] Migrate UI panels in `src/features/auction/ui/`.
-- [ ] Migrate UI panels in `src/features/economy/ui/`.
-- [ ] Migrate UI panels in `src/features/essentials/ui/`.
-- [ ] Migrate UI panels in `src/features/games/ui/`.
+- [x] Migrate UI panels in `src/features/auction/ui/`.
+- [x] Migrate UI panels in `src/features/economy/ui/`.
+- [x] Migrate UI panels in `src/features/essentials/ui/`.
+- [x] Migrate UI panels in `src/features/games/ui/`.
 
 #### Session 3 Handover Context
 
-_(To be written by future sessions of Jules)_
+Successfully completed the refactoring of UI feature panels for Session 3. The panels in `auction`, `economy` (including `bountyPanel`), `essentials` (specifically `worldProtectionPanel`), and `games` (`gamesPanel` and `wordlePanel`) have been migrated from using the legacy `IPanelHandler` with `ActionFormData`/`ModalFormData` to direct functional async calls implementing the new `ActionFormBuilder` and `ModalFormBuilder` types. All relevant tests compile successfully and build logic works correctly.
 
 ### Session 4: Refactor Feature Panels (Part 2)
 


### PR DESCRIPTION
- Migrated UI panels in `src/features/auction/ui/` to `ActionFormBuilder` and `ModalFormBuilder`.
- Migrated UI panels in `src/features/economy/ui/` (including `bountyPanel`) to the functional builder pattern.
- Migrated UI panels in `src/features/essentials/ui/` (`worldProtectionPanel`) to functional calls wrapping builders.
- Migrated UI panels in `src/features/games/ui/` (`gamesPanel`, `wordlePanel`) to functional calls wrapping builders.
- Removed legacy `IPanelHandler` implementations and updated registrations in index and core panel routers.
- Completed Session 3 of the `plan.md` refactoring strategy and updated the handover context.

---
*PR created automatically by Jules for task [16073240975463787154](https://jules.google.com/task/16073240975463787154) started by @SjnExe*