### PR TITLE
Refactor feature UI panels (Session 4)

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -97,17 +97,17 @@ Successfully migrated all UI panels within the `auction`, `economy`, `essentials
 
 ### Session 4: Refactor Feature Panels (Part 2)
 
-- [ ] Migrate UI panels in `src/features/kit/ui/`.
-- [ ] Migrate UI panels in `src/features/moderation/ui/`.
-- [ ] Migrate UI panels in `src/features/shop/ui/`.
-- [ ] Migrate UI panels in `src/features/social/ui/`.
-- [ ] Migrate UI panels in `src/features/team/ui/`.
-- [ ] Migrate UI panels in `src/features/teleport/ui/`.
-- [ ] Migrate UI panels in `src/features/vote/ui/`.
+- [x] Migrate UI panels in `src/features/kit/ui/`.
+- [x] Migrate UI panels in `src/features/moderation/ui/`.
+- [x] Migrate UI panels in `src/features/shop/ui/`.
+- [x] Migrate UI panels in `src/features/social/ui/`.
+- [x] Migrate UI panels in `src/features/team/ui/`.
+- [x] Migrate UI panels in `src/features/teleport/ui/`.
+- [x] Migrate UI panels in `src/features/vote/ui/`.
 
 #### Session 4 Handover Context
 
-_(To be written by future sessions of Jules)_
+Successfully replaced all legacy string-based `showPanel` routing with direct asynchronous functional imports (e.g. `showMainPanel`, `showMyStatsPanel`) within `shop`, `social`, `team`, and `teleport` UI feature files. The `vote` UI feature panel was also completely refactored to remove `ActionFormData` and `ModalFormData` in favor of the strongly-typed `ActionFormBuilder` and `ModalFormBuilder`, effectively decoupling it from the old manual index-matching logic. All changes were verified against `bun run check-types`. The next steps in Session 5 can now proceed to clean up the deprecated legacy routing and registry logic directly.
 
 ### Session 5: Update Systems Registry and Remove Legacy Code
 

--- a/src/core/__tests__/timerManager.test.ts
+++ b/src/core/__tests__/timerManager.test.ts
@@ -15,8 +15,8 @@ describe('timerManager', () => {
 
         // Reset all mocks on system methods
         if ((mc.system.runInterval as any).mockClear) (mc.system.runInterval as any).mockClear();
-        if ((mc.system.runTimeout as any).mockClear) (mc.system.runTimeout as any).mockClear();
-        if ((mc.system.runJob as any).mockClear) (mc.system.runJob as any).mockClear();
+        if ((mc.system.runTimeout as any)&&(mc.system.runTimeout as any).mockClear) (mc.system.runTimeout as any).mockClear();
+        if ((mc.system.runJob as any)&&(mc.system.runJob as any).mockClear) (mc.system.runJob as any).mockClear();
         if ((mc.system.clearRun as any).mockClear) (mc.system.clearRun as any).mockClear();
         if ((mc.system as any).clearJob && (mc.system as any).clearJob.mockClear) (mc.system as any).clearJob.mockClear();
     });

--- a/src/features/shop/ui/userPanel.ts
+++ b/src/features/shop/ui/userPanel.ts
@@ -1,6 +1,5 @@
 import { getShopConfig } from '@core/configurations.js';
 import { hasPermission } from '@core/permissionEngine.js';
-import { showPanel } from '@core/uiManager.js';
 import { formatCurrency } from '@core/utils.js';
 import { buyItem, getPlayerShopItemPrice, sellItem } from '@features/shop/manager.js';
 import { ensureItemsConfig } from '@features/shop/utils.js';
@@ -52,7 +51,8 @@ export async function showShopMainPanel(player: mc.Player): Promise<void> {
     }
 
     form.addBackButton(async () => {
-        await showPanel(player, 'mainPanel');
+        const { showMainPanel } = await import('@core/ui/panels/mainPanel.js');
+        await showMainPanel(player);
     });
 
     await form.show(player);

--- a/src/features/social/ui/friendPanel.ts
+++ b/src/features/social/ui/friendPanel.ts
@@ -2,7 +2,6 @@ import { getConfig } from '@core/configManager.js';
 import { getAllPlayersFromCache, getPlayerFromCache } from '@core/playerCache.js';
 import { getOrCreatePlayer, getPlayer, getPlayerIdByName } from '@core/playerDataManager.js';
 import { getPlayerRank } from '@core/rankManager.js';
-import { showPanel } from '@core/uiManager.js';
 import { getPlayerIcon } from '@core/utils/ui.js';
 import * as friendManager from '@features/social/friendManager.js';
 import * as mc from '@minecraft/server';
@@ -24,7 +23,8 @@ export async function showFriendMainPanel(player: mc.Player): Promise<void> {
         });
 
     form.addBackButton(async () => {
-        await showPanel(player, 'mainPanel');
+        const { showMainPanel } = await import('@core/ui/panels/mainPanel.js');
+        await showMainPanel(player);
     });
 
     await form.show(player);

--- a/src/features/team/ui/panel.ts
+++ b/src/features/team/ui/panel.ts
@@ -2,7 +2,6 @@ import { getConfig } from '@core/configManager.js';
 import { getPlayerFromCache } from '@core/playerCache.js';
 import { loadPlayerData } from '@core/playerDataManager.js';
 import { getPlayerRank } from '@core/rankManager.js';
-import { showPanel } from '@core/uiManager.js';
 import { getPlayerIcon } from '@core/utils/ui.js';
 import * as teamManager from '@features/team/manager.js';
 import { isNonEmptyString } from '@lib/guards.js';
@@ -59,7 +58,8 @@ export async function showTeamMainPanel(player: mc.Player): Promise<void> {
     }
 
     form.addBackButton(async () => {
-        await showPanel(player, 'mainPanel');
+        const { showMainPanel } = await import('@core/ui/panels/mainPanel.js');
+        await showMainPanel(player);
     });
 
     await form.show(player);

--- a/src/features/teleport/ui/panel.ts
+++ b/src/features/teleport/ui/panel.ts
@@ -1,6 +1,5 @@
 import { getConfig } from '@core/configManager.js';
 import { loadPlayerData } from '@core/playerDataManager.js';
-import { showPanel } from '@core/uiManager.js';
 import * as tpaManager from '@features/teleport/tpaManager.js';
 import * as mc from '@minecraft/server';
 import { ActionFormBuilder } from '@ui/builders/ActionFormBuilder.js';
@@ -28,7 +27,8 @@ export async function showTpaSettingsPanel(player: mc.Player): Promise<void> {
     });
 
     form.addBackButton(async () => {
-        await showPanel(player, 'profileMainPanel');
+        const { showMyStatsPanel } = await import('@core/ui/panels/playerPanel.js');
+        await showMyStatsPanel(player);
     });
 
     await form.show(player);

--- a/src/features/vote/ui/panel.ts
+++ b/src/features/vote/ui/panel.ts
@@ -1,8 +1,8 @@
 import { hasPermission } from '@core/permissionEngine.js';
 import * as mc from '@minecraft/server';
-import { ActionFormData, ActionFormResponse, ModalFormData, ModalFormResponse } from '@minecraft/server-ui';
+import { ActionFormBuilder } from '@core/ui/builders/ActionFormBuilder.js';
+import { ModalFormBuilder } from '@core/ui/builders/ModalFormBuilder.js';
 
-import { uiWait } from '@core/utils.js';
 import { castVote, createVote, endVote, getActiveVote, getLastVote } from '@features/vote/manager.js';
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
 
@@ -29,47 +29,29 @@ async function handleActiveVote(player: mc.Player, activeVote: ReturnType<typeof
         body += results;
     }
 
-    const form = new ActionFormData().title('Current Vote').body(body);
+    const form = new ActionFormBuilder().title('Current Vote').body(body);
 
     if (hasVoted) {
-        form.button('§4Close');
+        form.button('§4Close', undefined, () => {});
     } else {
         for (const opt of activeVote.options) {
-            form.button(opt.text);
+            form.button(opt.text, undefined, () => {
+                if (isDefined(opt)) {
+                    const res = castVote(player, opt.id);
+                    player.sendMessage(res.message);
+                }
+            });
         }
     }
 
     if (isAdmin) {
-        form.button('§4End Vote Early');
-    }
-
-    const response = await uiWait(player, form);
-    if (!isDefined(response) || response.canceled) return;
-    const actionResponse = response as ActionFormResponse;
-    if (!isDefined(actionResponse.selection)) return;
-
-    if (hasVoted) {
-        if (isAdmin && actionResponse.selection === 1) {
+        form.button('§4End Vote Early', undefined, () => {
             endVote();
             player.sendMessage('§cVote ended manually.');
-        }
-        return;
+        });
     }
 
-    const selection = actionResponse.selection;
-    if (isAdmin && selection === activeVote.options.length) {
-        endVote();
-        player.sendMessage('§cVote ended manually.');
-        return;
-    }
-
-    if (selection < activeVote.options.length) {
-        const selectedOption = activeVote.options[selection];
-        if (isDefined(selectedOption)) {
-            const res = castVote(player, selectedOption.id);
-            player.sendMessage(res.message);
-        }
-    }
+    await form.show(player);
 }
 
 async function handleNoActiveVote(player: mc.Player, isAdmin: boolean) {
@@ -80,44 +62,35 @@ async function handleNoActiveVote(player: mc.Player, isAdmin: boolean) {
         body += `\n\n§7Last Vote: ${lastVote.question}\nStatus: Ended`;
     }
 
-    const form = new ActionFormData().title('Voting').body(body);
+    const form = new ActionFormBuilder().title('Voting').body(body);
 
     if (isAdmin) {
-        form.button('§2Create New Vote');
+        form.button('§2Create New Vote', undefined, async () => {
+            await showCreateVoteUI(player);
+        });
     } else {
-        form.button('§4Close');
+        form.button('§4Close', undefined, () => {});
     }
 
-    const response = await uiWait(player, form);
-    if (!isDefined(response) || response.canceled) return;
-    const actionResponse = response as ActionFormResponse;
-    if (!isDefined(actionResponse.selection)) return;
-
-    if (isAdmin && actionResponse.selection === 0) {
-        await showCreateVoteUI(player);
-    }
+    await form.show(player);
 }
 
 async function showCreateVoteUI(player: mc.Player) {
-    const form = new ModalFormData()
+    const form = new ModalFormBuilder<{ question: string; options: string; duration: string }>()
         .title('Create Vote')
-        .textField('Question', 'Do you like apples?')
-        .textField('Options (comma separated)', 'Yes, No, Maybe')
-        .textField('Duration (minutes, 0 for infinite)', '10');
+        .textField('question', 'Question', 'Do you like apples?')
+        .textField('options', 'Options (comma separated)', 'Yes, No, Maybe')
+        .textField('duration', 'Duration (minutes, 0 for infinite)', '10');
 
-    const response = await uiWait(player, form);
-    if (!isDefined(response) || response.canceled) return;
-    const modalResponse = response as ModalFormResponse;
-    if (!isDefined(modalResponse.formValues)) return;
+    const res = await form.show(player);
+    if (!res) return;
 
-    const [question, optionsStr, durationStr] = modalResponse.formValues as string[];
-
-    if (!isNonEmptyString(question) || !isNonEmptyString(optionsStr)) {
+    if (!isNonEmptyString(res.question) || !isNonEmptyString(res.options)) {
         player.sendMessage('§cQuestion and options are required.');
         return;
     }
 
-    const options = optionsStr
+    const options = res.options
         .split(',')
         .map((s) => s.trim())
         .filter((s) => s.length > 0);
@@ -126,8 +99,8 @@ async function showCreateVoteUI(player: mc.Player) {
         return;
     }
 
-    const duration = Number.parseInt(durationStr ?? '0') || 0;
+    const duration = Number.parseInt(res.duration) || 0;
     const durationSeconds = duration * 60;
 
-    createVote(player, question, options, durationSeconds);
+    createVote(player, res.question, options, durationSeconds);
 }


### PR DESCRIPTION
- Removed legacy string-based `showPanel` usage in favor of direct async functional imports in UI modules (`shop`, `social`, `team`, `teleport`).
- Fully migrated the `vote` feature's UI panel from manual index selection with `ActionFormData`/`ModalFormData` to the strongly-typed, callback-driven `ActionFormBuilder`/`ModalFormBuilder`.
- Updated tests and fixed mocks for timerManager.
- Updated `plan.md` context marking Session 4 complete.

---
*PR created automatically by Jules for task [11925809498693606081](https://jules.google.com/task/11925809498693606081) started by @SjnExe*