### PR TITLE
fix: UI toggles for Economy and Daily Rewards

### DIFF
--- a/src/core/ui/configPanelRegistry.ts
+++ b/src/core/ui/configPanelRegistry.ts
@@ -42,11 +42,11 @@ export const configPanelSchema: ConfigCategory[] = [
         id: 'dailyRewards',
         title: 'Daily Rewards',
         icon: 'textures/items/gold_ingot',
-        configSource: 'main',
+        configSource: 'dailyRewards',
         category: 'Economy',
         settings: [
             {
-                key: 'dailyRewards.enabled',
+                key: 'enabled',
                 label: 'Enable Daily Rewards',
                 type: 'toggle',
                 description: 'Enables or disables the daily rewards system.'
@@ -167,12 +167,6 @@ export const configPanelSchema: ConfigCategory[] = [
                 description: 'Enables or disables the entire auction house system.'
             },
             {
-                key: 'enabled',
-                label: 'Auction House Enabled',
-                type: 'toggle',
-                description: 'Enables or disables the entire auction house system.'
-            },
-            {
                 key: 'taxRate',
                 label: 'Tax Rate (0.05 = 5%)',
                 type: 'textField',
@@ -237,6 +231,21 @@ export const configPanelSchema: ConfigCategory[] = [
                 label: 'Autosave Interval (s)',
                 type: 'textField',
                 description: 'How often to save player data, in seconds. Set to 0 to disable.'
+            }
+        ]
+    },
+    {
+        id: 'economyToggle',
+        title: 'Economy System Toggle',
+        icon: 'textures/items/emerald',
+        configSource: 'main',
+        category: 'Economy',
+        settings: [
+            {
+                key: 'economy.enabled',
+                label: 'Enable Economy System',
+                type: 'toggle',
+                description: 'Enables or disables the entire Economy System.'
             }
         ]
     },

--- a/src/core/ui/uiUtils.ts
+++ b/src/core/ui/uiUtils.ts
@@ -2,7 +2,9 @@ import { ActionFormData } from '@minecraft/server-ui';
 
 import { Config, getConfig, updateMultipleConfig } from '@core/configManager.js';
 import {
+    DailyRewardsConfig,
     getAuctionHouseConfig,
+    getDailyRewardsConfig,
     getEconomyConfig,
     getGamesConfig,
     getSidebarConfig,
@@ -10,6 +12,7 @@ import {
     getWordleConfig,
     getXrayConfig,
     saveAuctionHouseConfig,
+    saveDailyRewardsConfig,
     saveEconomyConfig,
     saveGamesConfig,
     saveSidebarConfig,
@@ -40,13 +43,15 @@ type ShopConfig = typeof shopConfig;
 type AuctionHouseConfig = typeof auctionHouseConfig;
 type GamesConfig = typeof gamesConfig;
 type WordleConfig = typeof wordleConfig;
+type DailyRewardsConfigType = DailyRewardsConfig;
 
 import { getSystemRegistry, SystemDefinition } from '@ui/systemRegistry.js';
 
 export const itemsPerPage = 8;
 
 interface ConfigHandler {
-    get: () => typeof Config | EconomyConfig | XrayConfig | TeamConfig | RanksConfig | ShopConfig | SidebarConfig | AnticheatConfig | AuctionHouseConfig | GamesConfig | WordleConfig;
+    get: () =>
+        typeof Config | EconomyConfig | XrayConfig | TeamConfig | RanksConfig | ShopConfig | SidebarConfig | AnticheatConfig | AuctionHouseConfig | GamesConfig | WordleConfig | DailyRewardsConfigType;
     save: (config: unknown) => void;
 }
 
@@ -86,6 +91,10 @@ export const configHandlers: Record<string, ConfigHandler> = {
     wordle: {
         get: getWordleConfig,
         save: (config: unknown) => saveWordleConfig(config as WordleConfig)
+    },
+    dailyRewards: {
+        get: getDailyRewardsConfig,
+        save: (config: unknown) => saveDailyRewardsConfig(config as DailyRewardsConfigType)
     }
 };
 


### PR DESCRIPTION
This pull request addresses an issue where users were unable to enable various addon features (such as the Economy system and Daily Rewards) through the in-game Configuration UI. The UI toggles were not mapping correctly to the backend configuration handlers.

Key changes:
- **Economy Toggle**: Added a missing schema object `economyToggle` to `configPanelRegistry.ts`. This allows users to correctly toggle the root `economy.enabled` flag in the main configuration, which is essential since many other features (e.g., shops, auction house) depend on the core economy system being active.
- **Daily Rewards Mapping**: Fixed the `dailyRewards` schema block to point to its own config source (`configSource: 'dailyRewards'`) and use the correct key (`enabled`) instead of attempting to modify a non-existent property on the main config.
- **Config Handler Registration**: Updated `uiUtils.ts` to import and register the `DailyRewardsConfig` in the `configHandlers` map, ensuring the UI has the necessary get/save methods.
- **Cleanup**: Removed a duplicated `enabled` property from the `auctionHouse` schema configuration.

---
*PR created automatically by Jules for task [1682034848978591917](https://jules.google.com/task/1682034848978591917) started by @SjnExe*