### PR TITLE
Fix UI panel unimplemented features and duplicate configs

### DIFF
--- a/src/core/ui/panels/adminPanel.ts
+++ b/src/core/ui/panels/adminPanel.ts
@@ -49,8 +49,8 @@ export async function showFloatingTextListPanel(player: mc.Player): Promise<void
     const form = new ActionFormBuilder().title('Floating Text Manager');
     form.body('Select a floating text entry to manage.');
 
-    form.button('§l§6View Placeholders', 'textures/ui/icon_sign', () => {
-        player.sendMessage('Placeholders list not available.');
+    form.button('§l§6View Placeholders', 'textures/ui/icon_sign', async () => {
+        await showPlaceholdersPanel(player);
     });
 
     form.button('§l§2Create New', 'textures/ui/color_plus', async () => {
@@ -206,4 +206,30 @@ export async function showFloatingTextEditPanel(player: mc.Player, id: string): 
     player.sendMessage(`§2Successfully updated floating text: ${id}`);
 
     await showFloatingTextActionPanel(player, id);
+}
+
+export async function showPlaceholdersPanel(player: mc.Player): Promise<void> {
+    const form = new ActionFormBuilder().title('Placeholders List');
+    form.body(
+        '§bGlobal Placeholders:§r\n' +
+            '§e{online}§r - Online player count\n' +
+            '§e{max_online}§r - Max online players limit\n' +
+            '§e{top_money_X}§r - Leaderboard entry X (e.g. {top_money_1})\n\n' +
+            '§bPlayer Placeholders:§r\n' +
+            '§e{name}§r - Player name\n' +
+            '§e{rank}§r - Player rank\n' +
+            '§e{money}§r - Player balance\n' +
+            '§e{kills}§r - Player kills\n' +
+            '§e{deaths}§r - Player deaths\n' +
+            '§e{kdr}§r - Kill/Death ratio\n' +
+            '§e{streak}§r - Kill streak\n' +
+            '§e{playtime}§r - Total playtime\n' +
+            '§e{team}§r - Team name (or None)'
+    );
+
+    form.addBackButton(async () => {
+        await showFloatingTextListPanel(player);
+    });
+
+    await form.show(player);
 }

--- a/src/core/ui/systemRegistry.ts
+++ b/src/core/ui/systemRegistry.ts
@@ -42,25 +42,6 @@ export function getSystemRegistry(): SystemDefinition[] {
                 if (schema.hidden === true) def.hidden = schema.hidden;
                 return def;
             }),
-
-        {
-            id: 'economyMain',
-            title: 'Economy Main Config',
-            icon: 'textures/ui/Scaffolding',
-            configPanelId: 'config_economyMain',
-            category: 'Economy',
-            hidden: true,
-            isSimpleConfig: true
-        },
-        {
-            id: 'shopSettings',
-            title: 'Shop Settings',
-            icon: 'textures/items/emerald',
-            configPanelId: 'config_shopSettings',
-            category: 'Economy',
-            hidden: true,
-            isSimpleConfig: true
-        },
         // 2. Add complex custom systems
         {
             id: 'kits',
@@ -88,16 +69,6 @@ export function getSystemRegistry(): SystemDefinition[] {
             showFunction: async (player) => {
                 const { showShopManagementPanel } = await import('@features/shop/ui/adminPanel.js');
                 await showShopManagementPanel(player);
-            },
-            category: 'Economy',
-            isSimpleConfig: false
-        },
-        {
-            id: 'economy',
-            title: 'Economy System',
-            icon: 'textures/ui/Scaffolding',
-            showFunction: (player) => {
-                player.sendMessage('Economy main panel not available.');
             },
             category: 'Economy',
             isSimpleConfig: false


### PR DESCRIPTION
This PR addresses UI panel issues by:
1. Implementing the previously dead "View Placeholders" button in the Floating Text Manager to actually show a list of valid `{...}` placeholders.
2. Removing redundant config options from `src/core/ui/systemRegistry.ts` that were either duplicating automatically generated `configPanelSchema` buttons or pointing to non-existent config IDs, preventing duplicated or broken buttons in the UI.

---
*PR created automatically by Jules for task [18343659574830265997](https://jules.google.com/task/18343659574830265997) started by @SjnExe*