### PR TITLE
Fix dailyRewards config updating in UI and config registry duplicates

### DIFF
--- a/src/core/ui/configPanelRegistry.ts
+++ b/src/core/ui/configPanelRegistry.ts
@@ -42,11 +42,11 @@ export const configPanelSchema: ConfigCategory[] = [
         id: 'dailyRewards',
         title: 'Daily Rewards',
         icon: 'textures/items/gold_ingot',
-        configSource: 'main',
+        configSource: 'dailyRewards',
         category: 'Economy',
         settings: [
             {
-                key: 'dailyRewards.enabled',
+                key: 'enabled',
                 label: 'Enable Daily Rewards',
                 type: 'toggle',
                 description: 'Enables or disables the daily rewards system.'
@@ -160,12 +160,6 @@ export const configPanelSchema: ConfigCategory[] = [
         configSource: 'auctionHouse',
         category: 'Economy',
         settings: [
-            {
-                key: 'enabled',
-                label: 'Auction House Enabled',
-                type: 'toggle',
-                description: 'Enables or disables the entire auction house system.'
-            },
             {
                 key: 'enabled',
                 label: 'Auction House Enabled',
@@ -365,30 +359,6 @@ export const configPanelSchema: ConfigCategory[] = [
         icon: 'textures/ui/chat_send',
         category: 'Chat',
         settings: [
-            {
-                key: 'chat.enabled',
-                label: 'Chat Enabled',
-                type: 'toggle',
-                description: 'Enables or disables the chat system.'
-            },
-            {
-                key: 'chat.allowMentions',
-                label: 'Allow Mentions',
-                type: 'toggle',
-                description: 'Allows players to mention others.'
-            },
-            {
-                key: 'chat.loggingEnabled',
-                label: 'Logging Enabled',
-                type: 'toggle',
-                description: 'Enables chat logging.'
-            },
-            {
-                key: 'chat.logExpirationDays',
-                label: 'Log Expiration Days',
-                type: 'textField',
-                description: 'How long chat logs are kept.'
-            },
             {
                 key: 'chat.enabled',
                 label: 'Chat Enabled',

--- a/src/core/ui/uiUtils.ts
+++ b/src/core/ui/uiUtils.ts
@@ -2,7 +2,9 @@ import { ActionFormData } from '@minecraft/server-ui';
 
 import { Config, getConfig, updateMultipleConfig } from '@core/configManager.js';
 import {
+    DailyRewardsConfig,
     getAuctionHouseConfig,
+    getDailyRewardsConfig,
     getEconomyConfig,
     getGamesConfig,
     getSidebarConfig,
@@ -10,6 +12,7 @@ import {
     getWordleConfig,
     getXrayConfig,
     saveAuctionHouseConfig,
+    saveDailyRewardsConfig,
     saveEconomyConfig,
     saveGamesConfig,
     saveSidebarConfig,
@@ -46,7 +49,8 @@ import { getSystemRegistry, SystemDefinition } from '@ui/systemRegistry.js';
 export const itemsPerPage = 8;
 
 interface ConfigHandler {
-    get: () => typeof Config | EconomyConfig | XrayConfig | TeamConfig | RanksConfig | ShopConfig | SidebarConfig | AnticheatConfig | AuctionHouseConfig | GamesConfig | WordleConfig;
+    get: () =>
+        typeof Config | EconomyConfig | XrayConfig | TeamConfig | RanksConfig | ShopConfig | SidebarConfig | AnticheatConfig | AuctionHouseConfig | GamesConfig | WordleConfig | DailyRewardsConfig;
     save: (config: unknown) => void;
 }
 
@@ -86,6 +90,10 @@ export const configHandlers: Record<string, ConfigHandler> = {
     wordle: {
         get: getWordleConfig,
         save: (config: unknown) => saveWordleConfig(config as WordleConfig)
+    },
+    dailyRewards: {
+        get: getDailyRewardsConfig,
+        save: (config: unknown) => saveDailyRewardsConfig(config as DailyRewardsConfig)
     }
 };
 


### PR DESCRIPTION
The `dailyRewards` feature uses a separate configuration manager, but its UI was defaulting to `configSource: 'main'`, causing changes not to be saved to the correct config state. This PR assigns the correct `configSource` to `dailyRewards` and adds it to `configHandlers`. Additionally, it cleans up a couple duplicate schema settings for `chat` and `auctionHouse`.

---
*PR created automatically by Jules for task [15839350318445297621](https://jules.google.com/task/15839350318445297621) started by @SjnExe*