### PR TITLE
feat(ui): implement missing UI panels and restructure main menu

### DIFF
--- a/src/core/ui/builders/ActionFormBuilder.ts
+++ b/src/core/ui/builders/ActionFormBuilder.ts
@@ -43,11 +43,6 @@ export class ActionFormBuilder {
         return this;
     }
 
-    public addCloseButton(onClick?: () => void | Promise<void>): this {
-        this.button('§cClose', 'textures/gui/new_default/cancel', onClick);
-        return this;
-    }
-
     public async show(player: Player): Promise<ActionFormResponse> {
         const response = await this.form.show(player);
 

--- a/src/core/ui/panels/inventoryPanel.ts
+++ b/src/core/ui/panels/inventoryPanel.ts
@@ -1,0 +1,72 @@
+import { getPlayerFromCache } from '@core/playerCache.js';
+import { getPlayerNameById } from '@core/playerDataManager.js';
+import { showPanel } from '@core/uiManager.js';
+import * as mc from '@minecraft/server';
+import { ActionFormBuilder } from '@ui/builders/ActionFormBuilder.js';
+
+export async function showInventoryPanel(player: mc.Player, targetPlayerId: string, page: number = 1): Promise<void> {
+    const targetName = getPlayerNameById(targetPlayerId) || targetPlayerId;
+    const targetPlayer = getPlayerFromCache(targetPlayerId);
+
+    if (!targetPlayer) {
+        player.sendMessage(`§cCannot view inventory. Player ${targetName} is offline.`);
+        return showPanel(player, 'playerActionsPanel', { targetPlayerId });
+    }
+
+    const form = new ActionFormBuilder().title(`${targetName}'s Inventory`);
+
+    const inventoryComponent = targetPlayer.getComponent('minecraft:inventory') as mc.EntityInventoryComponent;
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (!inventoryComponent || !inventoryComponent.container) {
+        player.sendMessage(`§cCannot access inventory component for ${targetName}.`);
+        return showPanel(player, 'playerActionsPanel', { targetPlayerId });
+    }
+
+    const container = inventoryComponent.container;
+    const items: { slot: number; item: mc.ItemStack | undefined }[] = [];
+
+    for (let i = 0; i < container.size; i++) {
+        items.push({ slot: i, item: container.getItem(i) });
+    }
+
+    const itemsPerPage = 15;
+    const startIndex = (page - 1) * itemsPerPage;
+    const endIndex = startIndex + itemsPerPage;
+    const paginated = items.slice(startIndex, endIndex);
+
+    for (const data of paginated) {
+        if (data.item) {
+            // eslint-disable-next-line no-restricted-syntax
+            const displayName = data.item.typeId.replace('minecraft:', '');
+            form.button(`Slot ${data.slot}: ${displayName} x${data.item.amount}`, 'textures/ui/inventory_icon', () => {
+                // Future expansion: Edit item
+                void showInventoryPanel(player, targetPlayerId, page);
+            });
+        } else {
+            form.button(`Slot ${data.slot}: Empty`, 'textures/ui/inventory_icon', () => {
+                void showInventoryPanel(player, targetPlayerId, page);
+            });
+        }
+    }
+
+    const totalPages = Math.ceil(items.length / 15);
+
+    if (page > 1) {
+        form.button('§6< Previous Page', 'textures/ui/arrow_left.png', async () => {
+            await showInventoryPanel(player, targetPlayerId, page - 1);
+        });
+    }
+
+    if (page < totalPages) {
+        form.button('§6Next Page >', 'textures/ui/arrow_right.png', async () => {
+            await showInventoryPanel(player, targetPlayerId, page + 1);
+        });
+    }
+
+    form.addBackButton(async () => {
+        await showPanel(player, 'playerActionsPanel', { targetPlayerId });
+    });
+
+    await form.show(player);
+}

--- a/src/core/ui/panels/mainPanel.ts
+++ b/src/core/ui/panels/mainPanel.ts
@@ -74,20 +74,8 @@ export async function showMainPanel(player: Player): Promise<void> {
         });
     }
 
-    form.button('Profile', 'textures/ui/profile_glyph_color', async () => {
-        await showPanel(player, 'profileMainPanel');
-    });
-
-    form.button('Server Info', 'textures/items/book_enchanted.png', async () => {
+    form.button('Info', 'textures/items/book_enchanted.png', async () => {
         await showPanel(player, 'infoPanel');
-    });
-
-    form.button('Rules', 'textures/items/book_enchanted.png', () => {
-        player.sendMessage('Rules panel not available.');
-    });
-
-    form.button('Helpful Links', 'textures/items/chain', () => {
-        player.sendMessage('Helpful links panel not available.');
     });
 
     if (hasPermission(player, 'ui.panel.mod')) {
@@ -97,6 +85,5 @@ export async function showMainPanel(player: Player): Promise<void> {
         });
     }
 
-    form.addCloseButton();
     await form.show(player);
 }

--- a/src/core/ui/panels/playerPanel.ts
+++ b/src/core/ui/panels/playerPanel.ts
@@ -76,14 +76,17 @@ export async function showPlayerActionsPanel(player: mc.Player, targetPlayerId: 
         form.button('Ban', 'textures/ui/hammer_l.png', () => {
             void import('@features/moderation/ui/panel.js').then((m) => m.handleBanPlayer(player, targetPlayerId));
         });
-        form.button('Manage Ranks', 'textures/ui/icon_rank.png', () => {
-            player.sendMessage('Rank management panel not available.');
+        form.button('Manage Ranks', 'textures/ui/icon_rank.png', async () => {
+            const { showRankManagementPanel } = await import('@features/ranks/ui/panel.js');
+            await showRankManagementPanel(player, targetPlayerId);
         });
-        form.button('Manage Stats', 'textures/ui/Scaffolding.png', () => {
-            player.sendMessage('Manage Player Stats panel not available.');
+        form.button('Manage Stats', 'textures/ui/Scaffolding.png', async () => {
+            const { showStatsPanel } = await import('@core/ui/panels/statsPanel.js');
+            await showStatsPanel(player, targetPlayerId);
         });
-        form.button('See Inventory', 'textures/ui/inventory_icon.png', () => {
-            player.sendMessage('Inventory panel not available.');
+        form.button('See Inventory', 'textures/ui/inventory_icon.png', async () => {
+            const { showInventoryPanel } = await import('@core/ui/panels/inventoryPanel.js');
+            await showInventoryPanel(player, targetPlayerId);
         });
         form.button('Teleport To', 'textures/ui/icon_map.png', () => {
             void import('@core/playerCache.js').then((m) => {
@@ -103,12 +106,14 @@ export async function showPlayerActionsPanel(player: mc.Player, targetPlayerId: 
         void import('@features/social/ui/friendPanel.js').then((m) => m.addFriendAction(player, targetPlayerId));
     });
 
-    form.button('Send Money', 'textures/items/gold_ingot', () => {
-        player.sendMessage('Send money not available.');
+    form.button('Send Money', 'textures/items/gold_ingot', async () => {
+        const { showTransferPanel } = await import('@features/economy/ui/transferPanel.js');
+        await showTransferPanel(player, targetPlayerId);
     });
 
-    form.button('Bounty Actions', 'textures/items/netherite_sword', () => {
-        player.sendMessage('Bounty panel disabled');
+    form.button('Bounty Actions', 'textures/items/netherite_sword', async () => {
+        const { showBountyPlayer } = await import('@features/economy/ui/bountyPanel.js');
+        await showBountyPlayer(player, { targetPlayerId });
     });
 
     form.addBackButton(async () => {

--- a/src/core/ui/panels/serverInfoPanel.ts
+++ b/src/core/ui/panels/serverInfoPanel.ts
@@ -1,0 +1,66 @@
+import { getConfig } from '@core/configManager.js';
+import { showPanel } from '@core/uiManager.js';
+import { getHelpfulLinks } from '@features/essentials/helpfulLinksManager.js';
+import * as mc from '@minecraft/server';
+import { ActionFormBuilder } from '@ui/builders/ActionFormBuilder.js';
+
+export async function showInfoPanel(player: mc.Player): Promise<void> {
+    const form = new ActionFormBuilder().title('Info');
+
+    form.button('My Stats', 'textures/ui/profile_glyph_color', async () => {
+        await showPanel(player, 'profileMainPanel');
+    });
+
+    form.button('Server Rules', 'textures/items/book_enchanted.png', async () => {
+        await showServerRulesPanel(player);
+    });
+
+    form.button('Helpful Links', 'textures/items/chain.png', async () => {
+        await showHelpfulLinksPanel(player);
+    });
+
+    form.addBackButton(async () => {
+        await showPanel(player, 'mainPanel');
+    });
+
+    await form.show(player);
+}
+
+export async function showServerRulesPanel(player: mc.Player): Promise<void> {
+    const config = getConfig();
+    const rules = config.serverInfo.rules;
+
+    const form = new ActionFormBuilder().title('Server Rules');
+
+    if (rules.length === 0) {
+        form.body('No rules have been set by the server administrator.');
+    } else {
+        const rulesText = rules.join('\n\n');
+        form.body(`§l§a--- Server Rules ---\n\n§r${rulesText}`);
+    }
+
+    form.addBackButton(async () => {
+        await showInfoPanel(player);
+    });
+
+    await form.show(player);
+}
+
+export async function showHelpfulLinksPanel(player: mc.Player): Promise<void> {
+    const links = getHelpfulLinks();
+
+    const form = new ActionFormBuilder().title('Helpful Links');
+
+    if (links.length === 0) {
+        form.body('No helpful links have been provided.');
+    } else {
+        const linksText = links.map((link) => `§l${link.title}§r\n§b${link.url}§r`).join('\n\n');
+        form.body(linksText);
+    }
+
+    form.addBackButton(async () => {
+        await showInfoPanel(player);
+    });
+
+    await form.show(player);
+}

--- a/src/core/ui/panels/statsPanel.ts
+++ b/src/core/ui/panels/statsPanel.ts
@@ -1,0 +1,68 @@
+import { getPlayerNameById, loadPlayerData, savePlayerData } from '@core/playerDataManager.js';
+import { showPanel } from '@core/uiManager.js';
+import * as mc from '@minecraft/server';
+import { ActionFormBuilder } from '@ui/builders/ActionFormBuilder.js';
+import { ModalFormBuilder } from '@ui/builders/ModalFormBuilder.js';
+
+export async function showStatsPanel(player: mc.Player, targetPlayerId: string): Promise<void> {
+    const targetName = getPlayerNameById(targetPlayerId) || targetPlayerId;
+    const form = new ActionFormBuilder().title(`Stats: ${targetName}`);
+
+    const targetData = loadPlayerData(targetPlayerId);
+    if (!targetData) {
+        player.sendMessage(`§cCannot manage stats. Player data not found.`);
+        return showPanel(player, 'playerActionsPanel', { targetPlayerId });
+    }
+
+    form.button(`Edit Kills\n§7Current: ${targetData.kills}`, 'textures/items/iron_sword', async () => {
+        await editStat(player, targetPlayerId, 'kills', targetData.kills);
+    });
+
+    form.button(`Edit Deaths\n§7Current: ${targetData.deaths}`, 'textures/ui/skull_face', async () => {
+        await editStat(player, targetPlayerId, 'deaths', targetData.deaths);
+    });
+
+    form.button(`Edit Playtime\n§7Current: ${Math.floor(targetData.totalPlayTime / 60000)} mins`, 'textures/items/clock_item', async () => {
+        await editStat(player, targetPlayerId, 'playtime', Math.floor(targetData.totalPlayTime / 60000));
+    });
+
+    form.button(`Edit Balance\n§7Current: ${targetData.balance}`, 'textures/items/emerald', async () => {
+        await editStat(player, targetPlayerId, 'balance', targetData.balance);
+    });
+
+    form.addBackButton(async () => {
+        await showPanel(player, 'playerActionsPanel', { targetPlayerId });
+    });
+
+    await form.show(player);
+}
+
+async function editStat(player: mc.Player, targetPlayerId: string, statType: 'kills' | 'deaths' | 'playtime' | 'balance', currentValue: number): Promise<void> {
+    const targetName = getPlayerNameById(targetPlayerId) || targetPlayerId;
+
+    const form = new ModalFormBuilder<{ newValue: string }>()
+        .title(`Edit ${statType}`)
+        .textField('newValue', `Enter new value for ${targetName}'s ${statType}:`, String(currentValue), String(currentValue));
+
+    const res = await form.show(player);
+    if (!res) return showStatsPanel(player, targetPlayerId);
+
+    const newValue = Number(res.newValue);
+    if (isNaN(newValue) || newValue < 0) {
+        player.sendMessage(`§cInvalid amount. Must be a positive number.`);
+        return showStatsPanel(player, targetPlayerId);
+    }
+
+    const targetData = loadPlayerData(targetPlayerId);
+    if (targetData) {
+        if (statType === 'playtime') {
+            targetData.totalPlayTime = newValue * 60000;
+        } else {
+            targetData[statType] = newValue;
+        }
+        savePlayerData(targetPlayerId);
+        player.sendMessage(`§aSuccessfully updated ${targetName}'s ${statType} to ${newValue}.`);
+    }
+
+    await showStatsPanel(player, targetPlayerId);
+}

--- a/src/core/uiManager.ts
+++ b/src/core/uiManager.ts
@@ -19,10 +19,29 @@ export async function showPanel(player: mc.Player, panelId: string, _context: Re
             return;
         }
 
+        if (panelId === 'infoPanel') {
+            const { showInfoPanel } = await import('@core/ui/panels/serverInfoPanel.js');
+            await showInfoPanel(player);
+            return;
+        }
+
         if (panelId === 'profileMainPanel') {
             const { showMyStatsPanel } = await import('@core/ui/panels/playerPanel.js');
             // Check if profile exists, if not, fallback to main
             await showMyStatsPanel(player);
+            return;
+        }
+
+        if (panelId === 'playerActionsPanel') {
+            const targetPlayerId = _context.targetPlayerId as string;
+            if (targetPlayerId) {
+                const { getPlayerNameById } = await import('@core/playerDataManager.js');
+                const targetName = getPlayerNameById(targetPlayerId) || targetPlayerId;
+                const { showPlayerActionsPanel } = await import('@core/ui/panels/playerPanel.js');
+                await showPlayerActionsPanel(player, targetPlayerId, targetName);
+            } else {
+                player.sendMessage('§cMissing target player context.');
+            }
             return;
         }
 

--- a/src/features/economy/ui/transferPanel.ts
+++ b/src/features/economy/ui/transferPanel.ts
@@ -1,0 +1,84 @@
+import { getConfig } from '@core/configManager.js';
+import { economyDisabled } from '@core/constants.js';
+import { isFeatureActive } from '@core/featureManager.js';
+import { getPlayer, getPlayerNameById, transfer } from '@core/playerDataManager.js';
+import { showPanel } from '@core/uiManager.js';
+import { formatCurrency } from '@core/utils.js';
+import * as mc from '@minecraft/server';
+import { ActionFormBuilder } from '@ui/builders/ActionFormBuilder.js';
+import { ModalFormBuilder } from '@ui/builders/ModalFormBuilder.js';
+
+export async function showTransferPanel(player: mc.Player, targetPlayerId: string): Promise<void> {
+    const config = getConfig();
+    if (!isFeatureActive('eco')) {
+        player.sendMessage(economyDisabled);
+        return showPanel(player, 'playerActionsPanel', { targetPlayerId });
+    }
+
+    if (player.id === targetPlayerId) {
+        player.sendMessage('§cYou cannot pay yourself.');
+        return showPanel(player, 'playerActionsPanel', { targetPlayerId });
+    }
+
+    const targetName = getPlayerNameById(targetPlayerId) || targetPlayerId;
+    const sourceData = getPlayer(player.id);
+
+    if (!sourceData) {
+        player.sendMessage('§cCould not retrieve your data.');
+        return showPanel(player, 'playerActionsPanel', { targetPlayerId });
+    }
+
+    const form = new ModalFormBuilder<{ amount: string }>()
+        .title(`Send Money to ${targetName}`)
+        .textField('amount', `Your Balance: ${formatCurrency(sourceData.balance)}\nEnter amount to send:`, 'e.g. 100, 2.5k', '');
+
+    const res = await form.show(player);
+    if (!res) return showPanel(player, 'playerActionsPanel', { targetPlayerId });
+
+    let amount = parseFloat(res.amount);
+    if (res.amount.toLowerCase().endsWith('k')) {
+        amount = parseFloat(res.amount.slice(0, -1)) * 1000;
+    } else if (res.amount.toLowerCase().endsWith('m')) {
+        amount = parseFloat(res.amount.slice(0, -1)) * 1000000;
+    }
+
+    if (isNaN(amount) || amount <= 0) {
+        player.sendMessage('§cInvalid amount. Must be positive.');
+        return showTransferPanel(player, targetPlayerId);
+    }
+
+    if (amount > sourceData.balance) {
+        player.sendMessage('§cYou do not have enough money.');
+        return showTransferPanel(player, targetPlayerId);
+    }
+
+    if (amount > config.economy.paymentConfirmationThreshold) {
+        // Confirmation panel
+        const confirmForm = new ActionFormBuilder()
+            .title('Confirm Payment')
+            .body(`Are you sure you want to send ${formatCurrency(amount)} to ${targetName}?`)
+            .button('§2Confirm', 'textures/ui/realms_green_check', async () => {
+                const result = transfer(player.id, targetPlayerId, amount);
+                if (result.success) {
+                    player.sendMessage(`§aYou have paid §e${formatCurrency(amount)}§a to ${targetName}.`);
+                } else {
+                    player.sendMessage(`§cPayment failed: ${result.message}`);
+                }
+                await showPanel(player, 'playerActionsPanel', { targetPlayerId });
+            })
+            .button('§4Cancel', 'textures/ui/cancel', async () => {
+                player.sendMessage('§cPayment cancelled.');
+                await showTransferPanel(player, targetPlayerId);
+            });
+
+        await confirmForm.show(player);
+    } else {
+        const result = transfer(player.id, targetPlayerId, amount);
+        if (result.success) {
+            player.sendMessage(`§aYou have paid §e${formatCurrency(amount)}§a to ${targetName}.`);
+        } else {
+            player.sendMessage(`§cPayment failed: ${result.message}`);
+        }
+        await showPanel(player, 'playerActionsPanel', { targetPlayerId });
+    }
+}

--- a/src/features/ranks/ui/panel.ts
+++ b/src/features/ranks/ui/panel.ts
@@ -1,0 +1,49 @@
+import { getPlayerNameById, loadPlayerData, setPlayerRanks } from '@core/playerDataManager.js';
+import { getAllRanks } from '@core/rankManager.js';
+import { showPanel } from '@core/uiManager.js';
+import * as mc from '@minecraft/server';
+import { ActionFormBuilder } from '@ui/builders/ActionFormBuilder.js';
+
+export async function showRankManagementPanel(player: mc.Player, targetPlayerId: string, page: number = 1): Promise<void> {
+    const targetName = getPlayerNameById(targetPlayerId) || targetPlayerId;
+    const form = new ActionFormBuilder().title(`Ranks: ${targetName}`);
+
+    const targetData = loadPlayerData(targetPlayerId);
+    if (!targetData) {
+        player.sendMessage(`§cCannot manage ranks. Player data not found.`);
+        return showPanel(player, 'playerActionsPanel', { targetPlayerId });
+    }
+
+    const allRanks = getAllRanks();
+
+    // Check if player has the rank
+    allRanks.forEach((rank) => {
+        const hasRank = targetData.ranks.includes(rank.id);
+        const icon = hasRank ? 'textures/ui/realms_green_check' : 'textures/ui/cancel';
+        const buttonText = `§l${rank.name}§r\n${hasRank ? '§2Click to Remove' : '§4Click to Add'}`;
+
+        form.button(buttonText, icon, async () => {
+            if (hasRank) {
+                // If it's their only rank, maybe prevent removal or fallback to default
+                if (targetData.ranks.length === 1 && targetData.ranks[0] === rank.id) {
+                    player.sendMessage(`§cCannot remove the player's only rank.`);
+                } else {
+                    const newRanks = targetData.ranks.filter((r) => r !== rank.id);
+                    setPlayerRanks(targetPlayerId, newRanks);
+                    player.sendMessage(`§aRemoved rank ${rank.name} from ${targetName}.`);
+                }
+            } else {
+                const newRanks = [...targetData.ranks, rank.id];
+                setPlayerRanks(targetPlayerId, newRanks);
+                player.sendMessage(`§aAdded rank ${rank.name} to ${targetName}.`);
+            }
+            await showRankManagementPanel(player, targetPlayerId, page);
+        });
+    });
+
+    form.addBackButton(async () => {
+        await showPanel(player, 'playerActionsPanel', { targetPlayerId });
+    });
+
+    await form.show(player);
+}


### PR DESCRIPTION
This commit fulfills all initial architectural requirements requested by the user.

- The `mainPanel.ts` is leaner, removing redundant buttons into a `serverInfoPanel.ts` component which loads dynamically from the config (`config.serverInfo.rules`, `config.serverInfo.helpfulLinks`).
- Disabled buttons in `playerPanel.ts` now securely point to their respective UI subsystems:
  - Inventory checking (`inventoryPanel.ts`) with safe component fallbacks.
  - Transfer system (`transferPanel.ts`) leveraging identical parameters and confirmations to the `/pay` economy command.
  - Rank Management (`ranks/ui/panel.ts`) acting as the primary GUI editor for assigning player ranks.
  - Player Statistics (`statsPanel.ts`) providing robust UI inputs for editing Kills, Deaths, Playtime, and Balances.
- Code smells removed: Unnecessary close buttons (`.addCloseButton()`) are purged from `ActionFormBuilder.ts` and consumers, cleaning up real estate on menus.

---
*PR created automatically by Jules for task [7016912237501290569](https://jules.google.com/task/7016912237501290569) started by @SjnExe*