### PR TITLE
Fix missing UI panel routes for Shop, Team, Friend, and Bounty features

### DIFF
--- a/src/core/uiManager.ts
+++ b/src/core/uiManager.ts
@@ -74,6 +74,30 @@ export async function showPanel(player: mc.Player, panelId: string, _context: Re
             return;
         }
 
+        if (panelId === 'shopMainPanel') {
+            const { showShopMainPanel } = await import('@features/shop/ui/userPanel.js');
+            await showShopMainPanel(player);
+            return;
+        }
+
+        if (panelId === 'teamMainPanel') {
+            const { showTeamMainPanel } = await import('@features/team/ui/panel.js');
+            await showTeamMainPanel(player);
+            return;
+        }
+
+        if (panelId === 'friendMainPanel') {
+            const { showFriendMainPanel } = await import('@features/social/ui/friendPanel.js');
+            await showFriendMainPanel(player);
+            return;
+        }
+
+        if (panelId === 'bountyListPanel') {
+            const { showBountyListPanel } = await import('@features/economy/ui/bountyPanel.js');
+            await showBountyListPanel(player, _context);
+            return;
+        }
+
         if (panelId === 'moderationPanel') {
             const { showModerationPanel } = await import('@features/moderation/ui/panel.js');
             await showModerationPanel(player);


### PR DESCRIPTION
Fixed broken routing in `uiManager.ts` for several main features (Shop, Team, Friends, Bounty). These panels were accessible via slash commands but broken when navigated to from the main UI panels. This ensures they correctly load and display.

---
*PR created automatically by Jules for task [2154987168174878411](https://jules.google.com/task/2154987168174878411) started by @SjnExe*