### PR TITLE
Fix moderation panels and configuration back navigation

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -120,10 +120,21 @@ export const commandIndexPlugin = {
                 const sourceFile = ts.createSourceFile('featureRegistry.ts', registryContent, ts.ScriptTarget.Latest, true);
 
                 function visit(node: import('typescript').Node) {
-                    if (ts.isPropertyAssignment(node) && ts.isIdentifier(node.name) && node.name.text === 'id' && ts.isStringLiteral(node.initializer)) {
-                        const featureName = node.initializer.text;
-                        if (featureName === 'test' && !isNightly) return;
-                        featureDirs.push(featureName);
+                    if (ts.isPropertyAssignment(node) && ts.isIdentifier(node.name) && node.name.text === 'load' && ts.isArrowFunction(node.initializer)) {
+                        const callExpr = node.initializer.body;
+                        if (ts.isCallExpression(callExpr) && callExpr.expression.getText() === 'import' && callExpr.arguments.length > 0) {
+                            const arg = callExpr.arguments[0];
+                            if (ts.isStringLiteral(arg)) {
+                                const match = arg.text.match(new RegExp('@features/([^/]+)/'));
+                                if (match && match[1]) {
+                                    const featureName = match[1];
+                                    if (featureName === 'test' && !isNightly) return;
+                                    if (!featureDirs.includes(featureName)) {
+                                        featureDirs.push(featureName);
+                                    }
+                                }
+                            }
+                        }
                     }
                     ts.forEachChild(node, visit);
                 }

--- a/src/core/ui/panels/configPanel.ts
+++ b/src/core/ui/panels/configPanel.ts
@@ -138,12 +138,12 @@ export async function showConfigSystemPanel(player: mc.Player, systemId: string,
     }
 
     const res = await modal.show(player);
-    if (!res) return showConfigCategoryPanel(player, { page: 1 });
+    if (!res) return showConfigCategoryDetailPanel(player, schema.category ?? 'General', { page: 1 });
 
     const updates = _processFormValues(validSettings, res, config as Record<string, unknown>);
     _saveConfigUpdates(handler, configSource, updates);
     player.sendMessage('§2Configuration saved.');
-    await showConfigCategoryPanel(player, { page: 1 });
+    await showConfigCategoryDetailPanel(player, schema.category ?? 'General', { page: 1 });
 }
 
 export async function showConfigResetPanel(player: mc.Player): Promise<void> {

--- a/src/core/uiManager.ts
+++ b/src/core/uiManager.ts
@@ -68,6 +68,18 @@ export async function showPanel(player: mc.Player, panelId: string, _context: Re
             return;
         }
 
+        if (panelId === 'reportListPanel') {
+            const { showReportListPanel } = await import('@features/moderation/ui/panel.js');
+            await showReportListPanel(player);
+            return;
+        }
+
+        if (panelId === 'moderationPanel') {
+            const { showModerationPanel } = await import('@features/moderation/ui/panel.js');
+            await showModerationPanel(player);
+            return;
+        }
+
         if (panelId === 'configCategoryPanel') {
             const { showConfigCategoryPanel } = await import('@core/ui/panels/configPanel.js');
             await showConfigCategoryPanel(player);

--- a/src/features/moderation/ui/panel.ts
+++ b/src/features/moderation/ui/panel.ts
@@ -288,3 +288,22 @@ export async function handleUnmuteForm(player: mc.Player): Promise<void> {
         player.sendMessage('§4Player not found in database.');
     }
 }
+
+export async function showModerationPanel(player: mc.Player): Promise<void> {
+    const form = new ActionFormBuilder().title('Moderation Tools');
+
+    form.button('Unban Player', 'textures/ui/refresh_light', async () => {
+        await handleUnbanForm(player);
+    });
+
+    form.button('Unmute Player', 'textures/ui/mute_off', async () => {
+        await handleUnmuteForm(player);
+    });
+
+    form.addBackButton(async () => {
+        const { showStaffDashboardPanel } = await import('@core/ui/panels/adminPanel.js');
+        await showStaffDashboardPanel(player);
+    });
+
+    await form.show(player);
+}


### PR DESCRIPTION
Fix missing moderation and report UI panels. Fix a bug in the configuration panel where saving takes the user back two pages instead of one. Fix command registering logic by extracting the correct paths from `featureRegistry.ts` in the build script.

---
*PR created automatically by Jules for task [2509196426646427557](https://jules.google.com/task/2509196426646427557) started by @SjnExe*