### PR TITLE
Fix config update crash and correct panel navigation routes

### DIFF
--- a/src/core/ui/panels/adminPanel.ts
+++ b/src/core/ui/panels/adminPanel.ts
@@ -30,11 +30,6 @@ export async function showStaffDashboardPanel(player: mc.Player): Promise<void> 
         form.button('Floating Text', 'textures/ui/text_color_paintbrush', async () => {
             await showFloatingTextListPanel(player);
         });
-
-        form.button('Shop Management', 'textures/items/emerald', async () => {
-            const { showShopManagementPanel } = await import('@features/shop/ui/adminPanel.js');
-            await showShopManagementPanel(player);
-        });
     }
 
     if (hasPermission(player, 'ui.panel.owner')) {

--- a/src/features/economy/ui/bountyPanel.ts
+++ b/src/features/economy/ui/bountyPanel.ts
@@ -50,7 +50,7 @@ export async function showBountyListPanel(player: mc.Player, context: Record<str
     }
 
     form.addBackButton(async () => {
-        await showPanel(player, 'economyMainPanel', context);
+        await showPanel(player, 'mainPanel', context);
     });
 
     await form.show(player);

--- a/src/features/shop/ui/adminPanel.ts
+++ b/src/features/shop/ui/adminPanel.ts
@@ -37,10 +37,9 @@ export async function showShopManagementPanel(player: mc.Player, page: number = 
         .title('Shop Management')
         .button(isEnabled ? '§2Shop System: ENABLED' : '§4Shop System: DISABLED', isEnabled ? 'textures/ui/realms_green_check' : 'textures/ui/cancel', () => {
             const newStatus = !getConfig().shop.enabled;
-            void (updateMultipleConfig as (updates: Record<string, unknown>) => Promise<void>)({ 'shop.enabled': newStatus }).then(() => {
-                player.sendMessage(`§2Shop system ${newStatus ? 'enabled' : 'disabled'}.`);
-                void showShopManagementPanel(player, page);
-            });
+            updateMultipleConfig({ 'shop.enabled': newStatus });
+            player.sendMessage(`§2Shop system ${newStatus ? 'enabled' : 'disabled'}.`);
+            void showShopManagementPanel(player, page);
         })
         .button('§l§2+ Add Category', 'textures/ui/color_plus', () => {
             void showAddCategoryPanel(player);


### PR DESCRIPTION
Fixed the `cannot read property 'then' of undefined` crash encountered by server administrators when trying to toggle features. Also removed the duplicate "Shop Management" button under the main staff dashboard and fixed a navigation issue in the Bounty panel that would break functionality when the user clicked 'Back'.

---
*PR created automatically by Jules for task [8512859770976372700](https://jules.google.com/task/8512859770976372700) started by @SjnExe*