### PR TITLE
fix: correct UI panel button icon paths

### DIFF
--- a/src/core/ui/builders/ActionFormBuilder.ts
+++ b/src/core/ui/builders/ActionFormBuilder.ts
@@ -39,7 +39,7 @@ export class ActionFormBuilder {
     }
 
     public addBackButton(onClick: () => void | Promise<void>): this {
-        this.button('§cBack', 'textures/gui/controls/left', onClick);
+        this.button('§cBack', 'textures/ui/arrow_left', onClick);
         return this;
     }
 

--- a/src/core/ui/panels/adminPanel.ts
+++ b/src/core/ui/panels/adminPanel.ts
@@ -16,12 +16,12 @@ export async function showStaffDashboardPanel(player: mc.Player): Promise<void> 
             await showPanel(player, 'reportListPanel');
         });
 
-        form.button('Player Management', 'textures/ui/icon_multiplayer.png', async () => {
+        form.button('Player Management', 'textures/ui/icon_multiplayer', async () => {
             const { showPlayerManagementPanel } = await import('@core/ui/panels/playerPanel.js');
             await showPlayerManagementPanel(player);
         });
 
-        form.button('Moderation', 'textures/ui/hammer_l.png', async () => {
+        form.button('Moderation', 'textures/ui/hammer_l', async () => {
             await showPanel(player, 'moderationPanel');
         });
     }

--- a/src/core/ui/panels/configPanel.ts
+++ b/src/core/ui/panels/configPanel.ts
@@ -203,7 +203,7 @@ export async function showConfigResetCategoryPanel(player: mc.Player, category: 
 export async function showConfigTransferPanel(player: mc.Player): Promise<void> {
     const form = new ActionFormBuilder()
         .title('Transfer Configs')
-        .button('Export Config', '', () => {
+        .button('Export Config', 'textures/ui/structure_block_export', () => {
             void showConfigExportPanel(player);
         })
         .button('Import Config', 'textures/ui/arrow_down', () => {

--- a/src/core/ui/panels/inventoryPanel.ts
+++ b/src/core/ui/panels/inventoryPanel.ts
@@ -53,13 +53,13 @@ export async function showInventoryPanel(player: mc.Player, targetPlayerId: stri
     const totalPages = Math.ceil(items.length / 15);
 
     if (page > 1) {
-        form.button('§6< Previous Page', 'textures/ui/arrow_left.png', async () => {
+        form.button('§6< Previous Page', 'textures/ui/arrow_left', async () => {
             await showInventoryPanel(player, targetPlayerId, page - 1);
         });
     }
 
     if (page < totalPages) {
-        form.button('§6Next Page >', 'textures/ui/arrow_right.png', async () => {
+        form.button('§6Next Page >', 'textures/ui/arrow_right', async () => {
             await showInventoryPanel(player, targetPlayerId, page + 1);
         });
     }

--- a/src/core/ui/panels/mainPanel.ts
+++ b/src/core/ui/panels/mainPanel.ts
@@ -38,17 +38,17 @@ export async function showMainPanel(player: Player): Promise<void> {
         });
     }
 
-    form.button('Player List', 'textures/ui/icon_steve.png', async () => {
+    form.button('Player List', 'textures/ui/icon_steve', async () => {
         const { showPlayerListPanel } = await import('@core/ui/panels/playerPanel.js');
         await showPlayerListPanel(player);
     });
 
     if (isFeatureActive('soc.team')) {
-        form.button('Team', 'textures/ui/icon_multiplayer.png', async () => {
+        form.button('Team', 'textures/ui/icon_multiplayer', async () => {
             await showPanel(player, 'teamMainPanel');
         });
     } else {
-        form.button('Team\n§0[§cDISABLED§0]', 'textures/ui/icon_multiplayer.png', async () => {
+        form.button('Team\n§0[§cDISABLED§0]', 'textures/ui/icon_multiplayer', async () => {
             await showMainPanel(player);
         });
     }
@@ -65,16 +65,16 @@ export async function showMainPanel(player: Player): Promise<void> {
 
     // Bounty depends on economy and bounties config, but let's map it roughly to economy for UI
     if (isFeatureActive('eco')) {
-        form.button('Bounty List', 'textures/items/netherite_sword.png', async () => {
+        form.button('Bounty List', 'textures/items/netherite_sword', async () => {
             await showPanel(player, 'bountyListPanel');
         });
     } else {
-        form.button('Bounty List\n§0[§cDISABLED§0]', 'textures/items/netherite_sword.png', async () => {
+        form.button('Bounty List\n§0[§cDISABLED§0]', 'textures/items/netherite_sword', async () => {
             await showMainPanel(player);
         });
     }
 
-    form.button('Info', 'textures/items/book_enchanted.png', async () => {
+    form.button('Info', 'textures/items/book_enchanted', async () => {
         await showPanel(player, 'infoPanel');
     });
 

--- a/src/core/ui/panels/playerPanel.ts
+++ b/src/core/ui/panels/playerPanel.ts
@@ -64,37 +64,37 @@ export async function showPlayerActionsPanel(player: mc.Player, targetPlayerId: 
     const isModMode = hasPermission(player, 'ui.panel.mod');
 
     if (isModMode) {
-        form.button('Kick', 'textures/ui/cancel.png', () => {
+        form.button('Kick', 'textures/ui/cancel', () => {
             void import('@features/moderation/ui/panel.js').then((m) => m.handleKickPlayer(player, targetPlayerId));
         });
-        form.button('Mute', 'textures/ui/mute_on.png', () => {
+        form.button('Mute', 'textures/ui/mute_on', () => {
             void import('@features/moderation/ui/panel.js').then((m) => m.handleMutePlayer(player, targetPlayerId));
         });
-        form.button('Unmute', 'textures/ui/mute_off.png', () => {
+        form.button('Unmute', 'textures/ui/mute_off', () => {
             void import('@features/moderation/ui/panel.js').then((m) => m.handleUnmutePlayer(player, targetPlayerId));
         });
-        form.button('Ban', 'textures/ui/hammer_l.png', () => {
+        form.button('Ban', 'textures/ui/hammer_l', () => {
             void import('@features/moderation/ui/panel.js').then((m) => m.handleBanPlayer(player, targetPlayerId));
         });
-        form.button('Manage Ranks', '', async () => {
+        form.button('Manage Ranks', 'textures/ui/permissions_op_crown', async () => {
             const { showRankManagementPanel } = await import('@features/ranks/ui/panel.js');
             await showRankManagementPanel(player, targetPlayerId);
         });
-        form.button('Manage Stats', 'textures/ui/Scaffolding.png', async () => {
+        form.button('Manage Stats', 'textures/ui/Scaffolding', async () => {
             const { showStatsPanel } = await import('@core/ui/panels/statsPanel.js');
             await showStatsPanel(player, targetPlayerId);
         });
-        form.button('See Inventory', 'textures/ui/inventory_icon.png', async () => {
+        form.button('See Inventory', 'textures/ui/inventory_icon', async () => {
             const { showInventoryPanel } = await import('@core/ui/panels/inventoryPanel.js');
             await showInventoryPanel(player, targetPlayerId);
         });
-        form.button('Teleport To', 'textures/ui/icon_map.png', () => {
+        form.button('Teleport To', 'textures/ui/icon_map', () => {
             void import('@core/playerCache.js').then((m) => {
                 const target = m.getPlayerFromCache(targetPlayerId);
                 if (target) player.teleport(target.location, { dimension: target.dimension });
             });
         });
-        form.button('Teleport Here', 'textures/ui/icon_map.png', () => {
+        form.button('Teleport Here', 'textures/ui/icon_map', () => {
             void import('@core/playerCache.js').then((m) => {
                 const target = m.getPlayerFromCache(targetPlayerId);
                 if (target) target.teleport(player.location, { dimension: player.dimension });
@@ -133,7 +133,7 @@ export async function showMyStatsPanel(player: mc.Player): Promise<void> {
 
     if (data) {
         form.button(`§2Balance: §r${formatCurrency(data.balance)}`, 'textures/items/emerald');
-        form.button(`§6Rank: §r${data.rankId}`, '');
+        form.button(`§6Rank: §r${data.rankId}`, 'textures/ui/permissions_op_crown');
         form.button(`${formatDuration(data.totalPlayTime)}`, 'textures/items/clock_item');
         form.button(`§4Kills: §r${data.kills}`, 'textures/items/iron_sword');
         form.button(`§4Deaths: §r${data.deaths}`, 'textures/items/skull_pottery_sherd');

--- a/src/core/ui/panels/serverInfoPanel.ts
+++ b/src/core/ui/panels/serverInfoPanel.ts
@@ -11,11 +11,11 @@ export async function showInfoPanel(player: mc.Player): Promise<void> {
         await showPanel(player, 'profileMainPanel');
     });
 
-    form.button('Server Rules', 'textures/items/book_enchanted.png', async () => {
+    form.button('Server Rules', 'textures/items/book_enchanted', async () => {
         await showServerRulesPanel(player);
     });
 
-    form.button('Helpful Links', 'textures/items/chain.png', async () => {
+    form.button('Helpful Links', 'textures/items/chain', async () => {
         await showHelpfulLinksPanel(player);
     });
 

--- a/src/features/anticheat/commands/logs.ts
+++ b/src/features/anticheat/commands/logs.ts
@@ -36,7 +36,7 @@ async function showLogsMenu(player: mc.Player) {
         .title('Logs Menu')
         .button('Punishment Logs', 'textures/ui/hammer_l')
         .button('Anti-Cheat Flags', 'textures/items/diamond_sword')
-        .button('Chat Logs', '')
+        .button('Chat Logs', 'textures/ui/message')
         .button('Settings', 'textures/ui/settings_glyph_color_2x');
 
     const response = await uiWait(player, form);

--- a/src/features/economy/ui/bountyPanel.ts
+++ b/src/features/economy/ui/bountyPanel.ts
@@ -38,12 +38,12 @@ export async function showBountyListPanel(player: mc.Player, context: Record<str
         const totalPages = Math.ceil(totalItems / itemsPerPage);
 
         if (page > 1) {
-            form.button('§6< Previous Page', 'textures/ui/arrow_left.png', async () => {
+            form.button('§6< Previous Page', 'textures/ui/arrow_left', async () => {
                 await showBountyListPanel(player, { ...context, page: page - 1 });
             });
         }
         if (page < totalPages) {
-            form.button('§6Next Page >', 'textures/ui/arrow_right.png', async () => {
+            form.button('§6Next Page >', 'textures/ui/arrow_right', async () => {
                 await showBountyListPanel(player, { ...context, page: page + 1 });
             });
         }

--- a/src/features/team/ui/panel.ts
+++ b/src/features/team/ui/panel.ts
@@ -84,7 +84,7 @@ export async function showTeamMembersPanel(player: mc.Player, page: number = 1):
             const status = isOnline ? '§aOnline' : '§cOffline';
             const role = team.ownerId === member ? '§6Owner' : '§7Member';
 
-            formBuilder.button(`${loadPlayerData(member)?.name ?? member}\n${status} §r- ${role}`, 'textures/ui/permissions_member_star.png', async () => {
+            formBuilder.button(`${loadPlayerData(member)?.name ?? member}\n${status} §r- ${role}`, 'textures/ui/permissions_member_star', async () => {
                 if (isOwner && member !== player.id) {
                     await showTeamMemberActionPanel(player, member, loadPlayerData(member)?.name ?? member);
                 } else {
@@ -185,7 +185,7 @@ export async function showTeamRequestsPanel(player: mc.Player, page: number = 1)
         (app, formBuilder) => {
             const onlineP = getPlayerFromCache(app.playerId);
             let rankText = '';
-            let icon = 'textures/ui/permissions_member_star.png';
+            let icon = 'textures/ui/permissions_member_star';
             if (onlineP) {
                 const targetRank = getPlayerRank(onlineP, getConfig());
                 rankText = targetRank.chatFormatting?.prefixText ? `§r[${targetRank.chatFormatting.prefixText}]` : `§r[${targetRank.name}]`;


### PR DESCRIPTION
This PR fixes incorrect UI button icon paths across several panels by removing `.png` extensions (to satisfy the static analysis icon validator) and replacing invalid missing `''` paths with valid texture paths (`textures/ui/permissions_op_crown`, `textures/ui/structure_block_export`, and `textures/ui/message` respectively). It also fixes an incorrect path (`textures/gui/controls/left`) to a valid one (`textures/ui/arrow_left`).

---
*PR created automatically by Jules for task [17250406198747875453](https://jules.google.com/task/17250406198747875453) started by @SjnExe*