### PR TITLE
Fix offline player data saving and clean up Auction House saves

### DIFF
--- a/src/core/playerDataManager.ts
+++ b/src/core/playerDataManager.ts
@@ -138,6 +138,7 @@ export function updatePlayerData(playerId: string, modificationCallback: (pData:
             pData.needsSave = true; // Mark as dirty for auto-save
         } else {
             // For offline players, save immediately and remove from cache to prevent memory leaks
+            activePlayerData.set(playerId, pData);
             savePlayerData(playerId);
             activePlayerData.delete(playerId);
         }

--- a/src/features/auction/manager.ts
+++ b/src/features/auction/manager.ts
@@ -4,7 +4,7 @@ import { getAuctionHouseConfig } from '@core/configurations.js';
 import { deserializeItem, SerializedItem, serializeItem } from '@core/itemSerializer.js';
 import { debugLog, errorLog } from '@core/logger.js';
 import { getPlayerFromCache } from '@core/playerCache.js';
-import { getOrCreatePlayer, incrementPlayerBalance, savePlayerData, updatePlayerData } from '@core/playerDataManager.js';
+import { getOrCreatePlayer, incrementPlayerBalance, updatePlayerData } from '@core/playerDataManager.js';
 import { StorageManager } from '@core/storage/StorageManager.js';
 import { formatCurrency, getTimestampFromUUIDv7 } from '@core/utils.js';
 import { isDefined, isNonEmptyString } from '@lib/guards.js';
@@ -95,7 +95,6 @@ export function createListing(player: mc.Player, item: SerializedItem, price: nu
             };
         }
         incrementPlayerBalance(player.id, -config.listingFee);
-        savePlayerData(player.id);
     }
 
     const listing: AuctionListing = {
@@ -135,21 +134,13 @@ export function buyItem(buyer: mc.Player, listingId: string): { success: boolean
 
     // Process Payment
     incrementPlayerBalance(buyer.id, -listing.price);
-    savePlayerData(buyer.id);
 
     // Send Money to Seller (Minus Tax)
     const tax = listing.price * config.taxRate;
     const payout = listing.price - tax;
 
-    // We can use incrementPlayerBalance because it handles online players AND we can use updatePlayerData for offline?
-    // incrementPlayerBalance in playerDataManager ONLY works for cached (online) players?
-    // Let's check playerDataManager: It calls updatePlayerData which calls getPlayer.
-    // getPlayer returns from cache.
-    // So incrementPlayerBalance fails for offline.
-
-    // We need a safe transfer function.
+    // We can use incrementPlayerBalance because updatePlayerData natively handles saving for offline players now
     sendMoneyToPlayer(listing.sellerId, payout);
-    savePlayerData(listing.sellerId);
 
     // Give Item to Buyer
     // We return serialized item to caller or handle deserialization here?
@@ -225,14 +216,12 @@ export function placeBid(bidder: mc.Player, listingId: string, amount: number): 
     // Return money to previous bidder
     if (isNonEmptyString(listing.highestBidderId) && isDefined(listing.bidPrice)) {
         sendMoneyToPlayer(listing.highestBidderId, listing.bidPrice);
-        savePlayerData(listing.highestBidderId);
         // Notify previous bidder if online?
         // We can't easily notify offline.
     }
 
     // Take money from new bidder
     incrementPlayerBalance(bidder.id, -amount);
-    savePlayerData(bidder.id);
 
     // Update Listing
     listing.bidPrice = amount;
@@ -269,20 +258,17 @@ function* checkExpiredAuctionsJob() {
                 // Auction Won!
                 // Give Item to Winner
                 addItemToMailbox(listing.highestBidderId, listing.item);
-                savePlayerData(listing.highestBidderId);
 
                 // Give Money to Seller
                 const config = getAuctionHouseConfig();
                 const tax = listing.bidPrice * config.taxRate;
                 sendMoneyToPlayer(listing.sellerId, listing.bidPrice - tax);
-                savePlayerData(listing.sellerId);
 
                 debugLog(`[AH] Auction ${id} won by ${listing.highestBidderName} for ${listing.bidPrice}`);
             } else {
                 // Expired (No Bids or BIN expired)
                 // Return Item to Seller
                 addItemToMailbox(listing.sellerId, listing.item);
-                savePlayerData(listing.sellerId);
                 debugLog(`[AH] Listing ${id} expired. Returned to seller.`);
             }
         }


### PR DESCRIPTION
- Fixed `updatePlayerData` in `playerDataManager.ts` to temporarily store offline player data in the active cache before saving, fixing a bug where offline modifications (like auction payouts) would fail to save.
- Removed manual, synchronous `savePlayerData` calls in the Auction House manager, as `updatePlayerData` now correctly handles both deferred auto-saving for online players and immediate saving for offline players, improving performance.

---
*PR created automatically by Jules for task [16847538183528632354](https://jules.google.com/task/16847538183528632354) started by @SjnExe*